### PR TITLE
implement cancellation of drain events

### DIFF
--- a/config/helm/ec2-metadata-test-proxy/templates/daemonset.yaml
+++ b/config/helm/ec2-metadata-test-proxy/templates/daemonset.yaml
@@ -27,6 +27,8 @@ spec:
           value: {{ .Values.ec2MetadataTestProxy.port | quote }}
         - name: ENABLE_SCHEDULED_MAINTENANCE_EVENTS
           value: {{ .Values.ec2MetadataTestProxy.enableScheduledMaintenanceEvents | quote }}
+        - name: SCHEDULED_EVENT_STATUS
+          value: {{ .Values.ec2MetadataTestProxy.scheduledEventStatus | quote }}
         - name: ENABLE_SPOT_ITN
           value: {{ .Values.ec2MetadataTestProxy.enableSpotITN | quote }}
 {{- end -}}

--- a/config/helm/ec2-metadata-test-proxy/values.yaml
+++ b/config/helm/ec2-metadata-test-proxy/values.yaml
@@ -4,6 +4,7 @@ ec2MetadataTestProxy:
     interruptionNoticeDelay: 15
     port: 1338
     label: ec2-metadata-test-proxy
+    scheduledEventStatus: active
     enableScheduledMaintenanceEvents: false
     enableSpotITN: true
     image:

--- a/pkg/draineventstore/drain-event-store.go
+++ b/pkg/draineventstore/drain-event-store.go
@@ -92,3 +92,10 @@ func (s *Store) MarkAllAsDrained() {
 		drainEvent.Drained = true
 	}
 }
+
+// ShouldUncordonNode returns true if there was a drainable event but it was cancelled and the store is now empty
+func (s *Store) ShouldUncordonNode() bool {
+	s.RLock()
+	defer s.RUnlock()
+	return s.atLeastOneEvent && len(s.drainEventStore) == 0
+}

--- a/pkg/draineventstore/spot-itn-event.go
+++ b/pkg/draineventstore/spot-itn-event.go
@@ -17,7 +17,7 @@ const (
 )
 
 // MonitorForSpotITNEvents continuously monitors metadata for spot ITNs and sends drain events to the passed in channel
-func MonitorForSpotITNEvents(drainChan chan<- drainevent.DrainEvent, nthConfig config.Config) {
+func MonitorForSpotITNEvents(drainChan chan<- drainevent.DrainEvent, cancelChan chan<- drainevent.DrainEvent, nthConfig config.Config) {
 	log.Println("Started monitoring for spot ITN events")
 	for range time.Tick(time.Second * 2) {
 		drainEvent := checkForSpotInterruptionNotice(nthConfig.MetadataURL)
@@ -25,7 +25,7 @@ func MonitorForSpotITNEvents(drainChan chan<- drainevent.DrainEvent, nthConfig c
 			log.Println("Sending drain event to the drain channel")
 			drainChan <- *drainEvent
 			// cool down for the system to respond to the drain
-			time.Sleep(120 * time.Minute)
+			time.Sleep(120 * time.Second)
 		}
 	}
 }
@@ -38,6 +38,7 @@ func checkForSpotInterruptionNotice(metadataURL string) *drainevent.DrainEvent {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
+		log.Println("Received an http error code when querying for spot itn events.")
 		return &drainevent.DrainEvent{}
 	}
 	var instanceAction ec2metadata.InstanceAction

--- a/test/e2e/maintenance-event-cancellation-test
+++ b/test/e2e/maintenance-event-cancellation-test
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -euo pipefail
+
+# Available env vars:
+#   $TMP_DIR
+#   $CLUSTER_NAME
+#   $KUBECONFIG
+
+echo "Starting Maintenance Event Cancellation Test for Node Termination Handler"
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+NODE_TERMINATION_HANDLER_DOCKER_IMG=$(cat $TMP_DIR/nth-docker-img)
+NODE_TERMINATION_HANDLER_DOCKER_REPO=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f1)
+NODE_TERMINATION_HANDLER_DOCKER_TAG=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f2)
+EC2_METADATA_DOCKER_IMG=$(cat $TMP_DIR/ec2-metadata-test-proxy-docker-img)
+EC2_METADATA_DOCKER_REPO=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f1)
+EC2_METADATA_DOCKER_TAG=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f2)
+
+echo "🥑 Tagging worker nodes to execute integ test"
+kubectl label nodes $CLUSTER_NAME-worker lifecycle=Ec2Spot --overwrite
+kubectl label nodes $CLUSTER_NAME-worker app=spot-termination-test --overwrite
+echo "👍 Tagged worker nodes to execute integ test"
+
+helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ \
+  --wait \
+  --namespace kube-system \
+  --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
+  --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
+  --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
+
+helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
+  --wait \
+  --namespace default \
+  --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
+  --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
+  --set ec2MetadataTestProxy.enableScheduledMaintenanceEvents="true" \
+  --set ec2MetadataTestProxy.enableSpotITN="false"
+
+TAINT_CHECK_CYCLES=15
+TAINT_CHECK_SLEEP=15
+
+DEPLOYED=0
+CORDONED=0
+
+for i in `seq 1 10`; do 
+    if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
+        echo "✅ Verified regular-pod-test pod was scheduled and started!"
+        DEPLOYED=1
+        break
+    fi
+    sleep 5
+done 
+
+if [[ $DEPLOYED -eq 0 ]]; then
+    echo "❌ Failed test setup for regular-pod"
+    exit 2
+fi
+
+for i in `seq 1 $TAINT_CHECK_CYCLES`; do
+    if kubectl get nodes $CLUSTER_NAME-worker | grep SchedulingDisabled; then
+        echo "✅ Verified the worker node was cordoned!"
+        if [[ $(kubectl get deployments regular-pod-test -o=jsonpath='{.status.unavailableReplicas}') -eq 1 ]]; then
+            echo "✅ Verified the regular-pod-test pod was evicted!"
+            CORDONED=1
+        fi
+    fi
+    sleep $TAINT_CHECK_SLEEP
+done
+
+if [[ $CORDONED -eq 0 ]]; then 
+    echo "❌ Failed cordoning node for scheduled maintenance event"
+    exit 3
+fi
+
+helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
+  --wait \
+  --namespace default \
+  --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
+  --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
+  --set ec2MetadataTestProxy.enableScheduledMaintenanceEvents="true" \
+  --set ec2MetadataTestProxy.enableSpotITN="false" \
+  --set ec2MetadataTestProxy.scheduledEventStatus="cancelled"
+
+for i in `seq 1 $TAINT_CHECK_CYCLES`; do
+    if kubectl get nodes $CLUSTER_NAME-worker | grep -v SchedulingDisabled; then
+        echo "✅ Verified the worker node was uncordoned!"
+        if [[ $(kubectl get deployments regular-pod-test -o=jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
+            echo "✅ Verified the regular-pod-test pod was rescheduled"
+            echo "✅ Scheduled Maintenance Event Cancellation Test Passed $CLUSTER_NAME! ✅"
+            exit 0
+        fi
+    fi
+    sleep $TAINT_CHECK_SLEEP
+done
+
+exit 1


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-node-termination-handler/issues/30

# Drain Event Cancellation Handling

## Description of changes:

This PR implements a cancel drain event channel and handler function. The new cancel drain channel is passed to all monitor functions. The Monitor functions are responsible for the cancellation logic for each specific case.  The Spot ITN monitoring function accepts the cancel channel as an argument but ignores it since there is never a case where we should cancel a spot ITN drain event. Scheduled maintenance events are able to be cancelled, either by the AWS user or by EC2. The monitor loop will watch for status changes in the metadata response for maintenance events and propagate those to the cancel channel. 

Once a cancel event is received, the root cancel handler will query the drain event store data structure to see if it should uncordon the node.

## Additional Changes:

 - The drainer package has been renamed to node since it now has more functionality than just draining and cordoning nodes. It can now uncordon nodes.

 ## Tests:

 - e2e test for cancelling a scheduled maintenance event. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
