### PR TITLE
Added statement to print Interruption notice metadata for keeping track of Interrupted instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 *.dll
 *.so
 *.dylib
-.idea/*
 
 # Test binary, built with `go test -c`
 *.test

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.dll
 *.so
 *.dylib
+.idea/*
 
 # Test binary, built with `go test -c`
 *.test

--- a/pkg/ec2metadata/ec2metadata.go
+++ b/pkg/ec2metadata/ec2metadata.go
@@ -57,7 +57,7 @@ func CheckForSpotInterruptionNotice(metadataURL string, nodeTerminationGracePeri
 	var instanceAction InstanceAction
 
 	json.NewDecoder(resp.Body).Decode(&instanceAction)
-    log.Printf("test")
+	log.Printf("Spot Instance Interruption Warning received. Instance metadata: %v", instanceAction)
 	interruptionTime, err := time.Parse(time.RFC3339, instanceAction.Time)
 	if err != nil {
 		log.Fatalln("Could not parse time from metadata json", err.Error())

--- a/pkg/ec2metadata/ec2metadata.go
+++ b/pkg/ec2metadata/ec2metadata.go
@@ -57,7 +57,7 @@ func CheckForSpotInterruptionNotice(metadataURL string, nodeTerminationGracePeri
 	var instanceAction InstanceAction
 
 	json.NewDecoder(resp.Body).Decode(&instanceAction)
-	log.Printf(resp.Body)
+    log.Printf("test")
 	interruptionTime, err := time.Parse(time.RFC3339, instanceAction.Time)
 	if err != nil {
 		log.Fatalln("Could not parse time from metadata json", err.Error())

--- a/pkg/ec2metadata/ec2metadata.go
+++ b/pkg/ec2metadata/ec2metadata.go
@@ -55,7 +55,9 @@ func CheckForSpotInterruptionNotice(metadataURL string, nodeTerminationGracePeri
 		return false
 	}
 	var instanceAction InstanceAction
+
 	json.NewDecoder(resp.Body).Decode(&instanceAction)
+	log.Printf(resp.Body)
 	interruptionTime, err := time.Parse(time.RFC3339, instanceAction.Time)
 	if err != nil {
 		log.Fatalln("Could not parse time from metadata json", err.Error())


### PR DESCRIPTION
*Issue #, if available:*
None
*Description of changes:*
Added statement to print Interruption notice metadata for keeping track of Interrupted instances. My manager wanted to see which instance was terminated and more details about the notice as a proof of spot interruptions. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
