### PR TITLE
update makefile to support versioning w/ git tags and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-VERSION ?= 1.0.0-SNAPSHOT
+VERSION = $(shell git describe --tags --always --dirty)
 IMG ?= amazon/aws-node-termination-handler
-IMG_W_TAG = ${IMG}:v${VERSION}
+IMG_W_TAG = ${IMG}:${VERSION}
 DOCKER_USERNAME ?= ""
 DOCKER_PASSWORD ?= ""
 
@@ -19,3 +19,17 @@ version:
 
 image:
 	@echo ${IMG_W_TAG}
+
+e2e-test:
+	test/spot-termination-test/run-spot-termination-test.sh -d
+
+compatibility-test:
+	test/k8s-compatibility-test/run-k8s-compatibility-test.sh
+
+license-test:
+	test/license-test/run-license-test.sh
+
+go-report-card-test:
+	test/go-report-card-test/run-report-card-test.sh
+
+test: e2e-test compatibility-test license-test go-report-card-test


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-node-termination-handler/issues/25

*Description of changes:*
 - Added git tag versioning to makefile
 - added test targets in makefile

If this PR is accepted I'll do a git annotated tag v1.0.0 release on this commit. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
