### PR TITLE
Added missing namespace references to helm chart

### DIFF
--- a/config/helm/aws-node-termination-handler/templates/daemonset.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "aws-node-termination-handler.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "aws-node-termination-handler.labels" . | indent 4 }}
 spec:

--- a/config/helm/aws-node-termination-handler/templates/serviceaccount.yaml
+++ b/config/helm/aws-node-termination-handler/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "aws-node-termination-handler.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- with .Values.serviceAccount.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}


### PR DESCRIPTION
When rendering out the helm chart to template files, the generated manifests don't have namespaces for all the namespaced resources. This fix adds the missing `namespace` to the `DaemonSet` and `ServiceAccount` resources.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
