### PR TITLE
Adding webhook unit tests

### DIFF
--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -1,0 +1,206 @@
+// Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package webhook_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/aws/aws-node-termination-handler/pkg/config"
+	"github.com/aws/aws-node-termination-handler/pkg/drainevent"
+	h "github.com/aws/aws-node-termination-handler/pkg/test"
+	"github.com/aws/aws-node-termination-handler/pkg/webhook"
+)
+
+const (
+	testDateFormat      = "02 Jan 2006 15:04:05 GMT"
+	testWebhookHeaders  = `{"Content-type":"application/json"}`
+	testWebhookTemplate = `{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} - State: {{ .State }} - Start Time: {{ .StartTime }}"}`
+)
+
+func parseScheduledEventTime(inputTime string) time.Time {
+	scheduledTime, _ := time.Parse(testDateFormat, inputTime)
+	return scheduledTime
+}
+
+func getExpectedMessage(event *drainevent.DrainEvent) string {
+	webhookTemplate, err := template.New("").Parse(testWebhookTemplate)
+	if err != nil {
+		log.Printf("Webhook Error: Template parsing failed - %s\n", err)
+		return ""
+	}
+
+	var byteBuffer bytes.Buffer
+	webhookTemplate.Execute(&byteBuffer, event)
+
+	m := map[string]interface{}{}
+	if err := json.Unmarshal(byteBuffer.Bytes(), &m); err != nil {
+		return ""
+	}
+
+	return fmt.Sprintf("%v", m["text"])
+}
+
+func TestPostSuccess(t *testing.T) {
+	var requestPath string = "/some/path"
+
+	event := &drainevent.DrainEvent{
+		EventID:     "instance-event-0d59937288b749b32",
+		Kind:        "SCHEDULED_EVENT",
+		Description: "Scheduled event will occur",
+		State:       "active",
+		StartTime:   parseScheduledEventTime("21 Jan 2019 09:00:43 GMT"),
+		EndTime:     parseScheduledEventTime("21 Jan 2019 09:17:23 GMT"),
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		h.Equals(t, req.Method, "POST")
+		h.Equals(t, req.URL.String(), requestPath)
+
+		// Test request headers
+		headerMap := make(map[string]interface{})
+		if err := json.Unmarshal([]byte(testWebhookHeaders), &headerMap); err != nil {
+			t.Error("Unable to parse webhook headers")
+		}
+		h.Equals(t, req.Header.Get("Content-type"), headerMap["Content-type"])
+
+		// Test requst body
+		requestBody, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			t.Error("Unable to read request body.")
+		}
+		requestMap := map[string]interface{}{}
+		if err := json.Unmarshal([]byte(requestBody), &requestMap); err != nil {
+			t.Error("Unable to parse request body to json.")
+		}
+		h.Equals(t, getExpectedMessage(event), requestMap["text"])
+
+		rw.Write([]byte(`OK`))
+	}))
+	defer server.Close()
+
+	nthconfig := config.Config{
+		WebhookURL:      server.URL + requestPath,
+		WebhookHeaders:  testWebhookHeaders,
+		WebhookTemplate: testWebhookTemplate,
+	}
+
+	webhook.Post(event, nthconfig)
+}
+
+func TestPostTemplateParseError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		t.Error("Request made with invalid webhook")
+	}))
+	defer server.Close()
+
+	event := &drainevent.DrainEvent{}
+	nthconfig := config.Config{
+		WebhookURL:      server.URL,
+		WebhookTemplate: "{{ ",
+	}
+
+	webhook.Post(event, nthconfig)
+}
+
+func TestPostTemplateExecutionError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		t.Error("Request made with invalid webhook")
+	}))
+	defer server.Close()
+
+	event := &drainevent.DrainEvent{}
+	nthconfig := config.Config{
+		WebhookURL:      server.URL,
+		WebhookTemplate: `{{.cat}}`,
+	}
+
+	webhook.Post(event, nthconfig)
+}
+
+func TestPostNewHttpRequestError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		t.Error("Request made with invalid webhook")
+	}))
+	defer server.Close()
+
+	event := &drainevent.DrainEvent{}
+	nthconfig := config.Config{
+		WebhookURL:      "\t",
+		WebhookTemplate: testWebhookTemplate,
+	}
+
+	webhook.Post(event, nthconfig)
+}
+
+func TestPostHeaderParseFail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		t.Error("Request made with invalid webhook")
+	}))
+	defer server.Close()
+
+	event := &drainevent.DrainEvent{}
+	nthconfig := config.Config{
+		WebhookURL:      server.URL,
+		WebhookTemplate: testWebhookTemplate,
+	}
+
+	webhook.Post(event, nthconfig)
+}
+
+func TestPostTimeout(t *testing.T) {
+	var requestCount int = 0
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		requestCount++
+		time.Sleep(6 * time.Second)
+	}))
+	defer server.Close()
+
+	event := &drainevent.DrainEvent{}
+	nthconfig := config.Config{
+		WebhookURL:      server.URL,
+		WebhookTemplate: testWebhookTemplate,
+		WebhookHeaders:  testWebhookHeaders,
+	}
+
+	webhook.Post(event, nthconfig)
+	h.Equals(t, 1, requestCount)
+}
+
+func TestPostBadResponseCode(t *testing.T) {
+	var requestCount int = 0
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		requestCount++
+		http.Error(rw, "404 page not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	event := &drainevent.DrainEvent{}
+	nthconfig := config.Config{
+		WebhookURL:      server.URL,
+		WebhookTemplate: testWebhookTemplate,
+		WebhookHeaders:  testWebhookHeaders,
+	}
+
+	webhook.Post(event, nthconfig)
+	h.Equals(t, 1, requestCount)
+}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
unit tests for webhook
Output
```
2020/01/21 15:59:48 Webhook Success: Notification Sent!
2020/01/21 15:59:48 Webhook Error: Template parsing failed - template: message:1: unexpected unclosed action in command
2020/01/21 15:59:48 Webhook Error: Template execution failed - template: message:1:2: executing "message" at <.cat>: can't evaluate field cat in type *drainevent.DrainEvent
2020/01/21 15:59:48 Webhook Error: Http NewRequest failed - parse     : net/url: invalid control character in URL
2020/01/21 15:59:48 Webhook Error: Header Unmarshal failed - unexpected end of JSON input
2020/01/21 15:59:53 Webhook Error: Client Do failed - Post http://127.0.0.1:60999: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
2020/01/21 15:59:54 Webhook Error: Recieved Status Code 404
PASS
coverage: 100.0% of statements
ok      github.com/aws/aws-node-termination-handler/pkg/webhook    7.394s
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
