### PR TITLE
respect dry-run on node labels

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -174,6 +174,10 @@ func (n Node) MarkForUncordonAfterReboot() error {
 
 // addLabel will add a label to the node given a label key and value
 func (n Node) addLabel(key string, value string) error {
+	if n.nthConfig.DryRun {
+		log.Printf("Would have added label %s=%s but dry-run flag was set", key, value)
+		return nil
+	}
 	type metadata struct {
 		Labels map[string]string `json:"labels"`
 	}
@@ -208,6 +212,10 @@ func (n Node) addLabel(key string, value string) error {
 
 // removeLabel will remove a node label given a label key
 func (n Node) removeLabel(key string) error {
+	if n.nthConfig.DryRun {
+		log.Printf("Would have removed label with key %s but dry-run flag was set", key)
+		return nil
+	}
 	type patchRequest struct {
 		Op   string `json:"op"`
 		Path string `json:"path"`


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-node-termination-handler/issues/30

Description of changes:
Handle dry-run events when labeling and removing labels from a node

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
