### PR TITLE
ignore completed drain events after reboot

### DIFF
--- a/pkg/drainevent/drain-event.go
+++ b/pkg/drainevent/drain-event.go
@@ -19,7 +19,7 @@ import (
 	"github.com/aws/aws-node-termination-handler/pkg/node"
 )
 
-type preDrainTask func(*node.Node) error
+type preDrainTask func(DrainEvent, node.Node) error
 
 // DrainEvent gives more context of the drainable event
 type DrainEvent struct {

--- a/pkg/draineventstore/drain-event-store_test.go
+++ b/pkg/draineventstore/drain-event-store_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestAddDrainEvent(t *testing.T) {
-	store := draineventstore.New(&config.Config{})
+	store := draineventstore.New(config.Config{})
 
 	event1 := &drainevent.DrainEvent{
 		EventID:   "123",
@@ -53,7 +53,7 @@ func TestAddDrainEvent(t *testing.T) {
 }
 
 func TestCancelDrainEvent(t *testing.T) {
-	store := draineventstore.New(&config.Config{})
+	store := draineventstore.New(config.Config{})
 
 	event := &drainevent.DrainEvent{
 		EventID:   "123",
@@ -70,7 +70,7 @@ func TestCancelDrainEvent(t *testing.T) {
 }
 
 func TestShouldDrainNode(t *testing.T) {
-	store := draineventstore.New(&config.Config{})
+	store := draineventstore.New(config.Config{})
 	futureEvent := &drainevent.DrainEvent{
 		EventID:   "future",
 		StartTime: time.Now().Add(time.Second * 20),
@@ -87,7 +87,7 @@ func TestShouldDrainNode(t *testing.T) {
 }
 
 func TestMarkAllAsDrained(t *testing.T) {
-	store := draineventstore.New(&config.Config{})
+	store := draineventstore.New(config.Config{})
 	event1 := &drainevent.DrainEvent{
 		EventID:   "1",
 		StartTime: time.Now().Add(time.Second * 20),
@@ -110,7 +110,7 @@ func TestMarkAllAsDrained(t *testing.T) {
 }
 
 func TestShouldUncordonNode(t *testing.T) {
-	store := draineventstore.New(&config.Config{})
+	store := draineventstore.New(config.Config{})
 	h.Equals(t, false, store.ShouldUncordonNode())
 
 	event := &drainevent.DrainEvent{

--- a/pkg/ec2metadata/ec2metadata.go
+++ b/pkg/ec2metadata/ec2metadata.go
@@ -25,8 +25,6 @@ const (
 	SpotInstanceActionPath = "/latest/meta-data/spot/instance-action"
 	// ScheduledEventPath is the context path to events/maintenance/scheduled within IMDS
 	ScheduledEventPath = "/latest/meta-data/events/maintenance/scheduled"
-	// SystemRebootCode is the string signifying a scheduled system reboot maintenance code
-	SystemRebootCode = "system-reboot"
 )
 
 // [

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -70,7 +70,7 @@ func Post(event *drainevent.DrainEvent, nthconfig config.Config) {
 	defer response.Body.Close()
 
 	if response.StatusCode < 200 || response.StatusCode > 299 {
-		log.Printf("Webhook Error: Recieved Status Code %d\n", response.StatusCode)
+		log.Printf("Webhook Error: Received Status Code %d\n", response.StatusCode)
 		return
 	}
 

--- a/test/e2e/maintenance-event-cancellation-test
+++ b/test/e2e/maintenance-event-cancellation-test
@@ -54,7 +54,7 @@ if [[ $DEPLOYED -eq 0 ]]; then
 fi
 
 for i in `seq 1 $TAINT_CHECK_CYCLES`; do
-    if kubectl get nodes $CLUSTER_NAME-worker | grep SchedulingDisabled; then
+    if kubectl get nodes $CLUSTER_NAME-worker --no-headers | grep SchedulingDisabled; then
         echo "✅ Verified the worker node was cordoned!"
         if [[ $(kubectl get deployments regular-pod-test -o=jsonpath='{.status.unavailableReplicas}') -eq 1 ]]; then
             echo "✅ Verified the regular-pod-test pod was evicted!"
@@ -71,7 +71,6 @@ if [[ $CORDONED -eq 0 ]]; then
 fi
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
-  --wait \
   --force \
   --namespace default \
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
@@ -81,7 +80,7 @@ helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-meta
   --set ec2MetadataTestProxy.scheduledEventStatus="cancelled" 
 
 for i in `seq 1 $TAINT_CHECK_CYCLES`; do
-    if kubectl get nodes $CLUSTER_NAME-worker | grep -v SchedulingDisabled; then
+    if kubectl get nodes $CLUSTER_NAME-worker --no-headers | grep -v SchedulingDisabled; then
         echo "✅ Verified the worker node was uncordoned!"
         if [[ $(kubectl get deployments regular-pod-test -o=jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
             echo "✅ Verified the regular-pod-test pod was rescheduled"

--- a/test/e2e/maintenance-event-dry-run-test
+++ b/test/e2e/maintenance-event-dry-run-test
@@ -37,7 +37,7 @@ POD_ID=$(kubectl get pods --namespace kube-system | grep -i node-termination-han
 for i in $(seq 0 10); do 
   if [[ ! -z $(kubectl logs $POD_ID -n kube-system | grep -i -e 'would have been cordoned and drained') ]]; then
       echo "✅ Verified the dryrun logs were executed"
-      if kubectl get nodes $CLUSTER_NAME-worker | tail -n1 | grep -v SchedulingDisabled; then
+      if kubectl get nodes $CLUSTER_NAME-worker --no-headers | grep -v SchedulingDisabled; then
           echo "✅ Verified the worker node was not cordoned!"
           echo "✅ Scheduled Maintenance Event Dry Run Test Passed $CLUSTER_NAME! ✅"
           exit 0

--- a/test/e2e/spot-interruption-dry-run-test
+++ b/test/e2e/spot-interruption-dry-run-test
@@ -37,7 +37,7 @@ POD_ID=$(kubectl get pods --namespace kube-system | grep -i node-termination-han
 for i in $(seq 0 10); do 
   if [[ ! -z $(kubectl logs $POD_ID -n kube-system | grep -i -e 'would have been cordoned and drained') ]]; then
       echo "✅ Verified the dryrun logs were executed"
-      if kubectl get nodes $CLUSTER_NAME-worker | tail -n1 | grep -v SchedulingDisabled; then
+      if kubectl get nodes $CLUSTER_NAME-worker --no-headers | grep -v SchedulingDisabled; then
           echo "✅ Verified the worker node was not cordoned!"
           echo "✅ Spot Interruption Dry Run Test Passed $CLUSTER_NAME! ✅"
           exit 0

--- a/test/ec2-metadata-test-proxy/cmd/ec2-metadata-test-proxy.go
+++ b/test/ec2-metadata-test-proxy/cmd/ec2-metadata-test-proxy.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"net/http/httputil"
-	"net/url"
 	"os"
 	"strconv"
 	"time"
@@ -47,7 +45,7 @@ const (
 
 var startTime int64 = time.Now().Unix()
 
-// ScheduledActionDetail metadata structure for json parsing
+// ScheduledEventDetail metadata structure for json parsing
 type ScheduledEventDetail struct {
 	NotBefore   string `json:"NotBefore"`
 	Code        string `json:"Code"`
@@ -174,13 +172,10 @@ func handleRequest(res http.ResponseWriter, req *http.Request) {
 		res.Header().Set("Content-Type", "application/json")
 		res.Write(js)
 		return
-	} else {
-		res.Header().Set("Content-Type", "application/json")
-		res.Write([]byte("{}"))
-		return
 	}
-	metadataUrl, _ := url.Parse(metadataIp)
-	httputil.NewSingleHostReverseProxy(metadataUrl).ServeHTTP(res, req)
+	res.Header().Set("Content-Type", "application/json")
+	res.Write([]byte("{}"))
+	return
 }
 
 func main() {

--- a/test/k8s-local-cluster-test/run-test
+++ b/test/k8s-local-cluster-test/run-test
@@ -26,7 +26,15 @@ function relpath() {
 function clean_up {
     if [[ "$PRESERVE" == false ]]; then
         $SCRIPTPATH/../k8s-local-cluster-test/delete-cluster $DELETE_CLUSTER_ARGS || :
+        return 
     fi 
+    labels_to_remove=($(kubectl get nodes -o json | jq '.items[].metadata.labels' | grep 'aws-node-termination-handler' | tr -d '[:blank:]' | tr -d '\"' | cut -d':' -f1))
+    for l in "${labels_to_remove[@]}"; do 
+      for n in $(kubectl get nodes -o json | jq -r '.items[].metadata.name'); do
+        echo "Deleting label $l on node $n"
+        kubectl label node $n "$l"-
+      done
+    done
     echo "To resume test with the same cluster use: \"-c $TMP_DIR\""""
 }
 


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-node-termination-handler/issues/30

Description of changes:

This PR will handle persisted drain events after a node is rebooted for scheduled maintenance. If a node is cordoned and drained for a qualifying reboot scheduled maintenance event, the event-id, timestamp, and an action label is added to the node. After the instance reboots, a handler will query for these labels, determine if the node has been rebooted by looking at uptime, tell the drain event store to ignore the event id (since there is latency between a scheduled maintenance event being completed and the status being flipped to complete within IMDS), uncordon the node, and then remove the NTH labels on the node. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
