### PR TITLE
Adding unit tests for ec2metadata package

### DIFF
--- a/pkg/ec2metadata/ec2metadata.go
+++ b/pkg/ec2metadata/ec2metadata.go
@@ -89,8 +89,6 @@ func retry(attempts int, sleep time.Duration, httpReq func() (*http.Response, er
 			time.Sleep(sleep)
 			return retry(attempts, 2*sleep, httpReq)
 		}
-
-		log.Fatalln("Error getting response from instance metadata ", err.Error())
 	}
 
 	return resp, err

--- a/pkg/ec2metadata/ec2metadata_internal_test.go
+++ b/pkg/ec2metadata/ec2metadata_internal_test.go
@@ -1,0 +1,46 @@
+// Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License
+
+package ec2metadata
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	h "github.com/aws/aws-node-termination-handler/pkg/test"
+)
+
+func TestRetry(t *testing.T) {
+	var numRetries int = 3
+	var errorMsg string = "Request failed"
+	var requestCount int
+
+	request := func() (*http.Response, error) {
+		requestCount++
+		return &http.Response{
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			Header:     make(http.Header),
+		}, errors.New(errorMsg)
+	}
+
+	resp, err := retry(numRetries, time.Microsecond, request)
+	defer resp.Body.Close()
+
+	h.Equals(t, errorMsg, err.Error())
+	h.Equals(t, numRetries, requestCount)
+}

--- a/pkg/ec2metadata/ec2metadata_test.go
+++ b/pkg/ec2metadata/ec2metadata_test.go
@@ -1,0 +1,48 @@
+// Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License
+
+package ec2metadata_test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-node-termination-handler/pkg/ec2metadata"
+	h "github.com/aws/aws-node-termination-handler/pkg/test"
+)
+
+func TestRequestMetadata(t *testing.T) {
+	var requestPath string = "/some/path"
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		h.Equals(t, req.URL.String(), requestPath)
+		rw.Write([]byte(`OK`))
+	}))
+	defer server.Close()
+
+	// Use Client & URL from our local test server
+	resp, err := ec2metadata.RequestMetadata(server.URL, requestPath)
+	defer resp.Body.Close()
+
+	h.Ok(t, err)
+	h.Equals(t, http.StatusOK, resp.StatusCode)
+
+	responseData, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Error("Unable to parse response.")
+	}
+
+	h.Equals(t, []byte("OK"), responseData)
+}

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -1,0 +1,50 @@
+// Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License
+
+package test
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+// Assert fails the test if the condition is false.
+func Assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
+	if !condition {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: "+msg+"\033[39m\n\n", append([]interface{}{filepath.Base(file), line}, v...)...)
+		tb.FailNow()
+	}
+}
+
+// Ok fails the test if an err is not nil.
+func Ok(tb testing.TB, err error) {
+	if err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: unexpected error: %s\033[39m\n\n", filepath.Base(file), line, err.Error())
+		tb.FailNow()
+	}
+}
+
+// Equals fails the test if exp is not equal to act.
+func Equals(tb testing.TB, exp, act interface{}) {
+	if !reflect.DeepEqual(exp, act) {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, exp, act)
+		tb.FailNow()
+	}
+
+}


### PR DESCRIPTION
Description of changes:
```
2020/01/20 15:52:34 Request failed. Attempts remaining: 2
2020/01/20 15:52:34 Sleep for 1.205µs seconds
2020/01/20 15:52:34 Request failed. Attempts remaining: 1
2020/01/20 15:52:34 Sleep for 2.71µs seconds
PASS
coverage: 100.0% of statements
ok      github.com/aws/aws-node-termination-handler/pkg/ec2metadata    1.366s
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
