### PR TITLE
docs update about setting up a node selector for spot instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,13 @@ You can create and run all of these at once on your own Kubernetes cluster by ru
 kubectl apply -k https://github.com/aws/aws-node-termination-handler/config/base?ref=master
 ```
 
-By default the termination handler will run on all nodes in your cluster, but will only cordon and drain your Spot instances upon receiving a termination notification.
+By default, the aws-node-termination-handler will run on all of your nodes (on-demand and spot). If your spot instances are labeled, you can configure aws-node-termination-handler to only run on your labeled spot nodes. If you're using the tag `lifecycle=Ec2Spot`, you can run the following to apply our spot-node-selector overlay:
+
+```
+kubectl apply -k https://github.com/aws/aws-node-termination-handler/config/overlays/spot-node-selector?ref=master
+```
+
+If you're using a different key/value tag to label your spot nodes, you can write your own overlay to set a spot-node-selector while still receiving updates of the base kubernetes resource files. See our [spot-node-selector](https://github.com/aws/aws-node-termination-handler/tree/master/config/overlays/spot-node-selector) overlay for an example. 
 
 For build instructions please consult [BUILD.md](./BUILD.md).
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-node-termination-handler/issues/4

*Description of changes:*
README updates to explain how to setup a node-selector for spot instances without maintaining a completely custom kubernetes resource file. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
