### PR TITLE
Bringing webhook and draineventstore to 100% coverage

### DIFF
--- a/pkg/draineventstore/drain-event-store_test.go
+++ b/pkg/draineventstore/drain-event-store_test.go
@@ -133,14 +133,16 @@ func TestShouldUncordonNode(t *testing.T) {
 func TestIgnoreEvent(t *testing.T) {
 	eventID := "event-id-123"
 	store := draineventstore.New(config.Config{})
-	store.IgnoreEvent(eventID)
-
+	store.IgnoreEvent("")
 	event := &drainevent.DrainEvent{
 		EventID:   eventID,
 		State:     "active",
 		StartTime: time.Now(),
 	}
 	store.AddDrainEvent(event)
+	h.Equals(t, true, store.ShouldDrainNode())
+
+	store.IgnoreEvent(eventID)
 	h.Equals(t, false, store.ShouldDrainNode())
 }
 

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -204,3 +204,22 @@ func TestPostBadResponseCode(t *testing.T) {
 	webhook.Post(event, nthconfig)
 	h.Equals(t, 1, requestCount)
 }
+
+func TestValidateWebhookConfig(t *testing.T) {
+	var nthConfig = config.Config{}
+	err := webhook.ValidateWebhookConfig(nthConfig)
+	h.Ok(t, err)
+
+	nthConfig.WebhookURL = "http://123.123.123"
+	nthConfig.WebhookTemplate = "{{ "
+	err = webhook.ValidateWebhookConfig(nthConfig)
+	h.Assert(t, true, "Failed to return error for failing to parse webhook template", err != nil)
+
+	nthConfig.WebhookTemplate = "{{.cat}}"
+	err = webhook.ValidateWebhookConfig(nthConfig)
+	h.Assert(t, true, "Failed to return error for failing to execute webhook template", err != nil)
+
+	nthConfig.WebhookTemplate = testWebhookTemplate
+	err = webhook.ValidateWebhookConfig(nthConfig)
+	h.Ok(t, err)
+}


### PR DESCRIPTION
```
?   	github.com/aws/aws-node-termination-handler/cmd	[no test files]
ok  	github.com/aws/aws-node-termination-handler/pkg/config	0.040s	coverage: 98.6% of statements
ok  	github.com/aws/aws-node-termination-handler/pkg/drainevent	0.272s	coverage: 1.4% of statements
ok  	github.com/aws/aws-node-termination-handler/pkg/draineventstore	0.256s	coverage: 100.0% of statements
ok  	github.com/aws/aws-node-termination-handler/pkg/ec2metadata	1.346s	coverage: 100.0% of statements
?   	github.com/aws/aws-node-termination-handler/pkg/node	[no test files]
?   	github.com/aws/aws-node-termination-handler/pkg/test	[no test files]
ok  	github.com/aws/aws-node-termination-handler/pkg/webhook	6.263s	coverage: 100.0% of statements
?   	github.com/aws/aws-node-termination-handler/test/ec2-metadata-test-proxy/cmd	[no test files]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
