### PR TITLE
fix webhook test on push

### DIFF
--- a/test/e2e/webhook-test
+++ b/test/e2e/webhook-test
@@ -15,7 +15,7 @@ echo "Starting Webhook Test for Node Termination Handler"
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 ### LOCAL ONLY TESTS FOR 200 RESPONSE FROM LOCAL CLUSTER, MASTER WILL TEST WITH TRAVIS SECRET URL
-if [[ $(env | grep "WEBHOOK_URL=" | wc -l) ]]; then
+if [[ -z $(env | grep "WEBHOOK_URL=") ]]; then
   WEBHOOK_URL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338"
 fi
 


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Fix the webhook test on git push. This test should use the travis secret to post to an actual messaging app to test webhook delivery. The shell conditional was always evaluating to true. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
