### PR TITLE
Remove namespace from manifest

### DIFF
--- a/node-termination-handler.yaml
+++ b/node-termination-handler.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: node-termination-handler
-  namespace: default
 rules:
 - apiGroups:
   - "apps"
@@ -44,11 +43,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: node-termination-handler
-  namespace: default
 subjects:
 - kind: ServiceAccount
   name: node-termination-handler
-  namespace: default
 roleRef:
   kind: ClusterRole
   name: node-termination-handler
@@ -58,7 +55,6 @@ apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: node-termination-handler
-  namespace: default
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Don't specify the namespace on the resources in the manifest so users can deploy to whichever namespace they choose by using `--namespace`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
