### PR TITLE
node-termination-grace-period configuration option added

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -37,16 +37,16 @@ func main() {
 
 	// Sleep to prevent process from restarting.
 	// The node should be terminated after configured drain time
-	time.Sleep(time.Duration(120) * time.Second)
+	time.Sleep(time.Duration(nthConfig.NodeTerminationGracePeriod) * time.Second)
 }
 
-func shouldDrainNode(metadataURL string) bool {
-	return ec2metadata.CheckForSpotInterruptionNotice(metadataURL)
+func shouldDrainNode(metadataURL string, nodeTerminationGracePeriod int) bool {
+	return ec2metadata.CheckForSpotInterruptionNotice(metadataURL, nodeTerminationGracePeriod)
 }
 
 func waitForTermination(nthConfig config.Config) {
 	for range time.Tick(time.Second * 1) {
-		if shouldDrainNode(nthConfig.MetadataURL) {
+		if shouldDrainNode(nthConfig.MetadataURL, nthConfig.NodeTerminationGracePeriod) {
 			break
 		}
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,32 +23,38 @@ import (
 
 const (
 	// EC2 Instance Metadata is configurable mainly for testing purposes
-	instanceMetadataURLConfigKey       = "INSTANCE_METADATA_URL"
-	defaultInstanceMetadataURL         = "http://169.254.169.254"
-	dryRunConfigKey                    = "DRY_RUN"
-	nodeNameConfigKey                  = "NODE_NAME"
-	kubernetesServiceHostConfigKey     = "KUBERNETES_SERVICE_HOST"
-	kubernetesServicePortConfigKey     = "KUBERNETES_SERVICE_PORT"
-	deleteLocalDataConfigKey           = "DELETE_LOCAL_DATA"
-	ignoreDaemonSetsConfigKey          = "IGNORE_DAEMON_SETS"
-	podTerminationGracePeriodConfigKey = "GRACE_PERIOD"
+	instanceMetadataURLConfigKey        = "INSTANCE_METADATA_URL"
+	defaultInstanceMetadataURL          = "http://169.254.169.254"
+	dryRunConfigKey                     = "DRY_RUN"
+	nodeNameConfigKey                   = "NODE_NAME"
+	kubernetesServiceHostConfigKey      = "KUBERNETES_SERVICE_HOST"
+	kubernetesServicePortConfigKey      = "KUBERNETES_SERVICE_PORT"
+	deleteLocalDataConfigKey            = "DELETE_LOCAL_DATA"
+	ignoreDaemonSetsConfigKey           = "IGNORE_DAEMON_SETS"
+	gracePeriodConfigKey                = "GRACE_PERIOD"
+	podTerminationGracePeriodConfigKey  = "POD_TERMINATION_GRACE_PERIOD"
+	podTerminationGracePeriodDefault    = -1
+	nodeTerminationGracePeriodConfigKey = "NODE_TERMINATION_GRACE_PERIOD"
+	nodeTerminationGracePeriodDefault   = 120
 )
 
 //Config arguments set via CLI, environment variables, or defaults
 type Config struct {
-	DryRun                    bool
-	NodeName                  string
-	MetadataURL               string
-	IgnoreDaemonSets          bool
-	DeleteLocalData           bool
-	KubernetesServiceHost     string
-	KubernetesServicePort     string
-	PodTerminationGracePeriod int
+	DryRun                     bool
+	NodeName                   string
+	MetadataURL                string
+	IgnoreDaemonSets           bool
+	DeleteLocalData            bool
+	KubernetesServiceHost      string
+	KubernetesServicePort      string
+	PodTerminationGracePeriod  int
+	NodeTerminationGracePeriod int
 }
 
 //ParseCliArgs parses cli arguments and uses environment variables as fallback values
 func ParseCliArgs() Config {
 	config := Config{}
+	var gracePeriod int
 	flag.BoolVar(&config.DryRun, "dry-run", getBoolEnv(dryRunConfigKey, false), "If true, only log if a node would be drained")
 	flag.StringVar(&config.NodeName, "node-name", getEnv(nodeNameConfigKey, ""), "The kubernetes node name")
 	flag.StringVar(&config.MetadataURL, "metadata-url", getEnv(instanceMetadataURLConfigKey, defaultInstanceMetadataURL), "The URL of EC2 instance metadata. This shouldn't need to be changed unless you are testing.")
@@ -56,9 +62,18 @@ func ParseCliArgs() Config {
 	flag.BoolVar(&config.DeleteLocalData, "delete-local-data", getBoolEnv(deleteLocalDataConfigKey, true), "If true, do not drain pods that are using local node storage in emptyDir")
 	flag.StringVar(&config.KubernetesServiceHost, "kubernetes-service-host", getEnv(kubernetesServiceHostConfigKey, ""), "[ADVANCED] The k8s service host to send api calls to.")
 	flag.StringVar(&config.KubernetesServicePort, "kubernetes-service-port", getEnv(kubernetesServicePortConfigKey, ""), "[ADVANCED] The k8s service port to send api calls to.")
-	flag.IntVar(&config.PodTerminationGracePeriod, "grace-period", getIntEnv(podTerminationGracePeriodConfigKey, -1), "Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used.")
+	flag.IntVar(&gracePeriod, "grace-period", getIntEnv(gracePeriodConfigKey, podTerminationGracePeriodDefault), "[DEPRECATED] * Use pod-termination-grace-period instead * Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used.")
+	flag.IntVar(&config.PodTerminationGracePeriod, "pod-termination-grace-period", getIntEnv(podTerminationGracePeriodConfigKey, podTerminationGracePeriodDefault), "Period of time in seconds given to each POD to terminate gracefully. If negative, the default value specified in the pod will be used.")
+	flag.IntVar(&config.NodeTerminationGracePeriod, "node-termination-grace-period", getIntEnv(nodeTerminationGracePeriodConfigKey, nodeTerminationGracePeriodDefault), "Period of time in seconds given to each NODE to terminate gracefully. Node draining will be scheduled based on this value to optimize the amount of compute time, but still safely drain the node before an event.")
 
 	flag.Parse()
+
+	if isConfigProvided("pod-termination-grace-period", podTerminationGracePeriodConfigKey) && isConfigProvided("grace-period", gracePeriodConfigKey) {
+		log.Println("Deprecated argument \"grace-period\" and the replacement argument \"pod-termination-grace-period\" was provided. Using the newer argument \"pod-termination-grace-period\"")
+	} else if isConfigProvided("grace-period", gracePeriodConfigKey) {
+		log.Println("Deprecated argument \"grace-period\" was provided. This argument will eventually be removed. Please switch to \"pod-termination-grace-period\" instead.")
+		config.PodTerminationGracePeriod = gracePeriod
+	}
 
 	if config.NodeName == "" {
 		log.Fatalln("You must provide a node-name to the CLI or NODE_NAME environment variable.")
@@ -75,7 +90,8 @@ func ParseCliArgs() Config {
 		"\tkubernetes-service-port: %s,\n"+
 		"\tdelete-local-data: %t,\n"+
 		"\tignore-daemon-sets: %t\n"+
-		"\tgrace-period: %d\n",
+		"\tpod-termination-grace-period: %d\n"+
+		"\tnode-termination-grace-period: %d\n",
 		config.DryRun,
 		config.NodeName,
 		config.MetadataURL,
@@ -83,7 +99,8 @@ func ParseCliArgs() Config {
 		config.KubernetesServicePort,
 		config.DeleteLocalData,
 		config.IgnoreDaemonSets,
-		config.PodTerminationGracePeriod)
+		config.PodTerminationGracePeriod,
+		config.NodeTerminationGracePeriod)
 
 	return config
 }
@@ -120,4 +137,17 @@ func getBoolEnv(key string, fallback bool) bool {
 		log.Fatalln("Env Var " + key + " must be either true or false")
 	}
 	return envBoolValue
+}
+
+func isConfigProvided(cliArgName string, envVarName string) bool {
+	cliArgProvided := false
+	if getEnv(envVarName, "") != "" {
+		return true
+	}
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == cliArgName {
+			cliArgProvided = true
+		}
+	})
+	return cliArgProvided
 }

--- a/pkg/drainer/drainer.go
+++ b/pkg/drainer/drainer.go
@@ -92,7 +92,7 @@ func getDrainHelper(nthConfig config.Config) *drain.Helper {
 		GracePeriodSeconds:  nthConfig.PodTerminationGracePeriod,
 		IgnoreAllDaemonSets: nthConfig.IgnoreDaemonSets,
 		DeleteLocalData:     nthConfig.DeleteLocalData,
-		Timeout:             time.Duration(60) * time.Second,
+		Timeout:             time.Duration(nthConfig.NodeTerminationGracePeriod) * time.Second,
 		Out:                 os.Stdout,
 		ErrOut:              os.Stderr,
 	}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-node-termination-handler/issues/29

*Description of changes:*
This change adds a configurable nodeTerminationGracePeriod which specifies how long a node is given to drain. This information is used within the drain logic to respond to scheduled drainable events (like spot interruption termination notice) so that every second of compute can be squeezed out of the node before a drain is initiated. The default value is 2 minutes which is the default spot ITN period. 

This also changes the configurable grace-period to pod-termination-grace-period to better differentiate the two configurable grace-periods. This code will be released in the v2.0.0 release since it breaks the backwards compatible configuration. 

If the new config changes are approved, I'll stage a PR to update the eks helm repo. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
