### PR TITLE
[1] - Label action handling for uncordoning after reboot

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -27,15 +27,25 @@ import (
 	"github.com/aws/aws-node-termination-handler/pkg/webhook"
 )
 
+type monitorFunc func(chan<- drainevent.DrainEvent, chan<- drainevent.DrainEvent, config.Config)
+
 func main() {
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGTERM)
 	defer signal.Stop(signalChan)
 
 	nthConfig := config.ParseCliArgs()
+	err := webhook.ValidateWebhookConfig(nthConfig)
+	if err != nil {
+		log.Fatalln("Webhook validation failed: ", err)
+	}
 	node, err := node.New(nthConfig)
 	if err != nil {
 		log.Fatalln("Unable to instantiate a node for various kubernetes node functions: ", err)
+	}
+	err = node.UncordonIfLabeled()
+	if err != nil {
+		log.Println("Unable to complete node label actions: ", err)
 	}
 	drainEventStore := draineventstore.New(&nthConfig)
 
@@ -44,9 +54,10 @@ func main() {
 	cancelChan := make(chan drainevent.DrainEvent)
 	defer close(cancelChan)
 
-	monitoringFns := []func(chan<- drainevent.DrainEvent, chan<- drainevent.DrainEvent, config.Config){}
-	monitoringFns = append(monitoringFns, draineventstore.MonitorForSpotITNEvents)
-	monitoringFns = append(monitoringFns, draineventstore.MonitorForScheduledEvents)
+	monitoringFns := []monitorFunc{
+		drainevent.MonitorForSpotITNEvents,
+		drainevent.MonitorForScheduledEvents,
+	}
 	for _, fn := range monitoringFns {
 		go fn(drainChan, cancelChan, nthConfig)
 	}
@@ -88,13 +99,19 @@ func watchForCancellationEvents(cancelChan <-chan drainevent.DrainEvent, drainEv
 		log.Printf("Got cancel event from channel %+v\n", drainEvent)
 		drainEventStore.CancelDrainEvent(drainEvent.EventID)
 		if drainEventStore.ShouldUncordonNode() {
-			node.UncordonNode()
+			node.Uncordon()
 		}
 	}
 }
 
 func drainIfNecessary(drainEventStore *draineventstore.Store, node *node.Node, nthConfig config.Config) {
 	if drainEvent, ok := drainEventStore.GetActiveEvent(); ok {
+		if drainEvent.PreDrainTask != nil {
+			err := drainEvent.PreDrainTask(node)
+			if err != nil {
+				log.Println("There was a problem executing the pre-drain task: ", err)
+			}
+		}
 		node.Drain()
 		drainEventStore.MarkAllAsDrained()
 		log.Printf("Node %q successfully drained.\n", nthConfig.NodeName)

--- a/config/helm/aws-node-termination-handler/templates/daemonset.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.yaml
@@ -25,6 +25,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         k8s-app: aws-node-termination-handler
     spec:
+      volumes:
+        - name: "uptime"
+          hostPath:
+            path: "{{ .Values.procUptimeFile }}"
       priorityClassName: "{{ .Values.priorityClassName }}"
       affinity:
         nodeAffinity:
@@ -46,6 +50,9 @@ spec:
         - name: {{ include "aws-node-termination-handler.name" . }}
           image: {{ .Values.image.repository}}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: "uptime"
+              mountPath: "/proc/uptime"
           env:
           - name: NODE_NAME
             valueFrom:

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -57,6 +57,9 @@ webhookTemplate: ""
 # instanceMetadataURL is used to override the default metadata URL (default: http://169.254.169.254:80)
 instanceMetadataURL: ""
 
+# (TESTING USE): Mount path for uptime file
+procUptimeFile: "/proc/uptime"
+
 # nodeSelector tells the daemonset where to place the node-termination-handler
 # pods. By default, this value is empty and every node will receive a pod.
 nodeSelector: {}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,15 +14,11 @@
 package config
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
 	"log"
 	"os"
 	"strconv"
-	"text/template"
-
-	"github.com/aws/aws-node-termination-handler/pkg/drainevent"
 )
 
 const (
@@ -93,19 +89,6 @@ func ParseCliArgs() Config {
 
 	if config.NodeName == "" {
 		log.Fatalln("You must provide a node-name to the CLI or NODE_NAME environment variable.")
-	}
-	// fail fast if webhook template will not work
-	if config.WebhookURL != "" {
-		webhookTemplate, err := template.New("message").Parse(config.WebhookTemplate)
-		if err != nil {
-			log.Fatalf("Unable to parse webhook template - %s\n", err)
-		}
-
-		var byteBuffer bytes.Buffer
-		err = webhookTemplate.Execute(&byteBuffer, &drainevent.DrainEvent{})
-		if err != nil {
-			log.Fatalf("Unable to execute webhook template - %s\n", err)
-		}
 	}
 
 	// client-go expects these to be set in env vars

--- a/pkg/drainevent/drain-event.go
+++ b/pkg/drainevent/drain-event.go
@@ -15,17 +15,22 @@ package drainevent
 
 import (
 	"time"
+
+	"github.com/aws/aws-node-termination-handler/pkg/node"
 )
+
+type preDrainTask func(*node.Node) error
 
 // DrainEvent gives more context of the drainable event
 type DrainEvent struct {
-	EventID     string
-	Kind        string
-	Description string
-	State       string
-	StartTime   time.Time
-	EndTime     time.Time
-	Drained     bool
+	EventID      string
+	Kind         string
+	Description  string
+	State        string
+	StartTime    time.Time
+	EndTime      time.Time
+	Drained      bool
+	PreDrainTask preDrainTask `json:"-"`
 }
 
 // TimeUntilEvent returns the duration until the event start time

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -16,6 +16,7 @@ package webhook
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"text/template"
@@ -74,4 +75,22 @@ func Post(event *drainevent.DrainEvent, nthconfig config.Config) {
 	}
 
 	log.Println("Webhook Success: Notification Sent!")
+}
+
+// ValidateWebhookConfig will check if the template provided in nthConfig with parse and execute
+func ValidateWebhookConfig(nthConfig config.Config) error {
+	if nthConfig.WebhookURL == "" {
+		return nil
+	}
+	webhookTemplate, err := template.New("message").Parse(nthConfig.WebhookTemplate)
+	if err != nil {
+		return fmt.Errorf("Unable to parse webhook template: %w", err)
+	}
+
+	var byteBuffer bytes.Buffer
+	err = webhookTemplate.Execute(&byteBuffer, &drainevent.DrainEvent{})
+	if err != nil {
+		return fmt.Errorf("Unable to execute webhook template: %w", err)
+	}
+	return nil
 }

--- a/test/e2e/maintenance-event-reboot-test
+++ b/test/e2e/maintenance-event-reboot-test
@@ -1,0 +1,105 @@
+#!/bin/bash
+set -euo pipefail
+
+# Available env vars:
+#   $TMP_DIR
+#   $CLUSTER_NAME
+#   $KUBECONFIG
+
+echo "Starting Maintenance Event Cancellation Test for Node Termination Handler"
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+NODE_TERMINATION_HANDLER_DOCKER_IMG=$(cat $TMP_DIR/nth-docker-img)
+NODE_TERMINATION_HANDLER_DOCKER_REPO=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f1)
+NODE_TERMINATION_HANDLER_DOCKER_TAG=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f2)
+EC2_METADATA_DOCKER_IMG=$(cat $TMP_DIR/ec2-metadata-test-proxy-docker-img)
+EC2_METADATA_DOCKER_REPO=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f1)
+EC2_METADATA_DOCKER_TAG=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f2)
+
+helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ \
+  --wait \
+  --force \
+  --namespace kube-system \
+  --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
+  --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
+  --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
+
+helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
+  --wait \
+  --force \
+  --namespace default \
+  --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
+  --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
+  --set ec2MetadataTestProxy.enableScheduledMaintenanceEvents="true" \
+  --set ec2MetadataTestProxy.enableSpotITN="false"
+
+TAINT_CHECK_CYCLES=15
+TAINT_CHECK_SLEEP=15
+
+DEPLOYED=0
+CORDONED=0
+
+for i in `seq 1 10`; do 
+    if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
+        echo "✅ Verified regular-pod-test pod was scheduled and started!"
+        DEPLOYED=1
+        break
+    fi
+    sleep 5
+done 
+
+if [[ $DEPLOYED -eq 0 ]]; then
+    echo "❌ Failed test setup for regular-pod"
+    exit 2
+fi
+
+for i in `seq 1 $TAINT_CHECK_CYCLES`; do
+    if kubectl get nodes $CLUSTER_NAME-worker | grep SchedulingDisabled; then
+        echo "✅ Verified the worker node was cordoned!"
+        if [[ $(kubectl get deployments regular-pod-test -o=jsonpath='{.status.unavailableReplicas}') -eq 1 ]]; then
+            echo "✅ Verified the regular-pod-test pod was evicted!"
+            CORDONED=1
+            break
+        fi
+    fi
+    sleep $TAINT_CHECK_SLEEP
+done
+
+if [[ $CORDONED -eq 0 ]]; then 
+    echo "❌ Failed cordoning node for scheduled maintenance event"
+    exit 3
+fi
+
+## Copy uptime file to Kind k8s worker node
+docker cp $SCRIPTPATH/../assets/uptime-reboot $CLUSTER_NAME-worker:/uptime
+docker exec $CLUSTER_NAME-worker sh -c "chmod 0444 /uptime && chown root /uptime && chgrp root /uptime"
+
+## Remove ec2-metadata-test-proxy to prevent another drain event but keep regular-test-pod
+daemonset=$(kubectl get daemonsets | grep 'ec2-metadata-test-proxy' | cut -d' ' -f1)
+kubectl delete daemonsets $daemonset 
+
+## Restart NTH which will simulate a system reboot by mounting a new uptime file
+helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ \
+  --wait \
+  --force \
+  --namespace kube-system \
+  --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
+  --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
+  --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
+  --set procUptimeFile="/uptime"
+
+for i in `seq 1 $TAINT_CHECK_CYCLES`; do
+    NODE_LINE=$(kubectl get nodes $CLUSTER_NAME-worker | grep -v 'STATUS')
+    if [[ -z $(echo $NODE_LINE | grep SchedulingDisabled) ]] && [[ ! -z $(echo $NODE_LINE | grep Ready) ]]; then
+        echo "✅ Verified the worker node was uncordoned!"
+        if [[ $(kubectl get deployments regular-pod-test -o=jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
+            echo "✅ Verified the regular-pod-test pod was rescheduled"
+            echo "✅ Scheduled Maintenance Event System Reboot Test Passed $CLUSTER_NAME! ✅"
+            exit 0
+        fi
+    fi
+    sleep $TAINT_CHECK_SLEEP
+done
+
+exit 1

--- a/test/k8s-local-cluster-test/run-test
+++ b/test/k8s-local-cluster-test/run-test
@@ -177,8 +177,8 @@ for assert_script in $ASSERTION_SCRIPTS; do
   $assert_script
   assert_end=$(date +%s)
   echo "⏰ Took $(expr $assert_end - $assert_start)sec"
-  POD_ID=$(kubectl get pods --namespace kube-system | grep -i node-termination-handler | grep Running | cut -d' ' -f1 )
-  kubectl logs $POD_ID --namespace kube-system
+  POD_ID=$(kubectl get pods --namespace kube-system | grep -i node-termination-handler | grep -i -e Running -e CrashLoop | cut -d' ' -f1 || :)
+  kubectl logs $POD_ID --namespace kube-system || :
   ## Resets cluster to run another test on the same cluster
   reset_cluster
   echo "✅ Assertion test $assert_script PASSED! ✅"


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-node-termination-handler/issues/30

# Maintenance Events Uncordon After Reboot

## Description of changes:
This change supports labeling the current node with an action tag and action-time tag in order to support uncordoning the node after a maintenance event requiring a reboot.  This automates the process of cordoning nodes temporarily going down for maintenance and then removing the cordon when the maintenance has been completed. 

 ## More Details:

 - If a `system-reboot` maintenance event is received, the scheduled-maintenance-event monitor loop will add a new `PreDrainTask` to the `drainevent` which is a function that executes right before the node is cordoned and drained. In the `system-reboot` case, the function checks if the node is already cordoned (meaning an out-of-band process cordoned the node), in which case the function will exit. If the node is not already cordoned, the `PreDrainTask` will apply a label to the node `aws-node-termination-handler/action=UncordonAfterReboot` and `aws-node-termination-handler/action-time=<seconds_since_epoch>`.  When the aws-node-termination-handler starts up, it will check for these labels on the node. If it finds them, it will check the current system uptime and determine if a reboot has taken place. It will then uncordon the node and remove the labels. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
