### PR TITLE
fix e2e test stability issues

### DIFF
--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -32,10 +32,10 @@ dryRun: false
 
 # deleteLocalData tells kubectl to continue even if there are pods using
 # emptyDir (local data that will be deleted when the node is drained).
-deleteLocalData: false
+deleteLocalData: ""
 
 # ignoreDaemonSets causes kubectl to skip Daemon Set managed pods.
-ignoreDaemonSets: true
+ignoreDaemonSets: ""
 
 # gracePeriod (DEPRECATED - use podTerminationGracePeriod instead) is time in seconds given to each pod to terminate gracefully.
 # If negative, the default value specified in the pod will be used.

--- a/test/e2e/maintenance-event-cancellation-test
+++ b/test/e2e/maintenance-event-cancellation-test
@@ -5,25 +5,18 @@ set -euo pipefail
 #   $TMP_DIR
 #   $CLUSTER_NAME
 #   $KUBECONFIG
+#   $NODE_TERMINATION_HANDLER_DOCKER_REPO
+#   $NODE_TERMINATION_HANDLER_DOCKER_TAG
+#   $EC2_METADATA_DOCKER_REPO
+#   $EC2_METADATA_DOCKER_TAG
 
 echo "Starting Maintenance Event Cancellation Test for Node Termination Handler"
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-NODE_TERMINATION_HANDLER_DOCKER_IMG=$(cat $TMP_DIR/nth-docker-img)
-NODE_TERMINATION_HANDLER_DOCKER_REPO=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f1)
-NODE_TERMINATION_HANDLER_DOCKER_TAG=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f2)
-EC2_METADATA_DOCKER_IMG=$(cat $TMP_DIR/ec2-metadata-test-proxy-docker-img)
-EC2_METADATA_DOCKER_REPO=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f1)
-EC2_METADATA_DOCKER_TAG=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f2)
-
-echo "🥑 Tagging worker nodes to execute integ test"
-kubectl label nodes $CLUSTER_NAME-worker lifecycle=Ec2Spot --overwrite
-kubectl label nodes $CLUSTER_NAME-worker app=spot-termination-test --overwrite
-echo "👍 Tagged worker nodes to execute integ test"
-
 helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ \
   --wait \
+  --force \
   --namespace kube-system \
   --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
@@ -31,6 +24,7 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
   --wait \
+  --force \
   --namespace default \
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
@@ -63,6 +57,7 @@ for i in `seq 1 $TAINT_CHECK_CYCLES`; do
         if [[ $(kubectl get deployments regular-pod-test -o=jsonpath='{.status.unavailableReplicas}') -eq 1 ]]; then
             echo "✅ Verified the regular-pod-test pod was evicted!"
             CORDONED=1
+            break
         fi
     fi
     sleep $TAINT_CHECK_SLEEP
@@ -75,6 +70,7 @@ fi
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
   --wait \
+  --force \
   --namespace default \
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \

--- a/test/e2e/maintenance-event-dry-run-test
+++ b/test/e2e/maintenance-event-dry-run-test
@@ -5,20 +5,18 @@ set -euo pipefail
 #   $TMP_DIR
 #   $CLUSTER_NAME
 #   $KUBECONFIG
+#   $NODE_TERMINATION_HANDLER_DOCKER_REPO
+#   $NODE_TERMINATION_HANDLER_DOCKER_TAG
+#   $EC2_METADATA_DOCKER_REPO
+#   $EC2_METADATA_DOCKER_TAG
 
 echo "Starting Maintenance Events Dry-Run Test for Node Termination Handler"
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-NODE_TERMINATION_HANDLER_DOCKER_IMG=$(cat $TMP_DIR/nth-docker-img)
-NODE_TERMINATION_HANDLER_DOCKER_REPO=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f1)
-NODE_TERMINATION_HANDLER_DOCKER_TAG=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f2)
-EC2_METADATA_DOCKER_IMG=$(cat $TMP_DIR/ec2-metadata-test-proxy-docker-img)
-EC2_METADATA_DOCKER_REPO=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f1)
-EC2_METADATA_DOCKER_TAG=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f2)
-
 helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ \
   --wait \
+  --force \
   --namespace kube-system \
   --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
@@ -27,20 +25,23 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
   --wait \
+  --force \
   --namespace default \
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG"
 
 POD_ID=$(kubectl get pods --namespace kube-system | grep -i node-termination-handler | grep Running | cut -d' ' -f1)
 
-if (timeout 30 kubectl logs $POD_ID -n kube-system -f &) | grep -m1 -i -e 'would have been cordoned and drained'; then
-    echo "✅ Verified the dryrun logs were executed"
-    sleep 10
-    if kubectl get nodes $CLUSTER_NAME-worker | tail -n1 | grep -v SchedulingDisabled; then
+for i in $(seq 0 10); do 
+  if [[ ! -z $(kubectl logs $POD_ID -n kube-system | grep -i -e 'would have been cordoned and drained') ]]; then
+      echo "✅ Verified the dryrun logs were executed"
+      if kubectl get nodes $CLUSTER_NAME-worker | tail -n1 | grep -v SchedulingDisabled; then
           echo "✅ Verified the worker node was not cordoned!"
           echo "✅ Scheduled Maintenance Event Dry Run Test Passed $CLUSTER_NAME! ✅"
           exit 0
-    fi
-fi
+      fi
+  fi
+  sleep 10
+done
 
 exit 1

--- a/test/e2e/maintenance-event-test
+++ b/test/e2e/maintenance-event-test
@@ -5,25 +5,18 @@ set -euo pipefail
 #   $TMP_DIR
 #   $CLUSTER_NAME
 #   $KUBECONFIG
+#   $NODE_TERMINATION_HANDLER_DOCKER_REPO
+#   $NODE_TERMINATION_HANDLER_DOCKER_TAG
+#   $EC2_METADATA_DOCKER_REPO
+#   $EC2_METADATA_DOCKER_TAG
 
 echo "Starting Maintenance Events Test for Node Termination Handler"
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-NODE_TERMINATION_HANDLER_DOCKER_IMG=$(cat $TMP_DIR/nth-docker-img)
-NODE_TERMINATION_HANDLER_DOCKER_REPO=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f1)
-NODE_TERMINATION_HANDLER_DOCKER_TAG=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f2)
-EC2_METADATA_DOCKER_IMG=$(cat $TMP_DIR/ec2-metadata-test-proxy-docker-img)
-EC2_METADATA_DOCKER_REPO=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f1)
-EC2_METADATA_DOCKER_TAG=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f2)
-
-echo "🥑 Tagging worker nodes to execute integ test"
-kubectl label nodes $CLUSTER_NAME-worker lifecycle=Ec2Spot --overwrite
-kubectl label nodes $CLUSTER_NAME-worker app=spot-termination-test --overwrite
-echo "👍 Tagged worker nodes to execute integ test"
-
 helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ \
   --wait \
+  --force \
   --namespace kube-system \
   --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
@@ -31,6 +24,7 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
   --wait \
+  --force \
   --namespace default \
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \

--- a/test/e2e/spot-interruption-dry-run-test
+++ b/test/e2e/spot-interruption-dry-run-test
@@ -5,20 +5,18 @@ set -euo pipefail
 #   $TMP_DIR
 #   $CLUSTER_NAME
 #   $KUBECONFIG
+#   $NODE_TERMINATION_HANDLER_DOCKER_REPO
+#   $NODE_TERMINATION_HANDLER_DOCKER_TAG
+#   $EC2_METADATA_DOCKER_REPO
+#   $EC2_METADATA_DOCKER_TAG
 
 echo "Starting Maintenance Events Dry-Run Test for Node Termination Handler"
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-NODE_TERMINATION_HANDLER_DOCKER_IMG=$(cat $TMP_DIR/nth-docker-img)
-NODE_TERMINATION_HANDLER_DOCKER_REPO=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f1)
-NODE_TERMINATION_HANDLER_DOCKER_TAG=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f2)
-EC2_METADATA_DOCKER_IMG=$(cat $TMP_DIR/ec2-metadata-test-proxy-docker-img)
-EC2_METADATA_DOCKER_REPO=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f1)
-EC2_METADATA_DOCKER_TAG=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f2)
-
 helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ \
   --wait \
+  --force \
   --namespace kube-system \
   --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
@@ -27,20 +25,23 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
   --wait \
+  --force \
   --namespace default \
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" 
 
 POD_ID=$(kubectl get pods --namespace kube-system | grep -i node-termination-handler | grep Running | cut -d' ' -f1)
 
-if (timeout 30 kubectl logs $POD_ID -n kube-system -f &) | grep -m1 -i -e 'would have been cordoned and drained'; then
-    echo "✅ Verified the dryrun logs were executed"
-    sleep 10 
-    if kubectl get nodes $CLUSTER_NAME-worker | tail -n1 | grep -v SchedulingDisabled; then
+for i in $(seq 0 10); do 
+  if [[ ! -z $(kubectl logs $POD_ID -n kube-system | grep -i -e 'would have been cordoned and drained') ]]; then
+      echo "✅ Verified the dryrun logs were executed"
+      if kubectl get nodes $CLUSTER_NAME-worker | tail -n1 | grep -v SchedulingDisabled; then
           echo "✅ Verified the worker node was not cordoned!"
           echo "✅ Spot Interruption Dry Run Test Passed $CLUSTER_NAME! ✅"
           exit 0
-    fi
-fi
+      fi
+  fi
+  sleep 10
+done
 
 exit 1

--- a/test/e2e/spot-interruption-test
+++ b/test/e2e/spot-interruption-test
@@ -5,25 +5,18 @@ set -euo pipefail
 #   $TMP_DIR
 #   $CLUSTER_NAME
 #   $KUBECONFIG
+#   $NODE_TERMINATION_HANDLER_DOCKER_REPO
+#   $NODE_TERMINATION_HANDLER_DOCKER_TAG
+#   $EC2_METADATA_DOCKER_REPO
+#   $EC2_METADATA_DOCKER_TAG
 
 echo "Starting Spot Interruption Test for Node Termination Handler"
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-NODE_TERMINATION_HANDLER_DOCKER_IMG=$(cat $TMP_DIR/nth-docker-img)
-NODE_TERMINATION_HANDLER_DOCKER_REPO=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f1)
-NODE_TERMINATION_HANDLER_DOCKER_TAG=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f2)
-EC2_METADATA_DOCKER_IMG=$(cat $TMP_DIR/ec2-metadata-test-proxy-docker-img)
-EC2_METADATA_DOCKER_REPO=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f1)
-EC2_METADATA_DOCKER_TAG=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f2)
-
-echo "🥑 Tagging worker nodes to execute integ test"
-kubectl label nodes $CLUSTER_NAME-worker lifecycle=Ec2Spot --overwrite
-kubectl label nodes $CLUSTER_NAME-worker app=spot-termination-test --overwrite
-echo "👍 Tagged worker nodes to execute integ test"
-
 helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ \
   --wait \
+  --force \
   --namespace kube-system \
   --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
@@ -33,6 +26,7 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
   --wait \
+  --force \
   --namespace default \
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \

--- a/test/e2e/webhook-test
+++ b/test/e2e/webhook-test
@@ -5,24 +5,14 @@ set -euo pipefail
 #   $TMP_DIR
 #   $CLUSTER_NAME
 #   $KUBECONFIG
+#   $NODE_TERMINATION_HANDLER_DOCKER_REPO
+#   $NODE_TERMINATION_HANDLER_DOCKER_TAG
+#   $EC2_METADATA_DOCKER_REPO
+#   $EC2_METADATA_DOCKER_TAG
 
 echo "Starting Webhook Test for Node Termination Handler"
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-
-NODE_TERMINATION_HANDLER_DOCKER_IMG=$(cat $TMP_DIR/nth-docker-img)
-NODE_TERMINATION_HANDLER_DOCKER_REPO=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f1)
-NODE_TERMINATION_HANDLER_DOCKER_TAG=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f2)
-EC2_METADATA_DOCKER_IMG=$(cat $TMP_DIR/ec2-metadata-test-proxy-docker-img)
-EC2_METADATA_DOCKER_REPO=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f1)
-EC2_METADATA_DOCKER_TAG=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f2)
-
-echo "🥑 Tagging worker nodes to execute integ test"
-kubectl label nodes $CLUSTER_NAME-worker lifecycle=Ec2Spot --overwrite
-kubectl label nodes $CLUSTER_NAME-worker app=spot-termination-test --overwrite
-echo "👍 Tagged worker nodes to execute integ test"
-
-### HELM STUFF
 
 ### LOCAL ONLY TESTS FOR 200 RESPONSE FROM LOCAL CLUSTER, MASTER WILL TEST WITH TRAVIS SECRET URL
 if [[ $(env | grep "WEBHOOK_URL=" | wc -l) ]]; then
@@ -30,6 +20,8 @@ if [[ $(env | grep "WEBHOOK_URL=" | wc -l) ]]; then
 fi
 
 helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ \
+  --wait \
+  --force \
   --namespace kube-system \
   --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
@@ -37,11 +29,11 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --set webhookURL="$WEBHOOK_URL"
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
+  --wait \
+  --force \
   --namespace default \
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG"
-
-## END HELM
 
 TAINT_CHECK_CYCLES=15
 TAINT_CHECK_SLEEP=15

--- a/test/k8s-local-cluster-test/provision-cluster
+++ b/test/k8s-local-cluster-test/provision-cluster
@@ -118,7 +118,14 @@ else
 fi
 
 echoerr "🥑 Creating k8s cluster using \"kind\""
-kind create cluster -q --name "$CLUSTER_NAME" --image $K8_VERSION --config "$SCRIPTPATH/kind-two-node-cluster.yaml" --wait "$CLUSTER_CREATION_TIMEOUT_IN_SEC"s --kubeconfig $TMP_DIR/kubeconfig 1>&2
+for i in $(seq 0 5); do
+  if [[ -z $(kind get clusters | grep $CLUSTER_NAME) ]]; then
+      kind create cluster -q --name "$CLUSTER_NAME" --image $K8_VERSION --config "$SCRIPTPATH/kind-two-node-cluster.yaml" --wait "$CLUSTER_CREATION_TIMEOUT_IN_SEC"s --kubeconfig $TMP_DIR/kubeconfig 1>&2 || :
+  else
+      break
+  fi
+done
+
 echo "$CLUSTER_NAME" > $TMP_DIR/clustername
 echoerr "👍 Created k8s cluster using \"kind\""
 

--- a/test/k8s-local-cluster-test/run-test
+++ b/test/k8s-local-cluster-test/run-test
@@ -164,10 +164,19 @@ echo "kubectl get pods -A"
 echo "======================================================================================================"
 
 
+### exported vars and funcs that tests can use
 export TMP_DIR
 export CLUSTER_NAME
 export -f timeout
 export -f relpath
+export NODE_TERMINATION_HANDLER_DOCKER_IMG=$(cat $TMP_DIR/nth-docker-img)
+export NODE_TERMINATION_HANDLER_DOCKER_REPO=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f1)
+export NODE_TERMINATION_HANDLER_DOCKER_TAG=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f2)
+export EC2_METADATA_DOCKER_IMG=$(cat $TMP_DIR/ec2-metadata-test-proxy-docker-img)
+export EC2_METADATA_DOCKER_REPO=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f1)
+export EC2_METADATA_DOCKER_TAG=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f2)
+###
+
 for assert_script in $ASSERTION_SCRIPTS; do
   reset_cluster
   echo "======================================================================================================"


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
e2e tests in travis have been intermittently failing. This PR fixes some stability issues with the tests and removes some code that can be placed in the base `run-test` script.  I tested these on my fork w/ travis and tests completed successfully several times in a row. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
