### PR TITLE
use channels to coordinate drainable events

### DIFF
--- a/pkg/drainevent/drain-event.go
+++ b/pkg/drainevent/drain-event.go
@@ -1,0 +1,97 @@
+package drainevent
+
+import (
+	"sync"
+	"time"
+
+	"github.com/aws/aws-node-termination-handler/pkg/config"
+)
+
+// DrainEvent gives more context of the drainable event
+type DrainEvent struct {
+	EventID     string
+	Kind        string
+	Description string
+	State       string
+	StartTime   time.Time
+
+	drained bool
+}
+
+// Store is a the drain event store data structure
+type Store struct {
+	sync.RWMutex
+	NthConfig       *config.Config
+	drainEventStore map[string]*DrainEvent
+	atLeastOneEvent bool
+}
+
+// TimeUntilEvent returns the duration until the event start time
+func (e *DrainEvent) TimeUntilEvent() time.Duration {
+	return e.StartTime.Sub(time.Now())
+}
+
+// NewStore Create a new drain event store
+func NewStore(nthConfig *config.Config) *Store {
+	return &Store{
+		NthConfig:       nthConfig,
+		drainEventStore: make(map[string]*DrainEvent),
+	}
+}
+
+// CancelDrainEvent removes a drain event from the internal store
+func (s *Store) CancelDrainEvent(eventID string) {
+	s.Lock()
+	defer s.Unlock()
+	delete(s.drainEventStore, eventID)
+}
+
+// AddDrainEvent adds a drain event to the internal store
+func (s *Store) AddDrainEvent(drainEvent *DrainEvent) {
+	s.atLeastOneEvent = true
+	s.RLock()
+	_, ok := s.drainEventStore[drainEvent.EventID]
+	s.RUnlock()
+	if ok {
+		return
+	}
+	s.Lock()
+	defer s.Unlock()
+	s.drainEventStore[drainEvent.EventID] = drainEvent
+	return
+}
+
+// ShouldDrainNode returns true if there are drainable events in the internal store
+func (s *Store) ShouldDrainNode() bool {
+	s.RLock()
+	defer s.RUnlock()
+	for _, drainEvent := range s.drainEventStore {
+		if s.shouldEventDrain(drainEvent) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Store) shouldEventDrain(drainEvent *DrainEvent) bool {
+	if !drainEvent.drained && s.TimeUntilDrain(drainEvent) <= 0 {
+		return true
+	}
+	return false
+}
+
+// TimeUntilDrain returns the duration until a node drain should occur (can return a negative duration)
+func (s *Store) TimeUntilDrain(drainEvent *DrainEvent) time.Duration {
+	nodeTerminationGracePeriod := time.Duration(s.NthConfig.NodeTerminationGracePeriod) * time.Second
+	drainTime := drainEvent.StartTime.Add(-1 * nodeTerminationGracePeriod)
+	return drainTime.Sub(time.Now())
+}
+
+// MarkAllAsDrained should be called after the node has been drained to prevent further unnecessary drain calls to the k8s api
+func (s *Store) MarkAllAsDrained() {
+	s.Lock()
+	defer s.Unlock()
+	for _, drainEvent := range s.drainEventStore {
+		drainEvent.drained = true
+	}
+}

--- a/pkg/drainevent/spot-itn-event.go
+++ b/pkg/drainevent/spot-itn-event.go
@@ -1,0 +1,54 @@
+package drainevent
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-node-termination-handler/pkg/config"
+	"github.com/aws/aws-node-termination-handler/pkg/ec2metadata"
+)
+
+const (
+	// SpotITNKind is a const to define a Spot ITN kind of drainable event
+	SpotITNKind = "SPOT_ITN"
+)
+
+// MonitorForSpotITNEvents continuously monitors metadata for spot ITNs and sends drain events to the passed in channel
+func MonitorForSpotITNEvents(drainChan chan<- DrainEvent, nthConfig config.Config) {
+	log.Println("Started monitoring for spot ITN events")
+	for range time.Tick(time.Second * 2) {
+		drainEvent := checkForSpotInterruptionNotice(nthConfig.MetadataURL)
+		if drainEvent.Kind == SpotITNKind {
+			log.Println("Sending drain event to the drain channel")
+			drainChan <- *drainEvent
+			// cool down for the system to respond to the drain
+			time.Sleep(120 * time.Minute)
+		}
+	}
+}
+
+// checkForSpotInterruptionNotice Checks EC2 instance metadata for a spot interruption termination notice
+func checkForSpotInterruptionNotice(metadataURL string) *DrainEvent {
+	resp, err := ec2metadata.RequestMetadata(metadataURL, ec2metadata.SpotInstanceActionPath)
+	if err != nil {
+		log.Fatalf("Unable to parse metadata response: %s", err.Error())
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return &DrainEvent{}
+	}
+	var instanceAction ec2metadata.InstanceAction
+	json.NewDecoder(resp.Body).Decode(&instanceAction)
+	interruptionTime, err := time.Parse(time.RFC3339, instanceAction.Time)
+	if err != nil {
+		log.Fatalln("Could not parse time from spot interruption notice metadata json", err.Error())
+	}
+	return &DrainEvent{
+		EventID:     instanceAction.Id,
+		Kind:        SpotITNKind,
+		StartTime:   interruptionTime,
+		Description: fmt.Sprintf("Spot ITN received. %s will be %s at %s \n", instanceAction.Detail.InstanceId, instanceAction.Detail.InstanceAction, instanceAction.Time),
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

- Refactor the event handling logic to be have more generic event handling that does not need to be touched when adding an additional drainable event.

- This PR adds a go routine which blocks on a go channel to receive drain events from monitor loop sources. The only monitor loop involved right now is the spot ITN loop. As more events types are introduced, the developer simply needs to write a monitor loop that uses the function interface and provide the function to the list of monitor functions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
