### PR TITLE
fix supporting build scripts wrt make args

### DIFF
--- a/scripts/build-binaries
+++ b/scripts/build-binaries
@@ -3,15 +3,24 @@ set -euo pipefail
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-VERSION=$(make -f $SCRIPTPATH/../Makefile version)
+MAKEFILEPATH=$SCRIPTPATH/../Makefile
+VERSION=$(make -s -f $MAKEFILEPATH version)
 mkdir -p $SCRIPTPATH/../build/bin
 
-for os_arch in "linux-amd64" "linux-arm" "linux-arm64"; do
+if [[ -z $(env | grep "NTH_OS_ARCH=") ]]; then
+    NTH_OS_ARCH=("linux-amd64" "linux-arm" "linux-arm64")
+fi
+
+for os_arch in "${NTH_OS_ARCH[@]}"; do
     os=$(echo $os_arch | cut -d'-' -f1)
     arch=$(echo $os_arch | cut -d'-' -f2)
 
-    docker container rm extract-nth-$os-$arch || :
-    GOOS="$os" GOARCH="$arch" GOPROXY="direct" IMG=nth-$os-$arch make docker-build 
-    docker container create --rm --name extract-nth-$os-$arch nth-$os-$arch:$VERSION
-    docker container cp extract-nth-$os-$arch:/node-termination-handler $SCRIPTPATH/../build/bin/node-termination-handler-$os-$arch 
+    container_name="extract-nth-$os-$arch"
+    img_name="nth-$os-$arch"
+    bin_name="node-termination-handler-$os-$arch"
+
+    docker container rm $container_name || :
+    GOOS="$os" GOARCH="$arch" GOPROXY="direct" IMG=$img_name make -s -f $MAKEFILEPATH docker-build 
+    docker container create --rm --name $container_name "$img_name:$VERSION"
+    docker container cp $container_name:/node-termination-handler $SCRIPTPATH/../build/bin/$bin_name
 done

--- a/scripts/upload-binaries-to-github
+++ b/scripts/upload-binaries-to-github
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-VERSION=$(make -f $SCRIPTPATH/../Makefile version)
+VERSION=$(make -s -f $SCRIPTPATH/../Makefile version)
 RELEASE_ID=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
     https://api.github.com/repos/aws/aws-node-termination-handler/releases | \
     jq --arg VERSION "$VERSION" '.[] | select(.tag_name==$VERSION) | .id')

--- a/test/k8s-compatibility-test/run-k8s-compatibility-test.sh
+++ b/test/k8s-compatibility-test/run-k8s-compatibility-test.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-versions=("1.16" "1.15" "1.14" "1.13" "1.12" "1.11")
+versions=("1.17" "1.16" "1.15" "1.14" "1.13" "1.12" "1.11")
 E_CODE=0
 AFTER_FIRST_RUN_ARGS=""
 PASS_THRU_ARGS=""
 
 USAGE=$(cat << 'EOM'
   Usage: run-k8s-compatability-test [-h]
-  Executes the spot termination integration test for each version of kubernetes (k8s 1.11 - 1.16 supported)
+  Executes the spot termination integration test for each version of kubernetes (k8s 1.11 - 1.17 supported)
 
   Examples: 
           # run test with direct download of go modules

--- a/test/k8s-local-cluster-test/run-test
+++ b/test/k8s-local-cluster-test/run-test
@@ -69,7 +69,7 @@ USAGE=$(cat << 'EOM'
             -e          EC2 Metadata Docker Image 
             -d          use GOPROXY=direct to bypass proxy.golang.org
             -o          Override path w/ your own kubectl and kind binaries
-            -v          Kubernetes Version (Default: 1.16) [1.11, 1.12, 1.13, 1.14, 1.15, and 1.16]
+            -v          Kubernetes Version (Default: 1.16) [1.11, 1.12, 1.13, 1.14, 1.15, 1.16, and 1.17]
             
 EOM
 )

--- a/test/license-test/run-license-test.sh
+++ b/test/license-test/run-license-test.sh
@@ -1,22 +1,12 @@
 #!/bin/bash
 set -euo pipefail
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-BINARY_NAME="node-termination-handler"
-BINARY_CONTAINER="extract"
-BINARY_IMAGE_TAG="nth"
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+BUILD_BIN="$SCRIPTPATH/../../build/bin"
+
+BINARY_NAME="node-termination-handler-linux-amd64"
 LICENSE_TEST_TAG="nth-license-test"
 
-function clean_up {
-    docker container rm $BINARY_CONTAINER || :
-    docker image rm $BINARY_IMAGE_TAG || :
-    rm -f $SCRIPTPATH/$BINARY_NAME || :
-}
-
-trap "clean_up" EXIT
-
-docker build --build-arg=GOPROXY=direct -t $BINARY_IMAGE_TAG $SCRIPTPATH/../../
-docker container create --name $BINARY_CONTAINER $BINARY_IMAGE_TAG
-docker container cp $BINARY_CONTAINER:/$BINARY_NAME $SCRIPTPATH/$BINARY_NAME 
+NTH_OS_ARCH="linux-amd64" make -s -f $SCRIPTPATH/../../Makefile build-binaries
 docker build --build-arg=GOPROXY=direct -t $LICENSE_TEST_TAG $SCRIPTPATH/
-docker run -it -e GITHUB_TOKEN --rm -v $SCRIPTPATH/:/test $LICENSE_TEST_TAG golicense /test/license-config.hcl /test/$BINARY_NAME
+docker run -it -e GITHUB_TOKEN --rm -v $SCRIPTPATH/:/test -v $BUILD_BIN/:/nth-bin $LICENSE_TEST_TAG golicense /test/license-config.hcl /nth-bin/$BINARY_NAME


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Fix up some supporting build scripts wrt to make args (specifying -f Makefile and -s) 
 - deleted some unnecessary code and reused make targets that were doing the same thing
 - Added K8s 1.17 to help text in test files that was missed when 1.17 support was introduced

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
