### PR TITLE
feature flags for scheduled events and spot interuption added to cli …

### DIFF
--- a/config/helm/aws-node-termination-handler/Chart.yaml
+++ b/config/helm/aws-node-termination-handler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.4.0
-appVersion: 1.1.0
+version: 0.5.0
+appVersion: 1.2.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/config/helm/aws-node-termination-handler/templates/daemonset.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.yaml
@@ -90,6 +90,10 @@ spec:
             value: {{ .Values.webhookTemplate | quote }}
           - name: DRY_RUN
             value: {{ .Values.dryRun | quote }}
+          - name: ENABLE_SPOT_INTERRUPTION_DRAINING
+            value: {{ .Values.enableSpotInterruptionDraining | quote }}
+          - name: ENABLE_SCHEDULED_EVENT_DRAINING
+            value: {{ .Values.enableScheduledEventDraining | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -27,6 +27,12 @@ resources:
     memory: "128Mi"
     cpu: "100m"
 
+## enableSpotInterruptionDraining If true, drain nodes when the spot interruption termination notice is receieved
+enableSpotInterruptionDraining: ""
+
+## enableScheduledEventDraining [EXPERIMENTAL] If true, drain nodes before the maintenance window starts for an EC2 instance scheduled event
+enableScheduledEventDraining: ""
+
 ## dryRun tells node-termination-handler to only log calls to kubernetes control plane
 dryRun: false
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,41 +23,47 @@ import (
 
 const (
 	// EC2 Instance Metadata is configurable mainly for testing purposes
-	instanceMetadataURLConfigKey        = "INSTANCE_METADATA_URL"
-	defaultInstanceMetadataURL          = "http://169.254.169.254"
-	dryRunConfigKey                     = "DRY_RUN"
-	nodeNameConfigKey                   = "NODE_NAME"
-	kubernetesServiceHostConfigKey      = "KUBERNETES_SERVICE_HOST"
-	kubernetesServicePortConfigKey      = "KUBERNETES_SERVICE_PORT"
-	deleteLocalDataConfigKey            = "DELETE_LOCAL_DATA"
-	ignoreDaemonSetsConfigKey           = "IGNORE_DAEMON_SETS"
-	gracePeriodConfigKey                = "GRACE_PERIOD"
-	podTerminationGracePeriodConfigKey  = "POD_TERMINATION_GRACE_PERIOD"
-	podTerminationGracePeriodDefault    = -1
-	nodeTerminationGracePeriodConfigKey = "NODE_TERMINATION_GRACE_PERIOD"
-	nodeTerminationGracePeriodDefault   = 120
-	webhookURLConfigKey                 = "WEBHOOK_URL"
-	webhookURLDefault                   = ""
-	webhookHeadersConfigKey             = "WEBHOOK_HEADERS"
-	webhookHeadersDefault               = `{"Content-type":"application/json"}`
-	webhookTemplateConfigKey            = "WEBHOOK_TEMPLATE"
-	webhookTemplateDefault              = `{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} - State: {{ .State }} - Start Time: {{ .StartTime }}"}`
+	instanceMetadataURLConfigKey            = "INSTANCE_METADATA_URL"
+	defaultInstanceMetadataURL              = "http://169.254.169.254"
+	dryRunConfigKey                         = "DRY_RUN"
+	nodeNameConfigKey                       = "NODE_NAME"
+	kubernetesServiceHostConfigKey          = "KUBERNETES_SERVICE_HOST"
+	kubernetesServicePortConfigKey          = "KUBERNETES_SERVICE_PORT"
+	deleteLocalDataConfigKey                = "DELETE_LOCAL_DATA"
+	ignoreDaemonSetsConfigKey               = "IGNORE_DAEMON_SETS"
+	gracePeriodConfigKey                    = "GRACE_PERIOD"
+	podTerminationGracePeriodConfigKey      = "POD_TERMINATION_GRACE_PERIOD"
+	podTerminationGracePeriodDefault        = -1
+	nodeTerminationGracePeriodConfigKey     = "NODE_TERMINATION_GRACE_PERIOD"
+	nodeTerminationGracePeriodDefault       = 120
+	webhookURLConfigKey                     = "WEBHOOK_URL"
+	webhookURLDefault                       = ""
+	webhookHeadersConfigKey                 = "WEBHOOK_HEADERS"
+	webhookHeadersDefault                   = `{"Content-type":"application/json"}`
+	webhookTemplateConfigKey                = "WEBHOOK_TEMPLATE"
+	webhookTemplateDefault                  = `{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} - State: {{ .State }} - Start Time: {{ .StartTime }}"}`
+	enableScheduledEventDrainingConfigKey   = "ENABLE_SCHEDULED_EVENT_DRAINING"
+	enableScheduledEventDrainingDefault     = false
+	enableSpotInterruptionDrainingConfigKey = "ENABLE_SPOT_INTERRUPTION_DRAINING"
+	enableSpotInterruptionDrainingDefault   = true
 )
 
 //Config arguments set via CLI, environment variables, or defaults
 type Config struct {
-	DryRun                     bool
-	NodeName                   string
-	MetadataURL                string
-	IgnoreDaemonSets           bool
-	DeleteLocalData            bool
-	KubernetesServiceHost      string
-	KubernetesServicePort      string
-	PodTerminationGracePeriod  int
-	NodeTerminationGracePeriod int
-	WebhookURL                 string
-	WebhookHeaders             string
-	WebhookTemplate            string
+	DryRun                         bool
+	NodeName                       string
+	MetadataURL                    string
+	IgnoreDaemonSets               bool
+	DeleteLocalData                bool
+	KubernetesServiceHost          string
+	KubernetesServicePort          string
+	PodTerminationGracePeriod      int
+	NodeTerminationGracePeriod     int
+	WebhookURL                     string
+	WebhookHeaders                 string
+	WebhookTemplate                string
+	EnableScheduledEventDraining   bool
+	EnableSpotInterruptionDraining bool
 }
 
 //ParseCliArgs parses cli arguments and uses environment variables as fallback values
@@ -77,6 +83,8 @@ func ParseCliArgs() Config {
 	flag.StringVar(&config.WebhookURL, "webhook-url", getEnv(webhookURLConfigKey, webhookURLDefault), "If specified, posts event data to URL upon instance interruption action.")
 	flag.StringVar(&config.WebhookHeaders, "webhook-headers", getEnv(webhookHeadersConfigKey, webhookHeadersDefault), "If specified, replaces the default webhook headers.")
 	flag.StringVar(&config.WebhookTemplate, "webhook-template", getEnv(webhookTemplateConfigKey, webhookTemplateDefault), "If specified, replaces the default webhook message template.")
+	flag.BoolVar(&config.EnableScheduledEventDraining, "enable-scheduled-event-draining", getBoolEnv(enableScheduledEventDrainingConfigKey, enableScheduledEventDrainingDefault), "[EXPERIMENTAL] If true, drain nodes before the maintenance window starts for an EC2 instance scheduled event")
+	flag.BoolVar(&config.EnableSpotInterruptionDraining, "enable-spot-interruption-draining", getBoolEnv(enableSpotInterruptionDrainingConfigKey, enableSpotInterruptionDrainingDefault), "If true, drain nodes when the spot interruption termination notice is receieved")
 
 	flag.Parse()
 
@@ -106,7 +114,9 @@ func ParseCliArgs() Config {
 			"\tdelete-local-data: %t,\n"+
 			"\tignore-daemon-sets: %t,\n"+
 			"\tpod-termination-grace-period: %d,\n"+
-			"\tnode-termination-grace-period: %d,\n",
+			"\tnode-termination-grace-period: %d,\n"+
+			"\tenable-scheduled-event-draining: %t,\n"+
+			"\tenable-spot-interruption-draining: %t,\n",
 		config.DryRun,
 		config.NodeName,
 		config.MetadataURL,
@@ -116,6 +126,8 @@ func ParseCliArgs() Config {
 		config.IgnoreDaemonSets,
 		config.PodTerminationGracePeriod,
 		config.NodeTerminationGracePeriod,
+		config.EnableScheduledEventDraining,
+		config.EnableSpotInterruptionDraining,
 	)
 
 	return config

--- a/test/e2e/maintenance-event-cancellation-test
+++ b/test/e2e/maintenance-event-cancellation-test
@@ -20,7 +20,9 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --namespace kube-system \
   --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
-  --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
+  --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
+  --set enableSpotInterruptionDraining="true" \
+  --set enableScheduledEventDraining="true"
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
   --wait \
@@ -76,7 +78,7 @@ helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-meta
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
   --set ec2MetadataTestProxy.enableScheduledMaintenanceEvents="true" \
   --set ec2MetadataTestProxy.enableSpotITN="false" \
-  --set ec2MetadataTestProxy.scheduledEventStatus="cancelled"
+  --set ec2MetadataTestProxy.scheduledEventStatus="cancelled" 
 
 for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     if kubectl get nodes $CLUSTER_NAME-worker | grep -v SchedulingDisabled; then

--- a/test/e2e/maintenance-event-dry-run-test
+++ b/test/e2e/maintenance-event-dry-run-test
@@ -21,7 +21,9 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
-  --set dryRun="true"
+  --set dryRun="true" \
+  --set enableSpotInterruptionDraining="true" \
+  --set enableScheduledEventDraining="true"
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
   --wait \

--- a/test/e2e/maintenance-event-reboot-test
+++ b/test/e2e/maintenance-event-reboot-test
@@ -23,7 +23,9 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --namespace kube-system \
   --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
-  --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
+  --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
+  --set enableSpotInterruptionDraining="true" \
+  --set enableScheduledEventDraining="true"
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
   --wait \
@@ -87,7 +89,9 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
-  --set procUptimeFile="/uptime"
+  --set procUptimeFile="/uptime" \
+  --set enableSpotInterruptionDraining="true" \
+  --set enableScheduledEventDraining="true"
 
 for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     NODE_LINE=$(kubectl get nodes $CLUSTER_NAME-worker | grep -v 'STATUS')

--- a/test/e2e/maintenance-event-test
+++ b/test/e2e/maintenance-event-test
@@ -20,7 +20,9 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --namespace kube-system \
   --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
-  --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
+  --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
+  --set enableSpotInterruptionDraining="true" \
+  --set enableScheduledEventDraining="true"
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
   --wait \

--- a/test/e2e/spot-interruption-dry-run-test
+++ b/test/e2e/spot-interruption-dry-run-test
@@ -21,7 +21,9 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
-  --set dryRun="true"
+  --set dryRun="true" \
+  --set enableSpotInterruptionDraining="true" \
+  --set enableScheduledEventDraining="true"
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
   --wait \

--- a/test/e2e/spot-interruption-test
+++ b/test/e2e/spot-interruption-test
@@ -22,7 +22,9 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
   --set enableSpotInterruptionDraining="true" \
-  --set enableScheduledEventDraining="false"
+  --set enableScheduledEventDraining="false" \
+  --set enableSpotInterruptionDraining="true" \
+  --set enableScheduledEventDraining="true"
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
   --wait \

--- a/test/e2e/webhook-test
+++ b/test/e2e/webhook-test
@@ -26,7 +26,9 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
-  --set webhookURL="$WEBHOOK_URL"
+  --set webhookURL="$WEBHOOK_URL" \
+  --set enableSpotInterruptionDraining="true" \
+  --set enableScheduledEventDraining="true"
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
   --wait \


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-node-termination-handler/issues/30

This should be merged after: https://github.com/aws/aws-node-termination-handler/pull/65
## Scheduled Events - Config (CLI & Helm) 

Description of changes:
Adds CLI args, helm chart values, and use config feature flags to add or not add monitoring functions to go routine start loop.  

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
