### PR TITLE
use default values if env var is specified but empty

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,7 +108,9 @@ func ParseCliArgs() Config {
 // Get env var or default
 func getEnv(key string, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {
-		return value
+		if value != "" {
+			return value
+		}
 	}
 	return fallback
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

If an environment variable is specified but no value is present, fallback to the default value. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
