### PR TITLE
adding hostnetwork to daemonset pod spec

### DIFF
--- a/config/helm/aws-node-termination-handler/templates/daemonset.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.yaml
@@ -46,6 +46,7 @@ spec:
                     values:
                       - amd64
       serviceAccountName: {{ template "aws-node-termination-handler.serviceAccountName" . }}
+      hostNetwork: true
       containers:
         - name: {{ include "aws-node-termination-handler.name" . }}
           image: {{ .Values.image.repository}}:{{ .Values.image.tag }}

--- a/config/helm/ec2-metadata-test-proxy/templates/daemonset.yaml
+++ b/config/helm/ec2-metadata-test-proxy/templates/daemonset.yaml
@@ -14,12 +14,14 @@ spec:
       labels:
         app: {{ .Values.ec2MetadataTestProxy.label }}
     spec:
+      hostNetwork: true
       containers:
       - name: {{ .Values.ec2MetadataTestProxy.label }}
         image: {{ .Values.ec2MetadataTestProxy.image.repository }}:{{ .Values.ec2MetadataTestProxy.image.tag }}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: {{ .Values.ec2MetadataTestProxy.port }}
+          hostPort: {{ .Values.ec2MetadataTestProxy.port }}
         env:
         - name: INTERRUPTION_NOTICE_DELAY
           value: {{ .Values.ec2MetadataTestProxy.interruptionNoticeDelay | quote }}

--- a/test/e2e/maintenance-event-cancellation-test
+++ b/test/e2e/maintenance-event-cancellation-test
@@ -18,7 +18,7 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --wait \
   --force \
   --namespace kube-system \
-  --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
+  --set instanceMetadataURL="http://localhost:1338" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
   --set enableSpotInterruptionDraining="true" \
@@ -39,14 +39,14 @@ TAINT_CHECK_SLEEP=15
 DEPLOYED=0
 CORDONED=0
 
-for i in `seq 1 10`; do 
+for i in `seq 1 10`; do
     if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
         echo "✅ Verified regular-pod-test pod was scheduled and started!"
         DEPLOYED=1
         break
     fi
     sleep 5
-done 
+done
 
 if [[ $DEPLOYED -eq 0 ]]; then
     echo "❌ Failed test setup for regular-pod"
@@ -65,19 +65,20 @@ for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     sleep $TAINT_CHECK_SLEEP
 done
 
-if [[ $CORDONED -eq 0 ]]; then 
+if [[ $CORDONED -eq 0 ]]; then
     echo "❌ Failed cordoning node for scheduled maintenance event"
     exit 3
 fi
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
+  --wait \
   --force \
   --namespace default \
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
   --set ec2MetadataTestProxy.enableScheduledMaintenanceEvents="true" \
   --set ec2MetadataTestProxy.enableSpotITN="false" \
-  --set ec2MetadataTestProxy.scheduledEventStatus="cancelled" 
+  --set ec2MetadataTestProxy.scheduledEventStatus="cancelled"
 
 for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     if kubectl get nodes $CLUSTER_NAME-worker --no-headers | grep -v SchedulingDisabled; then

--- a/test/e2e/maintenance-event-dry-run-test
+++ b/test/e2e/maintenance-event-dry-run-test
@@ -18,7 +18,7 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --wait \
   --force \
   --namespace kube-system \
-  --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
+  --set instanceMetadataURL="http://localhost:1339" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
   --set dryRun="true" \
@@ -30,11 +30,12 @@ helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-meta
   --force \
   --namespace default \
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
-  --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG"
+  --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
+  --set ec2MetadataTestProxy.port=1339
 
 POD_ID=$(kubectl get pods --namespace kube-system | grep -i node-termination-handler | grep Running | cut -d' ' -f1)
 
-for i in $(seq 0 10); do 
+for i in $(seq 0 10); do
   if [[ ! -z $(kubectl logs $POD_ID -n kube-system | grep -i -e 'would have been cordoned and drained') ]]; then
       echo "✅ Verified the dryrun logs were executed"
       if kubectl get nodes $CLUSTER_NAME-worker --no-headers | grep -v SchedulingDisabled; then

--- a/test/e2e/maintenance-event-reboot-test
+++ b/test/e2e/maintenance-event-reboot-test
@@ -21,7 +21,7 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --wait \
   --force \
   --namespace kube-system \
-  --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
+  --set instanceMetadataURL="http://localhost:1340" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
   --set enableSpotInterruptionDraining="true" \
@@ -34,7 +34,8 @@ helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-meta
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
   --set ec2MetadataTestProxy.enableScheduledMaintenanceEvents="true" \
-  --set ec2MetadataTestProxy.enableSpotITN="false"
+  --set ec2MetadataTestProxy.enableSpotITN="false" \
+  --set ec2MetadataTestProxy.port=1340
 
 TAINT_CHECK_CYCLES=15
 TAINT_CHECK_SLEEP=15
@@ -42,14 +43,14 @@ TAINT_CHECK_SLEEP=15
 DEPLOYED=0
 CORDONED=0
 
-for i in `seq 1 10`; do 
+for i in `seq 1 10`; do
     if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
         echo "✅ Verified regular-pod-test pod was scheduled and started!"
         DEPLOYED=1
         break
     fi
     sleep 5
-done 
+done
 
 if [[ $DEPLOYED -eq 0 ]]; then
     echo "❌ Failed test setup for regular-pod"
@@ -68,7 +69,7 @@ for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     sleep $TAINT_CHECK_SLEEP
 done
 
-if [[ $CORDONED -eq 0 ]]; then 
+if [[ $CORDONED -eq 0 ]]; then
     echo "❌ Failed cordoning node for scheduled maintenance event"
     exit 3
 fi
@@ -79,14 +80,14 @@ docker exec $CLUSTER_NAME-worker sh -c "chmod 0444 /uptime && chown root /uptime
 
 ## Remove ec2-metadata-test-proxy to prevent another drain event but keep regular-test-pod
 daemonset=$(kubectl get daemonsets | grep 'ec2-metadata-test-proxy' | cut -d' ' -f1)
-kubectl delete daemonsets $daemonset 
+kubectl delete daemonsets $daemonset
 
 ## Restart NTH which will simulate a system reboot by mounting a new uptime file
 helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ \
   --wait \
   --force \
   --namespace kube-system \
-  --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
+  --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1340" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
   --set procUptimeFile="/uptime" \

--- a/test/e2e/maintenance-event-test
+++ b/test/e2e/maintenance-event-test
@@ -18,11 +18,12 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --wait \
   --force \
   --namespace kube-system \
-  --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
+  --set instanceMetadataURL="http://localhost:1341" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
   --set enableSpotInterruptionDraining="true" \
   --set enableScheduledEventDraining="true"
+
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
   --wait \
@@ -31,21 +32,22 @@ helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-meta
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
   --set ec2MetadataTestProxy.enableScheduledMaintenanceEvents="true" \
-  --set ec2MetadataTestProxy.enableSpotITN="false"
+  --set ec2MetadataTestProxy.enableSpotITN="false" \
+  --set ec2MetadataTestProxy.port=1341
 
 TAINT_CHECK_CYCLES=15
 TAINT_CHECK_SLEEP=15
 
 DEPLOYED=0
 
-for i in `seq 1 10`; do 
+for i in `seq 1 10`; do
     if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
         echo "✅ Verified regular-pod-test pod was scheduled and started!"
         DEPLOYED=1
         break
     fi
     sleep 5
-done 
+done
 
 if [[ $DEPLOYED -eq 0 ]]; then
     exit 2

--- a/test/e2e/spot-interruption-dry-run-test
+++ b/test/e2e/spot-interruption-dry-run-test
@@ -18,7 +18,7 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --wait \
   --force \
   --namespace kube-system \
-  --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
+  --set instanceMetadataURL="http://localhost:1342" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
   --set dryRun="true" \
@@ -30,11 +30,12 @@ helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-meta
   --force \
   --namespace default \
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
-  --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" 
+  --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
+  --set ec2MetadataTestProxy.port=1342
 
 POD_ID=$(kubectl get pods --namespace kube-system | grep -i node-termination-handler | grep Running | cut -d' ' -f1)
 
-for i in $(seq 0 10); do 
+for i in $(seq 0 10); do
   if [[ ! -z $(kubectl logs $POD_ID -n kube-system | grep -i -e 'would have been cordoned and drained') ]]; then
       echo "✅ Verified the dryrun logs were executed"
       if kubectl get nodes $CLUSTER_NAME-worker --no-headers | grep -v SchedulingDisabled; then

--- a/test/e2e/spot-interruption-test
+++ b/test/e2e/spot-interruption-test
@@ -18,7 +18,7 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --wait \
   --force \
   --namespace kube-system \
-  --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
+  --set instanceMetadataURL="http://localhost:1343" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
   --set enableSpotInterruptionDraining="true" \
@@ -33,21 +33,22 @@ helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-meta
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
   --set ec2MetadataTestProxy.enableSpotITN="true" \
-  --set ec2MetadataTestProxy.enableScheduledMaintenanceEvents="false" 
+  --set ec2MetadataTestProxy.enableScheduledMaintenanceEvents="false" \
+  --set ec2MetadataTestProxy.port=1343
 
 TAINT_CHECK_CYCLES=15
 TAINT_CHECK_SLEEP=15
 
 DEPLOYED=0
 
-for i in `seq 1 10`; do 
+for i in `seq 1 10`; do
     if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
         echo "✅ Verified regular-pod-test pod was scheduled and started!"
         DEPLOYED=1
         break
     fi
     sleep 5
-done 
+done
 
 if [[ $DEPLOYED -eq 0 ]]; then
     exit 2

--- a/test/e2e/webhook-test
+++ b/test/e2e/webhook-test
@@ -16,14 +16,14 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 ### LOCAL ONLY TESTS FOR 200 RESPONSE FROM LOCAL CLUSTER, MASTER WILL TEST WITH TRAVIS SECRET URL
 if [[ -z $(env | grep "WEBHOOK_URL=") ]]; then
-  WEBHOOK_URL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338"
+  WEBHOOK_URL="http://localhost:1337"
 fi
 
 helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ \
   --wait \
   --force \
   --namespace kube-system \
-  --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1338" \
+  --set instanceMetadataURL="http://localhost:1337" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
   --set webhookURL="$WEBHOOK_URL" \
@@ -35,7 +35,8 @@ helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-meta
   --force \
   --namespace default \
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
-  --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG"
+  --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
+  --set ec2MetadataTestProxy.port=1337
 
 TAINT_CHECK_CYCLES=15
 TAINT_CHECK_SLEEP=15


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-node-termination-handler/issues/74

Description of changes:
if following the EKS documentation [here](https://docs.aws.amazon.com/eks/latest/userguide/restrict-ec2-credential-access.html) customers would not be able to use this handler as it prevents forwarding metadata, changing the pod spec to hostnetwork allows the daemonset pod to continue to get information from metadata service

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
