### PR TITLE
Implemented webhook functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ compile:
 	@echo ${MAKEFILE_PATH}
 	go build -a -o ${BUILD_DIR_PATH}/node-termination-handler ${MAKEFILE_PATH}/cmd/node-termination-handler.go
 
-create-build-dir: 
+create-build-dir:
 	mkdir -p ${BUILD_DIR_PATH}
 
 clean:
@@ -54,7 +54,7 @@ helm-sync-test:
 	${MAKEFILE_PATH}/test/helm-sync-test/run-helm-sync-test
 
 build-binaries:
-	${MAKEFILE_PATH}/scripts/build-binaries 
+	${MAKEFILE_PATH}/scripts/build-binaries
 
 upload-binaries-to-github:
 	${MAKEFILE_PATH}/scripts/upload-binaries-to-github

--- a/config/helm/aws-node-termination-handler/templates/daemonset.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.yaml
@@ -74,6 +74,12 @@ spec:
             value: {{ .Values.instanceMetadataURL | quote }}
           - name: NODE_TERMINATION_GRACE_PERIOD
             value: {{ .Values.nodeTerminationGracePeriod | quote }}
+          - name: WEBHOOK_URL
+            value: {{ .Values.webhookURL | quote }}
+          - name: WEBHOOK_HEADERS
+            value: {{ .Values.webhookHeaders | quote }}
+          - name: WEBHOOK_TEMPLATE
+            value: {{ .Values.webhookTemplate | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -42,6 +42,15 @@ podTerminationGracePeriod: ""
 # nodeTerminationGracePeriod specifies the period of time in seconds given to each NODE to terminate gracefully. Node draining will be scheduled based on this value to optimize the amount of compute time, but still safely drain the node before an event.
 nodeTerminationGracePeriod: ""
 
+# webhookURL if specified, posts event data to URL upon instance interruption action.
+webhookURL: ""
+
+# webhookHeaders if specified, replaces the default webhook headers.
+webhookHeaders: ""
+
+# webhookTemplate if specified, replaces the default webhook message template.
+webhookTemplate: ""
+
 # instanceMetadataURL is used to override the default metadata URL (default: http://169.254.169.254:80)
 instanceMetadataURL: ""
 

--- a/pkg/drainevent/drain-event.go
+++ b/pkg/drainevent/drain-event.go
@@ -1,10 +1,7 @@
 package drainevent
 
 import (
-	"sync"
 	"time"
-
-	"github.com/aws/aws-node-termination-handler/pkg/config"
 )
 
 // DrainEvent gives more context of the drainable event
@@ -15,83 +12,10 @@ type DrainEvent struct {
 	State       string
 	StartTime   time.Time
 
-	drained bool
-}
-
-// Store is a the drain event store data structure
-type Store struct {
-	sync.RWMutex
-	NthConfig       *config.Config
-	drainEventStore map[string]*DrainEvent
-	atLeastOneEvent bool
+	Drained bool
 }
 
 // TimeUntilEvent returns the duration until the event start time
 func (e *DrainEvent) TimeUntilEvent() time.Duration {
 	return e.StartTime.Sub(time.Now())
-}
-
-// NewStore Create a new drain event store
-func NewStore(nthConfig *config.Config) *Store {
-	return &Store{
-		NthConfig:       nthConfig,
-		drainEventStore: make(map[string]*DrainEvent),
-	}
-}
-
-// CancelDrainEvent removes a drain event from the internal store
-func (s *Store) CancelDrainEvent(eventID string) {
-	s.Lock()
-	defer s.Unlock()
-	delete(s.drainEventStore, eventID)
-}
-
-// AddDrainEvent adds a drain event to the internal store
-func (s *Store) AddDrainEvent(drainEvent *DrainEvent) {
-	s.atLeastOneEvent = true
-	s.RLock()
-	_, ok := s.drainEventStore[drainEvent.EventID]
-	s.RUnlock()
-	if ok {
-		return
-	}
-	s.Lock()
-	defer s.Unlock()
-	s.drainEventStore[drainEvent.EventID] = drainEvent
-	return
-}
-
-// ShouldDrainNode returns true if there are drainable events in the internal store
-func (s *Store) ShouldDrainNode() bool {
-	s.RLock()
-	defer s.RUnlock()
-	for _, drainEvent := range s.drainEventStore {
-		if s.shouldEventDrain(drainEvent) {
-			return true
-		}
-	}
-	return false
-}
-
-func (s *Store) shouldEventDrain(drainEvent *DrainEvent) bool {
-	if !drainEvent.drained && s.TimeUntilDrain(drainEvent) <= 0 {
-		return true
-	}
-	return false
-}
-
-// TimeUntilDrain returns the duration until a node drain should occur (can return a negative duration)
-func (s *Store) TimeUntilDrain(drainEvent *DrainEvent) time.Duration {
-	nodeTerminationGracePeriod := time.Duration(s.NthConfig.NodeTerminationGracePeriod) * time.Second
-	drainTime := drainEvent.StartTime.Add(-1 * nodeTerminationGracePeriod)
-	return drainTime.Sub(time.Now())
-}
-
-// MarkAllAsDrained should be called after the node has been drained to prevent further unnecessary drain calls to the k8s api
-func (s *Store) MarkAllAsDrained() {
-	s.Lock()
-	defer s.Unlock()
-	for _, drainEvent := range s.drainEventStore {
-		drainEvent.drained = true
-	}
 }

--- a/pkg/draineventstore/drain-event-store.go
+++ b/pkg/draineventstore/drain-event-store.go
@@ -1,0 +1,82 @@
+package draineventstore
+
+import (
+	"sync"
+	"time"
+
+	"github.com/aws/aws-node-termination-handler/pkg/config"
+	"github.com/aws/aws-node-termination-handler/pkg/drainevent"
+)
+
+// Store is a the drain event store data structure
+type Store struct {
+	sync.RWMutex
+	NthConfig       *config.Config
+	drainEventStore map[string]*drainevent.DrainEvent
+	atLeastOneEvent bool
+}
+
+// NewStore Create a new drain event store
+func NewStore(nthConfig *config.Config) *Store {
+	return &Store{
+		NthConfig:       nthConfig,
+		drainEventStore: make(map[string]*drainevent.DrainEvent),
+	}
+}
+
+// CancelDrainEvent removes a drain event from the internal store
+func (s *Store) CancelDrainEvent(eventID string) {
+	s.Lock()
+	defer s.Unlock()
+	delete(s.drainEventStore, eventID)
+}
+
+// AddDrainEvent adds a drain event to the internal store
+func (s *Store) AddDrainEvent(drainEvent *drainevent.DrainEvent) {
+	s.atLeastOneEvent = true
+	s.RLock()
+	_, ok := s.drainEventStore[drainEvent.EventID]
+	s.RUnlock()
+	if ok {
+		return
+	}
+	s.Lock()
+	defer s.Unlock()
+	s.drainEventStore[drainEvent.EventID] = drainEvent
+	return
+}
+
+// GetActiveEvent returns true if there are drainable events in the internal store
+func (s *Store) GetActiveEvent() (*drainevent.DrainEvent, bool) {
+	s.RLock()
+	defer s.RUnlock()
+	for _, drainEvent := range s.drainEventStore {
+		if s.shouldEventDrain(drainEvent) {
+			return drainEvent, true
+		}
+	}
+	return &drainevent.DrainEvent{}, false
+}
+
+func (s *Store) shouldEventDrain(drainEvent *drainevent.DrainEvent) bool {
+	if !drainEvent.Drained && s.TimeUntilDrain(drainEvent) <= 0 {
+		return true
+	}
+	return false
+}
+
+// TimeUntilDrain returns the duration until a node drain should occur (can return a negative duration)
+func (s *Store) TimeUntilDrain(drainEvent *drainevent.DrainEvent) time.Duration {
+	nodeTerminationGracePeriod := time.Duration(s.NthConfig.NodeTerminationGracePeriod) * time.Second
+	drainTime := drainEvent.StartTime.Add(-1 * nodeTerminationGracePeriod)
+	return drainTime.Sub(time.Now())
+}
+
+// MarkAllAsDrained should be called after the node has been drained to prevent further unnecessary drain calls to the k8s api
+func (s *Store) MarkAllAsDrained() {
+	s.Lock()
+	defer s.Unlock()
+	for _, drainEvent := range s.drainEventStore {
+		drainEvent.Drained = true
+	}
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -1,0 +1,77 @@
+// Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package webhook
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+	"text/template"
+	"time"
+
+	"github.com/aws/aws-node-termination-handler/pkg/config"
+	"github.com/aws/aws-node-termination-handler/pkg/drainevent"
+)
+
+// Post makes a http post to send drain event data to webhook url
+func Post(event *drainevent.DrainEvent, nthconfig config.Config) {
+
+	webhookTemplate, err := template.New("message").Parse(nthconfig.WebhookTemplate)
+	if err != nil {
+		log.Printf("Webhook Error: Template parsing failed - %s\n", err)
+		return
+	}
+
+	var byteBuffer bytes.Buffer
+	err = webhookTemplate.Execute(&byteBuffer, event)
+	if err != nil {
+		log.Printf("Webhook Error: Template execution failed - %s\n", err)
+		return
+	}
+
+	request, err := http.NewRequest("POST", nthconfig.WebhookURL, &byteBuffer)
+	if err != nil {
+		log.Printf("Webhook Error: Http NewRequest failed - %s\n", err)
+		return
+	}
+
+	headerMap := make(map[string]interface{})
+	err = json.Unmarshal([]byte(nthconfig.WebhookHeaders), &headerMap)
+	if err != nil {
+		log.Printf("Webhook Error: Header Unmarshal failed - %s\n", err)
+		return
+	}
+	for key, value := range headerMap {
+		request.Header.Set(key, value.(string))
+	}
+
+	client := http.Client{
+		Timeout: time.Duration(5 * time.Second),
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		log.Printf("Webhook Error: Client Do failed - %s\n", err)
+		return
+	}
+
+	defer response.Body.Close()
+
+	if response.StatusCode < 200 || response.StatusCode > 299 {
+		log.Printf("Webhook Error: Recieved Status Code %d\n", response.StatusCode)
+		return
+	}
+
+	log.Println("Webhook Success: Notification Sent!")
+}

--- a/test/e2e/webhook-test
+++ b/test/e2e/webhook-test
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -euo pipefail
+
+# Available env vars:
+#   $TMP_DIR
+#   $CLUSTER_NAME
+#   $KUBECONFIG
+
+echo "Starting Webhook Test for Node Termination Handler"
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+NODE_TERMINATION_HANDLER_DOCKER_IMG=$(cat $TMP_DIR/nth-docker-img)
+NODE_TERMINATION_HANDLER_DOCKER_REPO=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f1)
+NODE_TERMINATION_HANDLER_DOCKER_TAG=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f2)
+EC2_METADATA_DOCKER_IMG=$(cat $TMP_DIR/ec2-metadata-test-proxy-docker-img)
+EC2_METADATA_DOCKER_REPO=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f1)
+EC2_METADATA_DOCKER_TAG=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f2)
+
+echo "🥑 Tagging worker nodes to execute integ test"
+kubectl label nodes $CLUSTER_NAME-worker lifecycle=Ec2Spot --overwrite
+kubectl label nodes $CLUSTER_NAME-worker app=spot-termination-test --overwrite
+echo "👍 Tagged worker nodes to execute integ test"
+
+### HELM STUFF
+
+### LOCAL ONLY TESTS FOR 200 RESPONSE FROM LOCAL CLUSTER, MASTER WILL TEST WITH TRAVIS SECRET URL
+if [[ $(env | grep "WEBHOOK_URL=" | wc -l) ]]; then
+  WEBHOOK_URL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338"
+fi
+
+helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ \
+  --namespace kube-system \
+  --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
+  --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
+  --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
+  --set webhookURL="$WEBHOOK_URL"
+
+helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
+  --namespace default \
+  --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
+  --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG"
+
+## END HELM
+
+TAINT_CHECK_CYCLES=15
+TAINT_CHECK_SLEEP=15
+
+DEPLOYED=0
+for i in `seq 1 10`; do
+    if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
+        echo "✅ Verified regular-pod-test pod was scheduled and started!"
+        DEPLOYED=1
+        break
+    fi
+    sleep 5
+done
+
+if [[ $DEPLOYED -eq 0 ]]; then
+    exit 2
+fi
+
+for i in `seq 1 $TAINT_CHECK_CYCLES`; do
+      if kubectl get nodes $CLUSTER_NAME-worker | grep SchedulingDisabled; then
+          echo "✅ Verified the worker node was cordoned!"
+          NTH_POD_NAME=$(kubectl get pods -n kube-system -o json | jq '.items[] | select( .metadata.name | contains("node-termination-handler") ) | .metadata.name' -r | head -n 1)
+          if kubectl logs $NTH_POD_NAME -n kube-system | grep 'Webhook Success'; then
+              echo "✅ Verified the webhook message was sent!"
+              echo "✅ Webhook Test Passed $CLUSTER_NAME! ✅"
+              exit 0
+          fi
+      fi
+    sleep $TAINT_CHECK_SLEEP
+done
+
+exit 1

--- a/test/ec2-metadata-test-proxy/cmd/ec2-metadata-test-proxy.go
+++ b/test/ec2-metadata-test-proxy/cmd/ec2-metadata-test-proxy.go
@@ -106,6 +106,10 @@ func handleRequest(res http.ResponseWriter, req *http.Request) {
 		res.Header().Set("Content-Type", "application/json")
 		res.Write(js)
 		return
+	} else {
+		res.Header().Set("Content-Type", "application/json")
+		res.Write([]byte("{}"))
+		return
 	}
 	metadataUrl, _ := url.Parse(metadataIp)
 	httputil.NewSingleHostReverseProxy(metadataUrl).ServeHTTP(res, req)


### PR DESCRIPTION
Implemented webhook functionality, ability to specify message template and custom headers for each provider, includes integration tests

*Issue #, if available:*
#5 

*Description of changes:*
Sorry about the delay in getting this out, but this should now address issue 5 pretty well.  You have the ability to include arbitrary headers and message format, I've tested against Amazon Chime and Slack both seem to work just fine.  In a future PR I plan to add additional information available to the template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
