### PR TITLE
create multi-target build

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,40 @@
+# Build
+If you would like to build and run the project locally you can follow these steps:
+
+Clone the repo:
+```
+git clone https://github.com/aws/aws-node-termination-handler.git
+```
+Build the latest version of the docker image:
+```
+make docker-build
+```
+
+### Multi-Target
+
+By default a linux/amd64 image will be build. To build for a different target the build-arg `GOARCH` can be changed.
+
+```
+$ docker build --build-arg=GOARCH=amd64 -t ${USER}/aws-node-termination-handler-amd64:v1.0.0 .
+$ docker build --build-arg=GOARCH=arm64 -t ${USER}/aws-node-termination-handler-arm64:v1.0.0 .
+```
+
+To push a multi-arch image the helper tool [manifest-tool](https://github.com/estesp/manifest-tool) can be used.
+
+```
+$ cat << EOF > manifest.yaml
+image: ${USER}/aws-node-termination-handler:v1.0.0
+manifests:
+  -
+    image: ${USER}/aws-node-termination-handler-amd64:v1.0.0
+    platform:
+      architecture: amd64
+      os: linux
+  -
+    image: ${USER}/aws-node-termination-handler-arm64:v1.0.0
+    platform:
+      architecture: arm64
+      os: linux
+EOF
+$ manifest-tool push from-spec manifest.yaml
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN go mod download
 # Build
 COPY . /node-termination-handler
 RUN go build -a -o handler /node-termination-handler
+# In case the target is build for testing:
+# $ docker build  --target=builder -t test .
+ENTRYPOINT ["/node-termination-handler"]
 
 # Copy the controller-manager into a thin image
 FROM amazonlinux:2 as amazonlinux

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,20 @@
 # Build the manager binary
 FROM golang:1.13 as builder
 
-# Copy in the go src
+## GOLANG env
+ARG GO111MODULE="on"
+ARG CGO_ENABLED=0
+ARG GOOS=linux 
+ARG GOARCH=amd64 
+
+# Copy go.mod and download dependencies
 WORKDIR /node-termination-handler
-COPY . /node-termination-handler
+COPY go.mod .
+RUN go mod download
 
 # Build
-RUN GO111MODULE="on" CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o handler /node-termination-handler
+COPY . /node-termination-handler
+RUN go build -a -o handler /node-termination-handler
 
 # Copy the controller-manager into a thin image
 FROM amazonlinux:2 as amazonlinux

--- a/README.md
+++ b/README.md
@@ -27,6 +27,35 @@ Build the latest version of the docker image:
 make docker-build
 ```
 
+### Multi-Target
+
+By default a linux/amd64 image will be build, to build for a different target the build-arg `GOARCH` can be changed.
+
+```
+$ docker build --build-arg=GOARCH=amd64 -t ${USER}/aws-node-termination-handler-amd64:v1.0.0 .
+$ docker build --build-arg=GOARCH=arm64 -t ${USER}/aws-node-termination-handler-arm64:v1.0.0 .
+```
+
+To push a multi-arch image the helper tool [manifest-tool](https://github.com/estesp/manifest-tool) can be used.
+
+```
+$ cat << EOF > manifest.yaml
+image: ${USER}/aws-node-termination-handler:v1.0.0
+manifests:
+  -
+    image: ${USER}/aws-node-termination-handler-amd64:v1.0.0
+    platform:
+      architecture: amd64
+      os: linux
+  -
+    image: ${USER}/aws-node-termination-handler-arm64:v1.0.0
+    platform:
+      architecture: arm64
+      os: linux
+EOF
+$ manifest-tool push from-spec manifest.yaml
+```
+
 ## Communication
 * Found a bug? Please open an issue.
 * Have a feature request? Please open an issue.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ kubectl apply -f https://raw.github.com/aws/aws-node-termination-handler/master/
 
 By default the termination handler will run on all nodes in your cluster, but will only cordon and drain your Spot instances upon receiving a termination notification.
 
-For build instruction please consult [BUILD.md](./BUILD.md).
+For build instructions please consult [BUILD.md](./BUILD.md).
 
 ## Communication
 * Found a bug? Please open an issue.

--- a/README.md
+++ b/README.md
@@ -15,46 +15,7 @@ kubectl apply -f https://raw.github.com/aws/aws-node-termination-handler/master/
 
 By default the termination handler will run on all nodes in your cluster, but will only cordon and drain your Spot instances upon receiving a termination notification.
 
-## Development
-If you would like to build and run the project locally you can follow these steps:
-
-Clone the repo:
-```
-git clone https://github.com/aws/aws-node-termination-handler.git
-```
-Build the latest version of the docker image:
-```
-make docker-build
-```
-
-### Multi-Target
-
-By default a linux/amd64 image will be build, to build for a different target the build-arg `GOARCH` can be changed.
-
-```
-$ docker build --build-arg=GOARCH=amd64 -t ${USER}/aws-node-termination-handler-amd64:v1.0.0 .
-$ docker build --build-arg=GOARCH=arm64 -t ${USER}/aws-node-termination-handler-arm64:v1.0.0 .
-```
-
-To push a multi-arch image the helper tool [manifest-tool](https://github.com/estesp/manifest-tool) can be used.
-
-```
-$ cat << EOF > manifest.yaml
-image: ${USER}/aws-node-termination-handler:v1.0.0
-manifests:
-  -
-    image: ${USER}/aws-node-termination-handler-amd64:v1.0.0
-    platform:
-      architecture: amd64
-      os: linux
-  -
-    image: ${USER}/aws-node-termination-handler-arm64:v1.0.0
-    platform:
-      architecture: arm64
-      os: linux
-EOF
-$ manifest-tool push from-spec manifest.yaml
-```
+For build instruction please consult [BUILD.md](./BUILD.md).
 
 ## Communication
 * Found a bug? Please open an issue.


### PR DESCRIPTION
*Description of changes:*
- Split module download which makes build faster in case `go.mod` remains unchanged
- Adjusted Dockerfile to be multi-target ready and added multi-target build into README.