### PR TITLE
Fixing so that manifest can be deployed without error

### DIFF
--- a/config/base/daemon-set.yaml
+++ b/config/base/daemon-set.yaml
@@ -2,11 +2,16 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: node-termination-handler
+  labels:
+    app: node-termination-handler
 spec:
   selector:
     matchLabels:
       app: node-termination-handler
   template:
+    metadata:
+      labels:
+        app: node-termination-handler
     spec:
       serviceAccountName: node-termination-handler
       containers:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes issue where manifest for daemonset wouldn't be deployed due to the selector having no labels to match within the daemonset template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
