### PR TITLE
Migrate DaemonSet API

### DIFF
--- a/node-termination-handler.yaml
+++ b/node-termination-handler.yaml
@@ -54,7 +54,7 @@ roleRef:
   name: node-termination-handler
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: node-termination-handler


### PR DESCRIPTION
DaemonSet, Deployment, and ReplicaSet resources will no longer be served from extensions/v1beta1, apps/v1beta1, or apps/v1beta2 in v1.16. Migrate to the apps/v1 API, available since v1.9. Existing persisted data can be retrieved via the apps/v1 API.
