### PR TITLE
Add unit tests for spot-itn-event

### DIFF
--- a/pkg/drainevent/spot-itn-event_test.go
+++ b/pkg/drainevent/spot-itn-event_test.go
@@ -1,0 +1,177 @@
+// Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package drainevent_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-node-termination-handler/pkg/config"
+	"github.com/aws/aws-node-termination-handler/pkg/drainevent"
+	"github.com/aws/aws-node-termination-handler/pkg/ec2metadata"
+	h "github.com/aws/aws-node-termination-handler/pkg/test"
+)
+
+var eventId = "12345678-1234-1234-1234-123456789012"
+var startTime = "2017-09-18T08:22:00Z"
+var expFormattedTime = "2017-09-18 08:22:00 +0000 UTC"
+var instanceId = 12345
+var instanceAction = "INSTANCE_ACTION"
+
+var instanceActionResponse = []byte(`{
+    "version": "0",
+    "id": "` + eventId + `",
+    "detail-type": "EC2 Spot Instance Interruption Warning",
+    "source": "aws.ec2",
+    "account": "123456789012",
+    "time": "` + startTime + `",
+    "region": "us-east-2",
+    "resources": ["arn:aws:ec2:us-east-2:123456789012:instance/i-1234567890abcdef0"],
+    "detail": {
+        "instance-id": "` + strconv.Itoa(instanceId) + `",
+        "instance-action": "` + instanceAction + `"
+    }
+}`)
+
+func TestMonitorForSpotITNEventsSuccess(t *testing.T) {
+	var requestPath string = ec2metadata.SpotInstanceActionPath
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		h.Equals(t, req.URL.String(), requestPath)
+		rw.Write(instanceActionResponse)
+	}))
+	defer server.Close()
+
+	drainChan := make(chan drainevent.DrainEvent)
+	cancelChan := make(chan drainevent.DrainEvent)
+	nthConfig := config.Config{
+		MetadataURL: server.URL,
+	}
+
+	go func() {
+		result := <-drainChan
+		h.Equals(t, eventId, result.EventID)
+		h.Equals(t, drainevent.SpotITNKind, result.Kind)
+		h.Equals(t, expFormattedTime, result.StartTime.String())
+		h.Assert(t, true, "Drain event description does not contain instance id",
+			strings.Contains(result.Description, strconv.Itoa(instanceId)))
+		h.Assert(t, true, "Drain event description does not contain instance action",
+			strings.Contains(result.Description, instanceAction))
+		h.Assert(t, true, "Drain event description does not contain instance time",
+			strings.Contains(result.Description, startTime))
+		fmt.Println(result)
+	}()
+
+	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, nthConfig)
+	h.Ok(t, err)
+}
+
+func TestMonitorForSpotITNEventsMetadataParseFailure(t *testing.T) {
+	var requestPath string = ec2metadata.SpotInstanceActionPath
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		h.Equals(t, req.URL.String(), requestPath)
+	}))
+	defer server.Close()
+
+	drainChan := make(chan drainevent.DrainEvent)
+	cancelChan := make(chan drainevent.DrainEvent)
+	nthConfig := config.Config{
+		MetadataURL: "Bad url",
+	}
+
+	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, nthConfig)
+	h.Assert(t, true, "Failed to return error metadata parse fails", err != nil)
+}
+
+func TestMonitorForSpotITNEvents404Response(t *testing.T) {
+	var requestPath string = ec2metadata.SpotInstanceActionPath
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		h.Equals(t, req.URL.String(), requestPath)
+		http.Error(rw, "error", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	drainChan := make(chan drainevent.DrainEvent)
+	cancelChan := make(chan drainevent.DrainEvent)
+	nthConfig := config.Config{
+		MetadataURL: server.URL,
+	}
+
+	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, nthConfig)
+	h.Assert(t, true, "Failed to return error when 404 response", err != nil)
+}
+
+func TestMonitorForSpotITNEvents500Response(t *testing.T) {
+	var requestPath string = ec2metadata.SpotInstanceActionPath
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		h.Equals(t, req.URL.String(), requestPath)
+		http.Error(rw, "error", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	drainChan := make(chan drainevent.DrainEvent)
+	cancelChan := make(chan drainevent.DrainEvent)
+	nthConfig := config.Config{
+		MetadataURL: server.URL,
+	}
+
+	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, nthConfig)
+	h.Assert(t, true, "Failed to return error when 500 response", err != nil)
+}
+
+func TestMonitorForSpotITNEventsInstanceActionDecodeFailure(t *testing.T) {
+	var requestPath string = ec2metadata.SpotInstanceActionPath
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		h.Equals(t, req.URL.String(), requestPath)
+		rw.Write([]byte{0x7f})
+	}))
+	defer server.Close()
+
+	drainChan := make(chan drainevent.DrainEvent)
+	cancelChan := make(chan drainevent.DrainEvent)
+	nthConfig := config.Config{
+		MetadataURL: server.URL,
+	}
+
+	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, nthConfig)
+	h.Assert(t, true, "Failed to return error when failed to decode instance action", err != nil)
+}
+
+func TestMonitorForSpotITNEventsTimeParseFailure(t *testing.T) {
+	var requestPath string = ec2metadata.SpotInstanceActionPath
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		h.Equals(t, req.URL.String(), requestPath)
+		rw.Write([]byte(`{"time": ""}`))
+	}))
+	defer server.Close()
+
+	drainChan := make(chan drainevent.DrainEvent)
+	cancelChan := make(chan drainevent.DrainEvent)
+	nthConfig := config.Config{
+		MetadataURL: server.URL,
+	}
+
+	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, nthConfig)
+	fmt.Printf(err.Error())
+	h.Assert(t, true, "Failed to return error when failed to parse time", err != nil)
+}


### PR DESCRIPTION
spot-itn-event.go is 100% covered. 33.3% of draineventstore covered

```
=== RUN   TestTimeUntilEvent
--- PASS: TestTimeUntilEvent (0.00s)
=== RUN   TestMonitorForSpotITNEventsSuccess
2020/01/31 11:13:32 Sending drain event to the drain channel
--- PASS: TestMonitorForSpotITNEventsSuccess (0.01s)
=== RUN   TestMonitorForSpotITNEventsMetadataParseFailure
2020/01/31 11:13:32 Request failed. Attempts remaining: 2
2020/01/31 11:13:32 Sleep for 2.973889705s seconds
{12345678-1234-1234-1234-123456789012 SPOT_ITN Spot ITN received. 12345 will be INSTANCE_ACTION at 2017-09-18T08:22:00Z
  2017-09-18 08:22:00 +0000 UTC 0001-01-01 00:00:00 +0000 UTC false <nil>}
2020/01/31 11:13:35 Request failed. Attempts remaining: 1
2020/01/31 11:13:35 Sleep for 8.84038228s seconds
--- PASS: TestMonitorForSpotITNEventsMetadataParseFailure (11.82s)
=== RUN   TestMonitorForSpotITNEvents404Response
--- PASS: TestMonitorForSpotITNEvents404Response (0.00s)
=== RUN   TestMonitorForSpotITNEvents500Response
--- PASS: TestMonitorForSpotITNEvents500Response (0.00s)
=== RUN   TestMonitorForSpotITNEventsInstanceActionDecodeFailure
--- PASS: TestMonitorForSpotITNEventsInstanceActionDecodeFailure (0.00s)
=== RUN   TestMonitorForSpotITNEventsTimeParseFailure
Could not parse time from spot interruption notice metadata json: parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"--- PASS: TestMonitorForSpotITNEventsTimeParseFailure (0.00s)
PASS
coverage: 33.3% of statements
ok  	github.com/aws/aws-node-termination-handler/pkg/drainevent	12.167s	coverage: 33.3% of statements
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
