### PR TITLE
Update config to return err & add unit tests

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -40,8 +40,12 @@ func main() {
 	signal.Notify(signalChan, syscall.SIGTERM)
 	defer signal.Stop(signalChan)
 
-	nthConfig := config.ParseCliArgs()
-	err := webhook.ValidateWebhookConfig(nthConfig)
+	nthConfig, err := config.ParseCliArgs()
+	if err != nil {
+		log.Fatalln("Failed to parse cli args: ", err)
+	}
+
+	err = webhook.ValidateWebhookConfig(nthConfig)
 	if err != nil {
 		log.Fatalln("Webhook validation failed: ", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,84 +68,90 @@ type Config struct {
 	WebhookTemplate                string `json:"webhook-template"`
 }
 
-var flagData = map[string]map[string]interface{}{
-	"delete-local-data": map[string]interface{}{
-		"key":      deleteLocalDataConfigKey,
-		"defValue": true,
-		"usage":    "If true, do not drain pods that are using local node storage in emptyDir",
+type flagData struct {
+	Key      string
+	DefValue interface{}
+	Usage    string
+}
+
+var flags = map[string]flagData{
+	"delete-local-data": flagData{
+		Key:      deleteLocalDataConfigKey,
+		DefValue: true,
+		Usage:    "If true, do not drain pods that are using local node storage in emptyDir",
 	},
-	"dry-run": map[string]interface{}{
-		"key":      dryRunConfigKey,
-		"defValue": false,
-		"usage":    "If true, only log if a node would be drained",
+	"dry-run": flagData{
+		Key:      dryRunConfigKey,
+		DefValue: false,
+		Usage:    "If true, only log if a node would be drained",
 	},
-	"enable-scheduled-event-draining": map[string]interface{}{
-		"key":      enableScheduledEventDrainingConfigKey,
-		"defValue": enableScheduledEventDrainingDefault,
-		"usage":    "[EXPERIMENTAL] If true, drain nodes before the maintenance window starts for an EC2 instance scheduled event",
+	"enable-scheduled-event-draining": flagData{
+		Key:      enableScheduledEventDrainingConfigKey,
+		DefValue: enableScheduledEventDrainingDefault,
+		Usage:    "[EXPERIMENTAL] If true, drain nodes before the maintenance window starts for an EC2 instance scheduled event",
 	},
-	"enable-spot-interruption-draining": map[string]interface{}{
-		"key":      enableSpotInterruptionDrainingConfigKey,
-		"defValue": enableSpotInterruptionDrainingDefault,
-		"usage":    "If true, drain nodes when the spot interruption termination notice is receieved",
+	"enable-spot-interruption-draining": flagData{
+		Key:      enableSpotInterruptionDrainingConfigKey,
+		DefValue: enableSpotInterruptionDrainingDefault,
+		Usage:    "If true, drain nodes when the spot interruption termination notice is receieved",
 	},
-	"grace-period": map[string]interface{}{
-		"key":      gracePeriodConfigKey,
-		"defValue": podTerminationGracePeriodDefault,
-		"usage": "[DEPRECATED] * Use pod-termination-grace-period instead * Period of time in seconds given to each " +
+	"grace-period": flagData{
+		Key:      gracePeriodConfigKey,
+		DefValue: podTerminationGracePeriodDefault,
+		Usage: "[DEPRECATED] * Use pod-termination-grace-period instead * Period of time in seconds given to each " +
 			"pod to terminate gracefully. If negative, the default value specified in the pod will be used.",
 	},
-	"ignore-daemon-sets": map[string]interface{}{
-		"key":      ignoreDaemonSetsConfigKey,
-		"defValue": true,
-		"usage":    "If true, drain daemon sets when a spot interrupt is received.",
+	"ignore-daemon-sets": flagData{
+		Key:      ignoreDaemonSetsConfigKey,
+		DefValue: true,
+		Usage:    "If true, drain daemon sets when a spot interrupt is received.",
 	},
-	"kubernetes-service-host": map[string]interface{}{
-		"key":      kubernetesServiceHostConfigKey,
-		"defValue": "",
-		"usage":    "[ADVANCED] The k8s service host to send api calls to.",
+	"kubernetes-service-host": flagData{
+		Key:      kubernetesServiceHostConfigKey,
+		DefValue: "",
+		Usage:    "[ADVANCED] The k8s service host to send api calls to.",
 	},
-	"kubernetes-service-port": map[string]interface{}{
-		"key":      kubernetesServicePortConfigKey,
-		"defValue": "",
-		"usage":    "[ADVANCED] The k8s service port to send api calls to.",
+	"kubernetes-service-port": flagData{
+		Key:      kubernetesServicePortConfigKey,
+		DefValue: "",
+		Usage:    "[ADVANCED] The k8s service port to send api calls to.",
 	},
-	"node-name": map[string]interface{}{
-		"key":      nodeNameConfigKey,
-		"defValue": "",
-		"usage":    "The kubernetes node name",
+	"node-name": flagData{
+		Key:      nodeNameConfigKey,
+		DefValue: "",
+		Usage:    "The kubernetes node name",
 	},
-	"node-termination-grace-period": map[string]interface{}{
-		"key":      nodeTerminationGracePeriodConfigKey,
-		"defValue": nodeTerminationGracePeriodDefault,
-		"usage": "Period of time in seconds given to each NODE to terminate gracefully. Node draining will be scheduled " +
+	"node-termination-grace-period": flagData{
+		Key:      nodeTerminationGracePeriodConfigKey,
+		DefValue: nodeTerminationGracePeriodDefault,
+		Usage: "Period of time in seconds given to each NODE to terminate gracefully. Node draining will be scheduled " +
 			"based on this value to optimize the amount of compute time, but still safely drain the node before an event.",
 	},
-	"metadata-url": map[string]interface{}{
-		"key":      instanceMetadataURLConfigKey,
-		"defValue": defaultInstanceMetadataURL,
-		"usage":    "If true, only log if a node would be drained",
+	"metadata-url": flagData{
+		Key:      instanceMetadataURLConfigKey,
+		DefValue: defaultInstanceMetadataURL,
+		Usage:    "If true, only log if a node would be drained",
 	},
-	"pod-termination-grace-period": map[string]interface{}{
-		"key":      podTerminationGracePeriodConfigKey,
-		"defValue": podTerminationGracePeriodDefault,
-		"usage": "Period of time in seconds given to each POD to terminate gracefully. If negative, the default " +
+	"pod-termination-grace-period": flagData{
+		Key:      podTerminationGracePeriodConfigKey,
+		DefValue: podTerminationGracePeriodDefault,
+		Usage: "Period of time in seconds given to each POD to terminate gracefully. If negative, the default " +
 			"value specified in the pod will be used.",
 	},
-	"webhook-url": map[string]interface{}{
-		"key":      webhookURLConfigKey,
-		"defValue": webhookURLDefault,
-		"usage":    "If specified, posts event data to URL upon instance interruption action.",
+	"webhook-url": flagData{
+		Key:      webhookURLConfigKey,
+		DefValue: webhookURLDefault,
+		Usage:    "If specified, posts event data to URL upon instance interruption action.",
 	},
-	"webhook-headers": map[string]interface{}{
-		"key":      webhookHeadersConfigKey,
-		"defValue": webhookHeadersDefault,
-		"usage":    "If specified, replaces the default webhook headers.",
+	"webhook-headers": flagData{
+		Key:      webhookHeadersConfigKey,
+		DefValue: webhookHeadersDefault,
+		Usage:    "If specified, replaces the default webhook headers.",
 	},
-	"webhook-template": map[string]interface{}{
-		"key":      webhookTemplateConfigKey,
-		"defValue": webhookTemplateDefault,
-		"usage":    "If specified, replaces the default webhook message template.",
+	"webhook-template": flagData{
+		Key:      webhookTemplateConfigKey,
+		DefValue: webhookTemplateDefault,
+		Usage:    "If specified, replaces the default webhook message template.",
 	},
 }
 
@@ -153,7 +159,7 @@ var flagData = map[string]map[string]interface{}{
 func ParseCliArgs() (Config, error) {
 	config := Config{}
 
-	results, err := createFlags(flagData)
+	results, err := createFlags(flags)
 	if err != nil {
 		return config, err
 	}
@@ -216,31 +222,31 @@ func ParseCliArgs() (Config, error) {
 	return config, nil
 }
 
-func createFlags(flagData map[string]map[string]interface{}) (map[string]interface{}, error) {
+func createFlags(flagData map[string]flagData) (map[string]interface{}, error) {
 	result := make(map[string]interface{})
 
 	for name, data := range flagData {
-		switch data["defValue"].(type) {
+		switch data.DefValue.(type) {
 		case string:
-			value := getEnv(data["key"].(string), data["defValue"].(string))
+			value := getEnv(data.Key, data.DefValue.(string))
 			var flagValue string
-			flag.StringVar(&flagValue, name, value, data["usage"].(string))
+			flag.StringVar(&flagValue, name, value, data.Usage)
 			result[name] = flagValue
 		case int:
-			value, err := getIntEnv(data["key"].(string), data["defValue"].(int))
+			value, err := getIntEnv(data.Key, data.DefValue.(int))
 			if err != nil {
 				return result, err
 			}
 			var flagValue int
-			flag.IntVar(&flagValue, name, value, data["usage"].(string))
+			flag.IntVar(&flagValue, name, value, data.Usage)
 			result[name] = flagValue
 		case bool:
-			value, err := getBoolEnv(data["key"].(string), data["defValue"].(bool))
+			value, err := getBoolEnv(data.Key, data.DefValue.(bool))
 			if err != nil {
 				return result, err
 			}
 			var flagValue bool
-			flag.BoolVar(&flagValue, name, value, data["usage"].(string))
+			flag.BoolVar(&flagValue, name, value, data.Usage)
 			result[name] = flagValue
 		default:
 			return result, errors.New("Unrecognized defValue type for " + name)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -249,7 +249,7 @@ func createFlags(flagData map[string]flagData) (map[string]interface{}, error) {
 			flag.BoolVar(&flagValue, name, value, data.Usage)
 			result[name] = flagValue
 		default:
-			return result, errors.New("Unrecognized defValue type for " + name)
+			return result, fmt.Errorf("Unrecognized defValue type for: %s", name)
 		}
 	}
 	flag.Parse()
@@ -274,7 +274,7 @@ func getIntEnv(key string, fallback int) (int, error) {
 	}
 	envIntValue, err := strconv.Atoi(envStrValue)
 	if err != nil {
-		return -1, err
+		return -1, fmt.Errorf("Env var %s must be an integer: %w", key, err)
 	}
 	return envIntValue, nil
 }
@@ -287,7 +287,7 @@ func getBoolEnv(key string, fallback bool) (bool, error) {
 	}
 	envBoolValue, err := strconv.ParseBool(envStrValue)
 	if err != nil {
-		return false, errors.New("Env Var " + key + " must be either true or false")
+		return false, fmt.Errorf("Env var %s must be true or false: %w", key, err)
 	}
 	return envBoolValue, nil
 }

--- a/pkg/config/config_internal_test.go
+++ b/pkg/config/config_internal_test.go
@@ -33,84 +33,84 @@ func init() {
 }
 
 func TestParseCliArgsUnmarshalFailure(t *testing.T) {
-	var saveFlagData = make(map[string]map[string]interface{})
-	for k, v := range flagData {
-		saveFlagData[k] = v
+	var saveFlags = make(map[string]flagData)
+	for k, v := range flags {
+		saveFlags[k] = v
 	}
 
-	flagData["delete-local-data"] = map[string]interface{}{
-		"key":      deleteLocalDataConfigKey,
-		"defValue": 123,
-		"usage":    "If true, do not drain pods that are using local node storage in emptyDir",
+	flags["delete-local-data"] = flagData{
+		Key:      deleteLocalDataConfigKey,
+		DefValue: 123,
+		Usage:    "If true, do not drain pods that are using local node storage in emptyDir",
 	}
 	_, err := ParseCliArgs()
 	h.Assert(t, true, "Failed to return error when unmarshal failed", err != nil)
 
-	flagData = saveFlagData
+	flags = saveFlags
 }
 
 func TestCreateFlags(t *testing.T) {
 	var key = "KEY"
 
-	var validStringValue = map[string]map[string]interface{}{
-		"test-string": map[string]interface{}{
-			"key":      key,
-			"defValue": "default",
-			"usage":    "description",
+	var validStringValue = map[string]flagData{
+		"test-string": flagData{
+			Key:      key,
+			DefValue: "default",
+			Usage:    "description",
 		},
 	}
 	result, err := createFlags(validStringValue)
 	h.Ok(t, err)
-	h.Equals(t, result["test-string"], "default")
+	h.Equals(t, "default", result["test-string"])
 
-	var validIntValue = map[string]map[string]interface{}{
-		"test-int": map[string]interface{}{
-			"key":      key,
-			"defValue": 1234,
-			"usage":    "description",
+	var validIntValue = map[string]flagData{
+		"test-int": flagData{
+			Key:      key,
+			DefValue: 1234,
+			Usage:    "description",
 		},
 	}
 	result, err = createFlags(validIntValue)
 	h.Ok(t, err)
-	h.Equals(t, result["test-int"], 1234)
+	h.Equals(t, 1234, result["test-int"])
 
-	var validBoolValue = map[string]map[string]interface{}{
-		"test-bool": map[string]interface{}{
-			"key":      key,
-			"defValue": false,
-			"usage":    "description",
+	var validBoolValue = map[string]flagData{
+		"test-bool": flagData{
+			Key:      key,
+			DefValue: false,
+			Usage:    "description",
 		},
 	}
 	result, err = createFlags(validBoolValue)
 	h.Ok(t, err)
-	h.Equals(t, result["test-bool"], false)
+	h.Equals(t, false, result["test-bool"])
 
 	os.Setenv(key, "bla")
-	var invalidDefValue = map[string]map[string]interface{}{
-		"test": map[string]interface{}{
-			"key":      key,
-			"defValue": 7.9,
-			"usage":    "description",
+	var invalidDefValue = map[string]flagData{
+		"test-string": flagData{
+			Key:      key,
+			DefValue: 7.9,
+			Usage:    "description",
 		},
 	}
 	_, err = createFlags(invalidDefValue)
 	h.Assert(t, true, "Failed to return error when defValue type unrecognized", err != nil)
 
-	var invalidIntEnvValue = map[string]map[string]interface{}{
-		"test": map[string]interface{}{
-			"key":      key,
-			"defValue": 1,
-			"usage":    "description",
+	var invalidIntEnvValue = map[string]flagData{
+		"test-string": flagData{
+			Key:      key,
+			DefValue: 1,
+			Usage:    "description",
 		},
 	}
 	_, err = createFlags(invalidIntEnvValue)
 	h.Assert(t, true, "Failed to return error when env var not integer", err != nil)
 
-	var invalidBoolEnvValue = map[string]map[string]interface{}{
-		"test": map[string]interface{}{
-			"key":      key,
-			"defValue": false,
-			"usage":    "description",
+	var invalidBoolEnvValue = map[string]flagData{
+		"test-string": flagData{
+			Key:      key,
+			DefValue: false,
+			Usage:    "description",
 		},
 	}
 	_, err = createFlags(invalidBoolEnvValue)

--- a/pkg/config/config_internal_test.go
+++ b/pkg/config/config_internal_test.go
@@ -1,0 +1,185 @@
+// Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+import (
+	"flag"
+	"os"
+	"strconv"
+	"testing"
+
+	h "github.com/aws/aws-node-termination-handler/pkg/test"
+)
+
+// All of these needed for TestIsConfigProvided
+var location string
+var cliArgName = "name"
+var envVarName = "NAME_TEST"
+var value = "haugenj"
+
+func init() {
+	flag.StringVar(&location, cliArgName, value, value)
+}
+
+func TestParseCliArgsUnmarshalFailure(t *testing.T) {
+	var saveFlagData = make(map[string]map[string]interface{})
+	for k, v := range flagData {
+		saveFlagData[k] = v
+	}
+
+	flagData["delete-local-data"] = map[string]interface{}{
+		"key":      deleteLocalDataConfigKey,
+		"defValue": 123,
+		"usage":    "If true, do not drain pods that are using local node storage in emptyDir",
+	}
+	_, err := ParseCliArgs()
+	h.Assert(t, true, "Failed to return error when unmarshal failed", err != nil)
+
+	flagData = saveFlagData
+}
+
+func TestCreateFlags(t *testing.T) {
+	var key = "KEY"
+
+	var validStringValue = map[string]map[string]interface{}{
+		"test-string": map[string]interface{}{
+			"key":      key,
+			"defValue": "default",
+			"usage":    "description",
+		},
+	}
+	result, err := createFlags(validStringValue)
+	h.Ok(t, err)
+	h.Equals(t, result["test-string"], "default")
+
+	var validIntValue = map[string]map[string]interface{}{
+		"test-int": map[string]interface{}{
+			"key":      key,
+			"defValue": 1234,
+			"usage":    "description",
+		},
+	}
+	result, err = createFlags(validIntValue)
+	h.Ok(t, err)
+	h.Equals(t, result["test-int"], 1234)
+
+	var validBoolValue = map[string]map[string]interface{}{
+		"test-bool": map[string]interface{}{
+			"key":      key,
+			"defValue": false,
+			"usage":    "description",
+		},
+	}
+	result, err = createFlags(validBoolValue)
+	h.Ok(t, err)
+	h.Equals(t, result["test-bool"], false)
+
+	os.Setenv(key, "bla")
+	var invalidDefValue = map[string]map[string]interface{}{
+		"test": map[string]interface{}{
+			"key":      key,
+			"defValue": 7.9,
+			"usage":    "description",
+		},
+	}
+	_, err = createFlags(invalidDefValue)
+	h.Assert(t, true, "Failed to return error when defValue type unrecognized", err != nil)
+
+	var invalidIntEnvValue = map[string]map[string]interface{}{
+		"test": map[string]interface{}{
+			"key":      key,
+			"defValue": 1,
+			"usage":    "description",
+		},
+	}
+	_, err = createFlags(invalidIntEnvValue)
+	h.Assert(t, true, "Failed to return error when env var not integer", err != nil)
+
+	var invalidBoolEnvValue = map[string]map[string]interface{}{
+		"test": map[string]interface{}{
+			"key":      key,
+			"defValue": false,
+			"usage":    "description",
+		},
+	}
+	_, err = createFlags(invalidBoolEnvValue)
+	h.Assert(t, true, "Failed to return error when env var not boolean", err != nil)
+}
+
+func TestGetEnv(t *testing.T) {
+	var key = "STRING_TEST"
+	var successVal = "success"
+	var failVal = "failure"
+
+	os.Setenv(key, successVal)
+
+	result := getEnv(key+"bla", failVal)
+	h.Equals(t, failVal, result)
+
+	result = getEnv(key, failVal)
+	h.Equals(t, successVal, result)
+}
+
+func TestGetIntEnv(t *testing.T) {
+	var key = "INT_TEST"
+	var successVal = 1
+	var failVal = 0
+
+	os.Setenv(key, strconv.Itoa(successVal))
+
+	result, ok := getIntEnv(key+"bla", failVal)
+	h.Ok(t, ok)
+	h.Equals(t, failVal, result)
+
+	result, ok = getIntEnv(key, failVal)
+	h.Ok(t, ok)
+	h.Equals(t, successVal, result)
+
+	os.Setenv(key, "bla")
+	result, ok = getIntEnv(key, failVal)
+	h.Assert(t, true, "Failed to return error when var not integer.", ok != nil)
+}
+
+func TestGetBoolEnv(t *testing.T) {
+	var key = "BOOL_TEST"
+	var successVal = true
+	var failVal = false
+
+	os.Setenv(key, strconv.FormatBool(successVal))
+
+	result, err := getBoolEnv(key+"bla", failVal)
+	h.Ok(t, err)
+	h.Equals(t, failVal, result)
+
+	result, err = getBoolEnv(key, failVal)
+	h.Ok(t, err)
+	h.Equals(t, successVal, result)
+
+	os.Setenv(key, "bla")
+	result, err = getBoolEnv(key, failVal)
+	h.Assert(t, true, "Failed to return error when var not boolean.", err != nil)
+}
+
+func TestIsConfigProvided(t *testing.T) {
+	result := isConfigProvided(cliArgName, envVarName)
+	h.Equals(t, false, result)
+
+	flag.Set(cliArgName, value)
+	result = isConfigProvided(cliArgName, envVarName)
+	h.Equals(t, true, result)
+
+	os.Setenv(envVarName, value)
+	result = isConfigProvided(cliArgName, envVarName)
+	h.Equals(t, true, result)
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -26,42 +26,8 @@ func resetFlagsForTest() {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 }
 
-func TestParseCliArgsDefaultArgsSuccess(t *testing.T) {
+func TestParseCliArgsSuccess(t *testing.T) {
 	resetFlagsForTest()
-	os.Setenv("NODE_NAME", "bla")
-	nthConfig, err := config.ParseCliArgs()
-	h.Ok(t, err)
-
-	// Assert all the default values were set
-	h.Equals(t, nthConfig.DeleteLocalData, true)
-	h.Equals(t, nthConfig.DryRun, false)
-	h.Equals(t, nthConfig.EnableScheduledEventDraining, false)
-	h.Equals(t, nthConfig.EnableSpotInterruptionDraining, true)
-	h.Equals(t, nthConfig.IgnoreDaemonSets, true)
-	h.Equals(t, nthConfig.KubernetesServiceHost, "")
-	h.Equals(t, nthConfig.KubernetesServicePort, "")
-	h.Equals(t, nthConfig.NodeName, "bla")
-	h.Equals(t, nthConfig.NodeTerminationGracePeriod, 120)
-	h.Equals(t, nthConfig.MetadataURL, "http://169.254.169.254")
-	h.Equals(t, nthConfig.PodTerminationGracePeriod, -1)
-	h.Equals(t, nthConfig.WebhookURL, "")
-	h.Equals(t, nthConfig.WebhookHeaders, `{"Content-type":"application/json"}`)
-	h.Equals(t, nthConfig.WebhookTemplate, `{"text":"[NTH][Instance Interruption] `+
-		`EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} `+
-		`- State: {{ .State }} - Start Time: {{ .StartTime }}"}`)
-
-	// Check that env vars were set
-	value, ok := os.LookupEnv("KUBERNETES_SERVICE_HOST")
-	h.Equals(t, true, ok)
-	h.Equals(t, "", value)
-
-	value, ok = os.LookupEnv("KUBERNETES_SERVICE_PORT")
-	h.Equals(t, true, ok)
-	h.Equals(t, "", value)
-}
-func TestParseCliArgsCustomArgsSuccess(t *testing.T) {
-	resetFlagsForTest()
-
 	os.Setenv("DELETE_LOCAL_DATA", "false")
 	os.Setenv("DRY_RUN", "true")
 	os.Setenv("ENABLE_SCHEDULED_EVENT_DRAINING", "true")
@@ -80,21 +46,21 @@ func TestParseCliArgsCustomArgsSuccess(t *testing.T) {
 	nthConfig, err := config.ParseCliArgs()
 	h.Ok(t, err)
 
-	// Assert all the default values were set
-	h.Equals(t, nthConfig.DeleteLocalData, false)
-	h.Equals(t, nthConfig.DryRun, true)
-	h.Equals(t, nthConfig.EnableScheduledEventDraining, true)
-	h.Equals(t, nthConfig.EnableSpotInterruptionDraining, false)
-	h.Equals(t, nthConfig.IgnoreDaemonSets, false)
-	h.Equals(t, nthConfig.KubernetesServiceHost, "KUBERNETES_SERVICE_HOST")
-	h.Equals(t, nthConfig.KubernetesServicePort, "KUBERNETES_SERVICE_PORT")
-	h.Equals(t, nthConfig.NodeName, "NODE_NAME")
-	h.Equals(t, nthConfig.NodeTerminationGracePeriod, 12345)
-	h.Equals(t, nthConfig.MetadataURL, "INSTANCE_METADATA_URL")
-	h.Equals(t, nthConfig.PodTerminationGracePeriod, 12345)
-	h.Equals(t, nthConfig.WebhookURL, "WEBHOOK_URL")
-	h.Equals(t, nthConfig.WebhookHeaders, "WEBHOOK_HEADERS")
-	h.Equals(t, nthConfig.WebhookTemplate, "WEBHOOK_TEMPLATE")
+	// Assert all the values were set
+	h.Equals(t, false, nthConfig.DeleteLocalData)
+	h.Equals(t, true, nthConfig.DryRun)
+	h.Equals(t, true, nthConfig.EnableScheduledEventDraining)
+	h.Equals(t, false, nthConfig.EnableSpotInterruptionDraining)
+	h.Equals(t, false, nthConfig.IgnoreDaemonSets)
+	h.Equals(t, "KUBERNETES_SERVICE_HOST", nthConfig.KubernetesServiceHost)
+	h.Equals(t, "KUBERNETES_SERVICE_PORT", nthConfig.KubernetesServicePort)
+	h.Equals(t, "NODE_NAME", nthConfig.NodeName)
+	h.Equals(t, 12345, nthConfig.NodeTerminationGracePeriod)
+	h.Equals(t, "INSTANCE_METADATA_URL", nthConfig.MetadataURL)
+	h.Equals(t, 12345, nthConfig.PodTerminationGracePeriod)
+	h.Equals(t, "WEBHOOK_URL", nthConfig.WebhookURL)
+	h.Equals(t, "WEBHOOK_HEADERS", nthConfig.WebhookHeaders)
+	h.Equals(t, "WEBHOOK_TEMPLATE", nthConfig.WebhookTemplate)
 
 	// Check that env vars were set
 	value, ok := os.LookupEnv("KUBERNETES_SERVICE_HOST")
@@ -114,7 +80,7 @@ func TestParseCliArgsWithGracePeriodSuccess(t *testing.T) {
 
 	nthConfig, err := config.ParseCliArgs()
 	h.Ok(t, err)
-	h.Equals(t, nthConfig.PodTerminationGracePeriod, 12)
+	h.Equals(t, 12, nthConfig.PodTerminationGracePeriod)
 }
 
 func TestParseCliArgsMissingNodeNameFailure(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,132 @@
+// Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config_test
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-node-termination-handler/pkg/config"
+	h "github.com/aws/aws-node-termination-handler/pkg/test"
+)
+
+func resetFlagsForTest() {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+}
+
+func TestParseCliArgsDefaultArgsSuccess(t *testing.T) {
+	resetFlagsForTest()
+	os.Setenv("NODE_NAME", "bla")
+	nthConfig, err := config.ParseCliArgs()
+	h.Ok(t, err)
+
+	// Assert all the default values were set
+	h.Equals(t, nthConfig.DeleteLocalData, true)
+	h.Equals(t, nthConfig.DryRun, false)
+	h.Equals(t, nthConfig.EnableScheduledEventDraining, false)
+	h.Equals(t, nthConfig.EnableSpotInterruptionDraining, true)
+	h.Equals(t, nthConfig.IgnoreDaemonSets, true)
+	h.Equals(t, nthConfig.KubernetesServiceHost, "")
+	h.Equals(t, nthConfig.KubernetesServicePort, "")
+	h.Equals(t, nthConfig.NodeName, "bla")
+	h.Equals(t, nthConfig.NodeTerminationGracePeriod, 120)
+	h.Equals(t, nthConfig.MetadataURL, "http://169.254.169.254")
+	h.Equals(t, nthConfig.PodTerminationGracePeriod, -1)
+	h.Equals(t, nthConfig.WebhookURL, "")
+	h.Equals(t, nthConfig.WebhookHeaders, `{"Content-type":"application/json"}`)
+	h.Equals(t, nthConfig.WebhookTemplate, `{"text":"[NTH][Instance Interruption] `+
+		`EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} `+
+		`- State: {{ .State }} - Start Time: {{ .StartTime }}"}`)
+
+	// Check that env vars were set
+	value, ok := os.LookupEnv("KUBERNETES_SERVICE_HOST")
+	h.Equals(t, true, ok)
+	h.Equals(t, "", value)
+
+	value, ok = os.LookupEnv("KUBERNETES_SERVICE_PORT")
+	h.Equals(t, true, ok)
+	h.Equals(t, "", value)
+}
+func TestParseCliArgsCustomArgsSuccess(t *testing.T) {
+	resetFlagsForTest()
+
+	os.Setenv("DELETE_LOCAL_DATA", "false")
+	os.Setenv("DRY_RUN", "true")
+	os.Setenv("ENABLE_SCHEDULED_EVENT_DRAINING", "true")
+	os.Setenv("ENABLE_SPOT_INTERRUPTION_DRAINING", "false")
+	os.Setenv("GRACE_PERIOD", "12345")
+	os.Setenv("IGNORE_DAEMON_SETS", "false")
+	os.Setenv("KUBERNETES_SERVICE_HOST", "KUBERNETES_SERVICE_HOST")
+	os.Setenv("KUBERNETES_SERVICE_PORT", "KUBERNETES_SERVICE_PORT")
+	os.Setenv("NODE_NAME", "NODE_NAME")
+	os.Setenv("NODE_TERMINATION_GRACE_PERIOD", "12345")
+	os.Setenv("INSTANCE_METADATA_URL", "INSTANCE_METADATA_URL")
+	os.Setenv("POD_TERMINATION_GRACE_PERIOD", "12345")
+	os.Setenv("WEBHOOK_URL", "WEBHOOK_URL")
+	os.Setenv("WEBHOOK_HEADERS", "WEBHOOK_HEADERS")
+	os.Setenv("WEBHOOK_TEMPLATE", "WEBHOOK_TEMPLATE")
+	nthConfig, err := config.ParseCliArgs()
+	h.Ok(t, err)
+
+	// Assert all the default values were set
+	h.Equals(t, nthConfig.DeleteLocalData, false)
+	h.Equals(t, nthConfig.DryRun, true)
+	h.Equals(t, nthConfig.EnableScheduledEventDraining, true)
+	h.Equals(t, nthConfig.EnableSpotInterruptionDraining, false)
+	h.Equals(t, nthConfig.IgnoreDaemonSets, false)
+	h.Equals(t, nthConfig.KubernetesServiceHost, "KUBERNETES_SERVICE_HOST")
+	h.Equals(t, nthConfig.KubernetesServicePort, "KUBERNETES_SERVICE_PORT")
+	h.Equals(t, nthConfig.NodeName, "NODE_NAME")
+	h.Equals(t, nthConfig.NodeTerminationGracePeriod, 12345)
+	h.Equals(t, nthConfig.MetadataURL, "INSTANCE_METADATA_URL")
+	h.Equals(t, nthConfig.PodTerminationGracePeriod, 12345)
+	h.Equals(t, nthConfig.WebhookURL, "WEBHOOK_URL")
+	h.Equals(t, nthConfig.WebhookHeaders, "WEBHOOK_HEADERS")
+	h.Equals(t, nthConfig.WebhookTemplate, "WEBHOOK_TEMPLATE")
+
+	// Check that env vars were set
+	value, ok := os.LookupEnv("KUBERNETES_SERVICE_HOST")
+	h.Equals(t, true, ok)
+	h.Equals(t, "KUBERNETES_SERVICE_HOST", value)
+
+	value, ok = os.LookupEnv("KUBERNETES_SERVICE_PORT")
+	h.Equals(t, true, ok)
+	h.Equals(t, "KUBERNETES_SERVICE_PORT", value)
+}
+
+func TestParseCliArgsWithGracePeriodSuccess(t *testing.T) {
+	resetFlagsForTest()
+	os.Setenv("POD_TERMINATION_GRACE_PERIOD", "")
+	os.Setenv("NODE_NAME", "bla")
+	os.Setenv("GRACE_PERIOD", "12")
+
+	nthConfig, err := config.ParseCliArgs()
+	h.Ok(t, err)
+	h.Equals(t, nthConfig.PodTerminationGracePeriod, 12)
+}
+
+func TestParseCliArgsMissingNodeNameFailure(t *testing.T) {
+	resetFlagsForTest()
+	os.Setenv("NODE_NAME", "")
+	_, err := config.ParseCliArgs()
+	h.Assert(t, true, "Failed to return error when node-name not provided", err != nil)
+}
+
+func TestParseCliArgsCreateFlagsFailure(t *testing.T) {
+	resetFlagsForTest()
+	os.Setenv("DELETE_LOCAL_DATA", "something not true or false")
+	_, err := config.ParseCliArgs()
+	h.Assert(t, true, "Failed to return error when creating flags", err != nil)
+}


### PR DESCRIPTION
Description of changes:
Rewrote config.go to return errors instead of panicking in place. As a result, flags and their default values are all declared in an object of type map[string]map[string]interface{}. Each flag is then evaluated for validity and the resulting values are stored in a map[string]interface{} which is eventually json marshaled into the nthConfig. The new changes were necessary to help consolidate error checking and avoid repeatedly checking if error else do something. 

Changes fully unit tested: 
```
ok  	github.com/aws/aws-node-termination-handler/pkg/config	0.027s	coverage: 98.6% of statements
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
