### PR TITLE
add ec2-metadata-test-proxy helm chart

### DIFF
--- a/config/helm/ec2-metadata-test-proxy/.helmignore
+++ b/config/helm/ec2-metadata-test-proxy/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/config/helm/ec2-metadata-test-proxy/Chart.yaml
+++ b/config/helm/ec2-metadata-test-proxy/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+name: ec2-metadata-test-proxy
+description: A Helm chart for the AWS EC2 Metadata Test Proxy
+version: 0.3.1
+appVersion: 1.0.0
+home: https://github.com/aws/aws-node-termination-handler
+icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
+sources:
+  - https://github.com/aws/aws-node-termination-handler/test/ec2-metadata-test-proxy
+maintainers:
+  - name: Brandon Wagner
+    url: https://github.com/bwagner5
+    email: bwagner5@users.noreply.github.com
+  - name: Jillian Montalvo
+    url: https://github.com/jillmon
+    email: jillmon@users.noreply.github.com
+  - name: Matthew Becker
+    url: https://github.com/mattrandallbecker
+    email: mattrandallbecker@users.noreply.github.com
+keywords:
+  - eks
+  - ec2
+  - node-termination
+  - imds
+  - spot

--- a/config/helm/ec2-metadata-test-proxy/templates/daemonset.yaml
+++ b/config/helm/ec2-metadata-test-proxy/templates/daemonset.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ec2MetadataTestProxy.create -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Values.ec2MetadataTestProxy.label }}
+  labels:
+    app: {{ .Values.ec2MetadataTestProxy.label }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Values.ec2MetadataTestProxy.label }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.ec2MetadataTestProxy.label }}
+    spec:
+      containers:
+      - name: {{ .Values.ec2MetadataTestProxy.label }}
+        image: {{ .Values.ec2MetadataTestProxy.image.repository }}:{{ .Values.ec2MetadataTestProxy.image.tag }}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: {{ .Values.ec2MetadataTestProxy.port }}
+        env:
+        - name: INTERRUPTION_NOTICE_DELAY
+          value: {{ .Values.ec2MetadataTestProxy.interruptionNoticeDelay | quote }}
+        - name: PORT
+          value: {{ .Values.ec2MetadataTestProxy.port | quote }}
+{{- end -}}
+
+
+

--- a/config/helm/ec2-metadata-test-proxy/templates/regular-pod-test.yaml
+++ b/config/helm/ec2-metadata-test-proxy/templates/regular-pod-test.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.regularPodTest.create -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.regularPodTest.label }}
+  labels:
+    app: {{ .Values.regularPodTest.label }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Values.regularPodTest.label }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.regularPodTest.label }}
+    spec:
+      containers:
+      - name: {{ .Values.regularPodTest.label }}
+        image: {{ .Values.ec2MetadataTestProxy.image.repository }}:{{ .Values.ec2MetadataTestProxy.image.tag }}
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: PORT
+          value: {{ .Values.regularPodTest.port | quote }}
+{{- end -}}
+
+
+

--- a/config/helm/ec2-metadata-test-proxy/templates/service.yaml
+++ b/config/helm/ec2-metadata-test-proxy/templates/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.ec2MetadataTestProxy.label }}
+spec:
+  selector:
+    app: {{ .Values.ec2MetadataTestProxy.label }}
+  ports:
+  - port: {{ .Values.ec2MetadataTestProxy.port }}
+    protocol: TCP

--- a/config/helm/ec2-metadata-test-proxy/values.yaml
+++ b/config/helm/ec2-metadata-test-proxy/values.yaml
@@ -1,0 +1,14 @@
+# The ec2-metadata-test-proxy is for testing purposes
+ec2MetadataTestProxy:
+    create: true
+    interruptionNoticeDelay: 15
+    port: 1338
+    label: ec2-metadata-test-proxy
+    image:
+        repository: ec2-metadata-test-proxy
+        tag: customtest
+regularPodTest:
+    create: true
+    label: regular-pod-test
+    port: 1339
+        


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add an ec2-metadata-test-proxy helm chart so we can make the tests a bit smaller by getting rid of kustomize heredocs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
