### PR TITLE
integrate goimports into makefile and go-report-card test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,12 @@ IMG_W_TAG = ${IMG}:${VERSION}
 DOCKER_USERNAME ?= ""
 DOCKER_PASSWORD ?= ""
 
+build:
+	go build -a -o node-termination-handler cmd/node-termination-handler.go
+
+fmt:
+	goimports -w ./
+
 docker-build:
 	docker build . -t ${IMG_W_TAG}
 

--- a/test/go-report-card-test/Dockerfile
+++ b/test/go-report-card-test/Dockerfile
@@ -7,4 +7,6 @@ RUN cd $GOPATH/src/github.com/gojp/goreportcard && make install
 
 RUN go get github.com/gojp/goreportcard/cmd/goreportcard-cli
 
+RUN go get -u golang.org/x/tools/cmd/goimports
+
 CMD $GOPATH/bin/goreportcard-cli -v -t 90

--- a/test/go-report-card-test/run-report-card-test.sh
+++ b/test/go-report-card-test/run-report-card-test.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 THRESHOLD=90
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+EXIT_CODE=0
 
 function fail() {
     echo "❌ Test failed to meet go-report-card threshold score of: $THRESHOLD"
@@ -11,4 +12,13 @@ function fail() {
 trap fail ERR
 
 docker build --build-arg=GOPROXY=direct -t go-report-card-cli $SCRIPTPATH
+if [[ $(docker run -it -v $SCRIPTPATH/../../:/app go-report-card-cli /go/bin/goimports -l /app/) ]]; then
+    echo "❌ goimports found a problem in go source files. See above for the files with problems."
+    EXIT_CODE=2
+else
+    echo "✅ goimports found no formatting errors in go source files"
+fi
+
 docker run -it -v $SCRIPTPATH/../../:/app go-report-card-cli /go/bin/goreportcard-cli -v -t $THRESHOLD
+
+exit $EXIT_CODE


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 - Add `fmt` target to Makefile which uses go imports to fmt go source files
 - Add goimports to go-report-card test 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
