### PR TITLE
Revert "sync-readme-to-dockerhub: fix env variable for dockerhub pass…

### DIFF
--- a/scripts/sync-readme-to-dockerhub
+++ b/scripts/sync-readme-to-dockerhub
@@ -8,7 +8,7 @@ image="amazon/aws-node-termination-handler"
 if git --no-pager diff --name-only HEAD^ HEAD | grep 'README.md'; then 
     token=$(curl -s -X POST \
         -H "Content-Type: application/json" \
-        -d '{"username": "'"${DOCKER_USERNAME}"'", "password": "'"${DOCKER_PASSWORD}"'"}' \
+        -d '{"username": "'"${DOCKER_USERNAME}"'", "password": "'"${DOCKERHUB_PASSWORD}"'"}' \
         https://hub.docker.com/v2/users/login/ | jq -r .token)
 
     rcode=$(jq -n --arg msg "$(<$SCRIPTPATH/../README.md)" \


### PR DESCRIPTION
…word (#52)"

This reverts commit 5f7a0fb5edbe4178e22faa9cbb264613ef9b8e58.

*Issue #, if available:*

*Description of changes:*
Turns out this script was correct and the issues was in the travis configuration. Reverted back. I reran the travis builds on the commit that failed the readme sync and it worked after updating the travis config. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
