### PR TITLE
imdsv2 support

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -32,7 +32,6 @@ import (
 const (
 	scheduledMaintenance = "Scheduled Maintenance"
 	spotITN              = "Spot ITN"
-	metadataTries        = 3
 )
 
 type monitorFunc func(chan<- drainevent.DrainEvent, chan<- drainevent.DrainEvent, *ec2metadata.EC2MetadataService) error
@@ -70,7 +69,7 @@ func main() {
 	cancelChan := make(chan drainevent.DrainEvent)
 	defer close(cancelChan)
 
-	imds := ec2metadata.New(nthConfig.MetadataURL, metadataTries)
+	imds := ec2metadata.New(nthConfig.MetadataURL, nthConfig.MetadataTries)
 
 	monitoringFns := map[string]monitorFunc{}
 	if nthConfig.EnableSpotInterruptionDraining {

--- a/config/helm/ec2-metadata-test-proxy/templates/daemonset.yaml
+++ b/config/helm/ec2-metadata-test-proxy/templates/daemonset.yaml
@@ -33,6 +33,8 @@ spec:
           value: {{ .Values.ec2MetadataTestProxy.scheduledEventStatus | quote }}
         - name: ENABLE_SPOT_ITN
           value: {{ .Values.ec2MetadataTestProxy.enableSpotITN | quote }}
+        - name: ENABLE_IMDS_V2
+          value: {{ .Values.ec2MetadataTestProxy.enableIMDSV2 | quote }}
 {{- end -}}
 
 

--- a/config/helm/ec2-metadata-test-proxy/values.yaml
+++ b/config/helm/ec2-metadata-test-proxy/values.yaml
@@ -7,6 +7,7 @@ ec2MetadataTestProxy:
     scheduledEventStatus: active
     enableScheduledMaintenanceEvents: false
     enableSpotITN: true
+    enableIMDSV2: false
     image:
         repository: ec2-metadata-test-proxy
         tag: customtest

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,6 +46,8 @@ const (
 	enableScheduledEventDrainingDefault     = false
 	enableSpotInterruptionDrainingConfigKey = "ENABLE_SPOT_INTERRUPTION_DRAINING"
 	enableSpotInterruptionDrainingDefault   = true
+	metadataTriesConfigKey                  = "METADATA_TRIES"
+	metadataTriesDefault                    = 3
 )
 
 //Config arguments set via CLI, environment variables, or defaults
@@ -64,6 +66,7 @@ type Config struct {
 	WebhookTemplate                string
 	EnableScheduledEventDraining   bool
 	EnableSpotInterruptionDraining bool
+	MetadataTries                  int
 }
 
 //ParseCliArgs parses cli arguments and uses environment variables as fallback values
@@ -92,6 +95,7 @@ func ParseCliArgs() (config Config, err error) {
 	flag.StringVar(&config.WebhookTemplate, "webhook-template", getEnv(webhookTemplateConfigKey, webhookTemplateDefault), "If specified, replaces the default webhook message template.")
 	flag.BoolVar(&config.EnableScheduledEventDraining, "enable-scheduled-event-draining", getBoolEnv(enableScheduledEventDrainingConfigKey, enableScheduledEventDrainingDefault), "[EXPERIMENTAL] If true, drain nodes before the maintenance window starts for an EC2 instance scheduled event")
 	flag.BoolVar(&config.EnableSpotInterruptionDraining, "enable-spot-interruption-draining", getBoolEnv(enableSpotInterruptionDrainingConfigKey, enableSpotInterruptionDrainingDefault), "If true, drain nodes when the spot interruption termination notice is receieved")
+	flag.IntVar(&config.MetadataTries, "metadata-tries", getIntEnv(metadataTriesConfigKey, metadataTriesDefault), "The number of times to try requesting metadata. If you would like 2 retries, set metadata-tries to 3.")
 
 	flag.Parse()
 
@@ -123,7 +127,9 @@ func ParseCliArgs() (config Config, err error) {
 			"\tpod-termination-grace-period: %d,\n"+
 			"\tnode-termination-grace-period: %d,\n"+
 			"\tenable-scheduled-event-draining: %t,\n"+
-			"\tenable-spot-interruption-draining: %t,\n",
+			"\tenable-spot-interruption-draining: %t,\n"+
+			"\tmetadata-tries: %d,\n",
+
 		config.DryRun,
 		config.NodeName,
 		config.MetadataURL,
@@ -135,6 +141,7 @@ func ParseCliArgs() (config Config, err error) {
 		config.NodeTerminationGracePeriod,
 		config.EnableScheduledEventDraining,
 		config.EnableSpotInterruptionDraining,
+		config.MetadataTries,
 	)
 
 	return config, err

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -44,6 +44,7 @@ func TestParseCliArgsEnvSuccess(t *testing.T) {
 	os.Setenv("WEBHOOK_URL", "WEBHOOK_URL")
 	os.Setenv("WEBHOOK_HEADERS", "WEBHOOK_HEADERS")
 	os.Setenv("WEBHOOK_TEMPLATE", "WEBHOOK_TEMPLATE")
+	os.Setenv("METADATA_TRIES", "100")
 	nthConfig, err := config.ParseCliArgs()
 	h.Ok(t, err)
 
@@ -62,6 +63,7 @@ func TestParseCliArgsEnvSuccess(t *testing.T) {
 	h.Equals(t, "WEBHOOK_URL", nthConfig.WebhookURL)
 	h.Equals(t, "WEBHOOK_HEADERS", nthConfig.WebhookHeaders)
 	h.Equals(t, "WEBHOOK_TEMPLATE", nthConfig.WebhookTemplate)
+	h.Equals(t, 100, nthConfig.MetadataTries)
 
 	// Check that env vars were set
 	value, ok := os.LookupEnv("KUBERNETES_SERVICE_HOST")
@@ -91,6 +93,7 @@ func TestParseCliArgsSuccess(t *testing.T) {
 		"--webhook-url=WEBHOOK_URL",
 		"--webhook-headers=WEBHOOK_HEADERS",
 		"--webhook-template=WEBHOOK_TEMPLATE",
+		"--metadata-tries=100",
 	}
 	nthConfig, err := config.ParseCliArgs()
 	h.Ok(t, err)
@@ -110,6 +113,7 @@ func TestParseCliArgsSuccess(t *testing.T) {
 	h.Equals(t, "WEBHOOK_URL", nthConfig.WebhookURL)
 	h.Equals(t, "WEBHOOK_HEADERS", nthConfig.WebhookHeaders)
 	h.Equals(t, "WEBHOOK_TEMPLATE", nthConfig.WebhookTemplate)
+	h.Equals(t, 100, nthConfig.MetadataTries)
 
 	// Check that env vars were set
 	value, ok := os.LookupEnv("KUBERNETES_SERVICE_HOST")
@@ -134,6 +138,7 @@ func TestParseCliArgsOverrides(t *testing.T) {
 	os.Setenv("WEBHOOK_URL", "no")
 	os.Setenv("WEBHOOK_HEADERS", "no")
 	os.Setenv("WEBHOOK_TEMPLATE", "no")
+	os.Setenv("METADATA_TRIES", "100")
 	os.Args = []string{
 		"cmd",
 		"--delete-local-data=false",
@@ -150,6 +155,7 @@ func TestParseCliArgsOverrides(t *testing.T) {
 		"--webhook-url=WEBHOOK_URL",
 		"--webhook-headers=WEBHOOK_HEADERS",
 		"--webhook-template=WEBHOOK_TEMPLATE",
+		"--metadata-tries=101",
 	}
 	nthConfig, err := config.ParseCliArgs()
 	h.Ok(t, err)
@@ -169,6 +175,7 @@ func TestParseCliArgsOverrides(t *testing.T) {
 	h.Equals(t, "WEBHOOK_URL", nthConfig.WebhookURL)
 	h.Equals(t, "WEBHOOK_HEADERS", nthConfig.WebhookHeaders)
 	h.Equals(t, "WEBHOOK_TEMPLATE", nthConfig.WebhookTemplate)
+	h.Equals(t, 101, nthConfig.MetadataTries)
 
 	// Check that env vars were set
 	value, ok := os.LookupEnv("KUBERNETES_SERVICE_HOST")

--- a/pkg/drainevent/scheduled-event.go
+++ b/pkg/drainevent/scheduled-event.go
@@ -14,7 +14,6 @@
 package drainevent
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -56,13 +55,10 @@ func MonitorForScheduledEvents(drainChan chan<- DrainEvent, cancelChan chan<- Dr
 
 // checkForScheduledEvents Checks EC2 instance metadata for a scheduled event requiring a node drain
 func checkForScheduledEvents(imds *ec2metadata.EC2MetadataService) ([]DrainEvent, error) {
-	resp, err := imds.Request(ec2metadata.ScheduledEventPath)
+	scheduledEvents, err := imds.GetScheduledMaintenanceEvents()
 	if err != nil {
 		return nil, fmt.Errorf("Unable to parse metadata response: %w", err)
 	}
-	defer resp.Body.Close()
-	var scheduledEvents []ec2metadata.ScheduledEventDetail
-	json.NewDecoder(resp.Body).Decode(&scheduledEvents)
 	events := make([]DrainEvent, 0)
 	for _, scheduledEvent := range scheduledEvents {
 		var preDrainFunc preDrainTask

--- a/pkg/drainevent/spot-itn-event.go
+++ b/pkg/drainevent/spot-itn-event.go
@@ -19,7 +19,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/aws/aws-node-termination-handler/pkg/config"
 	"github.com/aws/aws-node-termination-handler/pkg/ec2metadata"
 )
 
@@ -29,8 +28,8 @@ const (
 )
 
 // MonitorForSpotITNEvents continuously monitors metadata for spot ITNs and sends drain events to the passed in channel
-func MonitorForSpotITNEvents(drainChan chan<- DrainEvent, cancelChan chan<- DrainEvent, nthConfig config.Config) error {
-	drainEvent, err := checkForSpotInterruptionNotice(nthConfig.MetadataURL)
+func MonitorForSpotITNEvents(drainChan chan<- DrainEvent, cancelChan chan<- DrainEvent, imds *ec2metadata.EC2MetadataService) error {
+	drainEvent, err := checkForSpotInterruptionNotice(imds)
 	if err != nil {
 		return err
 	}
@@ -42,19 +41,16 @@ func MonitorForSpotITNEvents(drainChan chan<- DrainEvent, cancelChan chan<- Drai
 }
 
 // checkForSpotInterruptionNotice Checks EC2 instance metadata for a spot interruption termination notice
-func checkForSpotInterruptionNotice(metadataURL string) (*DrainEvent, error) {
-	resp, err := ec2metadata.RequestMetadata(metadataURL, ec2metadata.SpotInstanceActionPath)
+func checkForSpotInterruptionNotice(imds *ec2metadata.EC2MetadataService) (*DrainEvent, error) {
+	resp, err := imds.Request(ec2metadata.SpotInstanceActionPath)
+	if resp != nil && resp.StatusCode == 404 {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, fmt.Errorf("Unable to parse metadata response: %w", err)
 	}
 	defer resp.Body.Close()
 
-	// If there are no spot interruption events, an http 404 will be sent
-	if resp.StatusCode == 404 {
-		return nil, nil
-	} else if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf("Received an http error code when querying for spot itn events: http %d", resp.StatusCode)
-	}
 	var instanceAction ec2metadata.InstanceAction
 	err = json.NewDecoder(resp.Body).Decode(&instanceAction)
 	if err != nil {

--- a/pkg/drainevent/spot-itn-event.go
+++ b/pkg/drainevent/spot-itn-event.go
@@ -41,9 +41,9 @@ func MonitorForSpotITNEvents(drainChan chan<- DrainEvent, cancelChan chan<- Drai
 
 // checkForSpotInterruptionNotice Checks EC2 instance metadata for a spot interruption termination notice
 func checkForSpotInterruptionNotice(imds *ec2metadata.EC2MetadataService) (*DrainEvent, error) {
-	instanceAction, ok, err := imds.GetSpotITNEvent()
-	// if there are no spot itns and no errors
-	if !ok && err == nil {
+	instanceAction, err := imds.GetSpotITNEvent()
+	if instanceAction == nil && err == nil {
+		// if there are no spot itns and no errors
 		return nil, nil
 	}
 	if err != nil {

--- a/pkg/drainevent/spot-itn-event_test.go
+++ b/pkg/drainevent/spot-itn-event_test.go
@@ -117,7 +117,7 @@ func TestMonitorForSpotITNEvents404Response(t *testing.T) {
 	imds := ec2metadata.New(server.URL, 1)
 
 	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, imds)
-	h.Assert(t, true, "Failed to return error when 404 response", err != nil)
+	h.Ok(t, err)
 }
 
 func TestMonitorForSpotITNEvents500Response(t *testing.T) {

--- a/pkg/drainevent/spot-itn-event_test.go
+++ b/pkg/drainevent/spot-itn-event_test.go
@@ -20,17 +20,18 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-node-termination-handler/pkg/config"
 	"github.com/aws/aws-node-termination-handler/pkg/drainevent"
 	"github.com/aws/aws-node-termination-handler/pkg/ec2metadata"
 	h "github.com/aws/aws-node-termination-handler/pkg/test"
 )
 
-var eventId = "12345678-1234-1234-1234-123456789012"
-var startTime = "2017-09-18T08:22:00Z"
-var expFormattedTime = "2017-09-18 08:22:00 +0000 UTC"
-var instanceId = 12345
-var instanceAction = "INSTANCE_ACTION"
+const (
+	eventId          = "12345678-1234-1234-1234-123456789012"
+	startTime        = "2017-09-18T08:22:00Z"
+	expFormattedTime = "2017-09-18 08:22:00 +0000 UTC"
+	instanceId       = 12345
+	instanceAction   = "INSTANCE_ACTION"
+)
 
 var instanceActionResponse = []byte(`{
     "version": "0",
@@ -51,6 +52,10 @@ func TestMonitorForSpotITNEventsSuccess(t *testing.T) {
 	var requestPath string = ec2metadata.SpotInstanceActionPath
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if imdsV2TokenPath == req.URL.String() {
+			rw.WriteHeader(403)
+			return
+		}
 		h.Equals(t, req.URL.String(), requestPath)
 		rw.Write(instanceActionResponse)
 	}))
@@ -58,9 +63,7 @@ func TestMonitorForSpotITNEventsSuccess(t *testing.T) {
 
 	drainChan := make(chan drainevent.DrainEvent)
 	cancelChan := make(chan drainevent.DrainEvent)
-	nthConfig := config.Config{
-		MetadataURL: server.URL,
-	}
+	imds := ec2metadata.New(server.URL, 1)
 
 	go func() {
 		result := <-drainChan
@@ -75,22 +78,24 @@ func TestMonitorForSpotITNEventsSuccess(t *testing.T) {
 			strings.Contains(result.Description, startTime))
 	}()
 
-	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, nthConfig)
+	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, imds)
 	h.Ok(t, err)
 }
 
 func TestMonitorForSpotITNEventsMetadataParseFailure(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if imdsV2TokenPath == req.URL.String() {
+			rw.WriteHeader(403)
+			return
+		}
 	}))
 	defer server.Close()
 
 	drainChan := make(chan drainevent.DrainEvent)
 	cancelChan := make(chan drainevent.DrainEvent)
-	nthConfig := config.Config{
-		MetadataURL: "Bad url",
-	}
+	imds := ec2metadata.New(server.URL, 1)
 
-	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, nthConfig)
+	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, imds)
 	h.Assert(t, true, "Failed to return error metadata parse fails", err != nil)
 }
 
@@ -98,6 +103,10 @@ func TestMonitorForSpotITNEvents404Response(t *testing.T) {
 	var requestPath string = ec2metadata.SpotInstanceActionPath
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if imdsV2TokenPath == req.URL.String() {
+			rw.WriteHeader(403)
+			return
+		}
 		h.Equals(t, req.URL.String(), requestPath)
 		http.Error(rw, "error", http.StatusNotFound)
 	}))
@@ -105,11 +114,9 @@ func TestMonitorForSpotITNEvents404Response(t *testing.T) {
 
 	drainChan := make(chan drainevent.DrainEvent)
 	cancelChan := make(chan drainevent.DrainEvent)
-	nthConfig := config.Config{
-		MetadataURL: server.URL,
-	}
+	imds := ec2metadata.New(server.URL, 1)
 
-	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, nthConfig)
+	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, imds)
 	h.Assert(t, true, "Failed to return error when 404 response", err != nil)
 }
 
@@ -117,6 +124,10 @@ func TestMonitorForSpotITNEvents500Response(t *testing.T) {
 	var requestPath string = ec2metadata.SpotInstanceActionPath
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if imdsV2TokenPath == req.URL.String() {
+			rw.WriteHeader(403)
+			return
+		}
 		h.Equals(t, req.URL.String(), requestPath)
 		http.Error(rw, "error", http.StatusInternalServerError)
 	}))
@@ -124,11 +135,9 @@ func TestMonitorForSpotITNEvents500Response(t *testing.T) {
 
 	drainChan := make(chan drainevent.DrainEvent)
 	cancelChan := make(chan drainevent.DrainEvent)
-	nthConfig := config.Config{
-		MetadataURL: server.URL,
-	}
+	imds := ec2metadata.New(server.URL, 1)
 
-	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, nthConfig)
+	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, imds)
 	h.Assert(t, true, "Failed to return error when 500 response", err != nil)
 }
 
@@ -136,6 +145,10 @@ func TestMonitorForSpotITNEventsInstanceActionDecodeFailure(t *testing.T) {
 	var requestPath string = ec2metadata.SpotInstanceActionPath
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if imdsV2TokenPath == req.URL.String() {
+			rw.WriteHeader(403)
+			return
+		}
 		h.Equals(t, req.URL.String(), requestPath)
 		rw.Write([]byte{0x7f})
 	}))
@@ -143,11 +156,9 @@ func TestMonitorForSpotITNEventsInstanceActionDecodeFailure(t *testing.T) {
 
 	drainChan := make(chan drainevent.DrainEvent)
 	cancelChan := make(chan drainevent.DrainEvent)
-	nthConfig := config.Config{
-		MetadataURL: server.URL,
-	}
+	imds := ec2metadata.New(server.URL, 1)
 
-	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, nthConfig)
+	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, imds)
 	h.Assert(t, true, "Failed to return error when failed to decode instance action", err != nil)
 }
 
@@ -155,6 +166,10 @@ func TestMonitorForSpotITNEventsTimeParseFailure(t *testing.T) {
 	var requestPath string = ec2metadata.SpotInstanceActionPath
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if imdsV2TokenPath == req.URL.String() {
+			rw.WriteHeader(403)
+			return
+		}
 		h.Equals(t, req.URL.String(), requestPath)
 		rw.Write([]byte(`{"time": ""}`))
 	}))
@@ -162,10 +177,8 @@ func TestMonitorForSpotITNEventsTimeParseFailure(t *testing.T) {
 
 	drainChan := make(chan drainevent.DrainEvent)
 	cancelChan := make(chan drainevent.DrainEvent)
-	nthConfig := config.Config{
-		MetadataURL: server.URL,
-	}
+	imds := ec2metadata.New(server.URL, 1)
 
-	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, nthConfig)
+	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, imds)
 	h.Assert(t, true, "Failed to return error when failed to parse time", err != nil)
 }

--- a/pkg/ec2metadata/ec2metadata.go
+++ b/pkg/ec2metadata/ec2metadata.go
@@ -14,9 +14,13 @@
 package ec2metadata
 
 import (
+	"fmt"
+	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
+	"strconv"
+	"sync"
 	"time"
 )
 
@@ -25,7 +29,24 @@ const (
 	SpotInstanceActionPath = "/latest/meta-data/spot/instance-action"
 	// ScheduledEventPath is the context path to events/maintenance/scheduled within IMDS
 	ScheduledEventPath = "/latest/meta-data/events/maintenance/scheduled"
+
+	// IMDSv2 token related constants
+	tokenRefreshPath        = "/latest/api/token"
+	tokenTTLHeader          = "X-aws-ec2-metadata-token-ttl-seconds"
+	tokenRequestHeader      = "X-aws-ec2-metadata-token"
+	tokenTTL                = 3600 // 1 hour
+	secondsBeforeTTLRefresh = 15
 )
+
+// EC2MetadataService is used to query the EC2 instance metadata service v1 and v2
+type EC2MetadataService struct {
+	httpClient  http.Client
+	tries       int
+	metadataURL string
+	v2Token     string
+	tokenTTL    int
+	sync.RWMutex
+}
 
 // [
 //   {
@@ -67,12 +88,96 @@ type InstanceAction struct {
 	Detail     InstanceActionDetail `json:"detail"`
 }
 
-// RequestMetadata sends an http request to IMDS at the specified path using the specified URL
-func RequestMetadata(metadataURL string, contextPath string) (*http.Response, error) {
-	httpReq := func() (*http.Response, error) {
-		return http.Get(metadataURL + contextPath)
+// New constructs an instance of the EC2MetadataService client
+func New(metadataURL string, tries int) *EC2MetadataService {
+	return &EC2MetadataService{
+		metadataURL: metadataURL,
+		tries:       tries,
+		httpClient:  http.Client{},
 	}
-	return retry(3, 2*time.Second, httpReq)
+}
+
+// Request sends an http request to IMDSv1 or v2 at the specified path
+func (e *EC2MetadataService) Request(contextPath string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, e.metadataURL+contextPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to construct an http get request to IDMS for %s: %w", e.metadataURL+contextPath, err)
+	}
+	if e.v2Token == "" || e.tokenTTL <= secondsBeforeTTLRefresh {
+		e.Lock()
+		token, ttl, err := e.getV2Token()
+		if err != nil {
+			e.v2Token = ""
+			e.tokenTTL = -1
+			log.Printf("Unable to retrieve an IMDSv2 token, continuing with IMDSv1: %v", err)
+		} else {
+			e.v2Token = token
+			e.tokenTTL = ttl
+		}
+		e.Unlock()
+	}
+	if e.v2Token != "" {
+		req.Header.Add(tokenRequestHeader, e.v2Token)
+	}
+	httpReq := func() (*http.Response, error) {
+		return e.httpClient.Do(req)
+	}
+	resp, err := retry(e.tries, 2*time.Second, httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to get a response from IMDS: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("Unable to request metadata, received http status code: %d", resp.StatusCode)
+	}
+	ttl, err := ttlHeaderToInt(resp)
+	if err == nil {
+		e.Lock()
+		e.tokenTTL = ttl
+		e.Unlock()
+	}
+	return resp, nil
+}
+
+func (e *EC2MetadataService) getV2Token() (string, int, error) {
+	req, err := http.NewRequest(http.MethodPut, e.metadataURL+tokenRefreshPath, nil)
+	if err != nil {
+		return "", -1, fmt.Errorf("Unable to construct http put request to retrieve imdsv2 token: %w", err)
+	}
+	req.Header.Add(tokenTTLHeader, strconv.Itoa(tokenTTL))
+	httpReq := func() (*http.Response, error) {
+		return e.httpClient.Do(req)
+	}
+	log.Println("Trying to get token from IMDSv2")
+	resp, err := retry(1, 2*time.Second, httpReq)
+	if err != nil {
+		return "", -1, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", -1, fmt.Errorf("Received an http status code %d", resp.StatusCode)
+	}
+	token, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", -1, fmt.Errorf("Unable to read token response from IMDSv2: %w", err)
+	}
+	ttl, err := ttlHeaderToInt(resp)
+	if err != nil {
+		return "", -1, fmt.Errorf("IMDS v2 Token TTL header not sent in response: %w", err)
+	}
+	log.Println("Got token from IMDSv2")
+	return string(token), ttl, nil
+}
+
+func ttlHeaderToInt(resp *http.Response) (int, error) {
+	ttl := resp.Header.Get(tokenTTLHeader)
+	if ttl == "" {
+		return -1, fmt.Errorf("No token TTL header found")
+	}
+	ttlInt, err := strconv.Atoi(ttl)
+	if err != nil {
+		return -1, err
+	}
+	return ttlInt, nil
 }
 
 func retry(attempts int, sleep time.Duration, httpReq func() (*http.Response, error)) (*http.Response, error) {

--- a/pkg/ec2metadata/ec2metadata_test.go
+++ b/pkg/ec2metadata/ec2metadata_test.go
@@ -23,20 +23,25 @@ import (
 	h "github.com/aws/aws-node-termination-handler/pkg/test"
 )
 
-func TestRequestMetadata(t *testing.T) {
+func TestRequestV1(t *testing.T) {
 	var requestPath string = "/some/path"
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() == "/latest/api/token" {
+			rw.WriteHeader(401)
+			return
+		}
 		h.Equals(t, req.URL.String(), requestPath)
 		rw.Write([]byte(`OK`))
 	}))
 	defer server.Close()
 
-	// Use Client & URL from our local test server
-	resp, err := ec2metadata.RequestMetadata(server.URL, requestPath)
-	defer resp.Body.Close()
+	// Use URL from our local test server
+	imds := ec2metadata.New(server.URL, 1)
 
+	resp, err := imds.Request(requestPath)
 	h.Ok(t, err)
+	defer resp.Body.Close()
 	h.Equals(t, http.StatusOK, resp.StatusCode)
 
 	responseData, err := ioutil.ReadAll(resp.Body)
@@ -45,4 +50,72 @@ func TestRequestMetadata(t *testing.T) {
 	}
 
 	h.Equals(t, []byte("OK"), responseData)
+}
+
+func TestRequestV2(t *testing.T) {
+	var requestPath string = "/some/path"
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Add("X-aws-ec2-metadata-token-ttl-seconds", "100")
+		if req.URL.String() == "/latest/api/token" {
+			rw.WriteHeader(200)
+			rw.Write([]byte(`token`))
+			return
+		}
+		h.Equals(t, req.Header.Get("X-aws-ec2-metadata-token"), "token")
+		h.Equals(t, req.URL.String(), requestPath)
+		rw.Write([]byte(`OK`))
+	}))
+	defer server.Close()
+
+	// Use URL from our local test server
+	imds := ec2metadata.New(server.URL, 1)
+
+	resp, err := imds.Request(requestPath)
+	h.Ok(t, err)
+	defer resp.Body.Close()
+	h.Equals(t, http.StatusOK, resp.StatusCode)
+
+	responseData, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Error("Unable to parse response.")
+	}
+
+	h.Equals(t, []byte("OK"), responseData)
+}
+
+func TestRequestFailure(t *testing.T) {
+	var requestPath string = "/some/path"
+	imds := ec2metadata.New("notadomain", 1)
+
+	_, err := imds.Request(requestPath)
+	h.Assert(t, err != nil, "imds request failed")
+}
+
+func TestRequest500(t *testing.T) {
+	var requestPath string = "/some/path"
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.String() == "/latest/api/token" {
+			rw.WriteHeader(401)
+			return
+		}
+		h.Equals(t, req.URL.String(), requestPath)
+		rw.WriteHeader(500)
+	}))
+	defer server.Close()
+
+	// Use URL from our local test server
+	imds := ec2metadata.New(server.URL, 1)
+
+	_, err := imds.Request(requestPath)
+	h.Assert(t, err != nil, "imds request failed")
+}
+
+func TestRequestConstructFail(t *testing.T) {
+	// Use URL from our local test server
+	imds := ec2metadata.New("test", 0)
+
+	_, err := imds.Request(string([]byte{0x7f}))
+	h.Assert(t, err != nil, "imds request failed")
 }

--- a/pkg/ec2metadata/ec2metadata_test.go
+++ b/pkg/ec2metadata/ec2metadata_test.go
@@ -14,6 +14,7 @@
 package ec2metadata_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -108,14 +109,262 @@ func TestRequest500(t *testing.T) {
 	// Use URL from our local test server
 	imds := ec2metadata.New(server.URL, 1)
 
-	_, err := imds.Request(requestPath)
-	h.Assert(t, err != nil, "imds request failed")
+	resp, err := imds.Request(requestPath)
+	h.Ok(t, err)
+	h.Equals(t, 500, resp.StatusCode)
 }
 
 func TestRequestConstructFail(t *testing.T) {
-	// Use URL from our local test server
 	imds := ec2metadata.New("test", 0)
 
 	_, err := imds.Request(string([]byte{0x7f}))
 	h.Assert(t, err != nil, "imds request failed")
+}
+
+func TestGetSpotITNEventSuccess(t *testing.T) {
+	const (
+		version        = "0"
+		id             = "12345678-1234-1234-1234-123456789012"
+		detailType     = "EC2 Spot Instance Interruption Warning"
+		source         = "aws.ec2"
+		account        = "123456789012"
+		time           = "2020-02-07T14:55:55Z"
+		region         = "us-east-2"
+		resource       = "arn:aws:ec2:us-east-2:123456789012:instance/i-1234567890abcdef0"
+		instanceAction = "terminate"
+		instanceId     = "i-1234567890abcdef0"
+	)
+	var requestPath string = "/latest/meta-data/spot/instance-action"
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Add("X-aws-ec2-metadata-token-ttl-seconds", "100")
+		if req.URL.String() == "/latest/api/token" {
+			rw.WriteHeader(200)
+			rw.Write([]byte(`token`))
+			return
+		}
+		h.Equals(t, req.Header.Get("X-aws-ec2-metadata-token"), "token")
+		h.Equals(t, req.URL.String(), requestPath)
+		rw.Write([]byte(fmt.Sprintf(`{
+			"version": "%s",
+			"id": "%s",
+			"detail-type": "%s",
+			"source": "%s",
+			"account": "%s",
+			"time": "%s",
+			"region": "%s",
+			"resources": ["%s"],
+			"detail": {
+				"instance-id": "%s",
+				"instance-action": "%s"
+			}
+		}`, version, id, detailType, source, account, time, region, resource, instanceId, instanceAction)))
+	}))
+	defer server.Close()
+
+	expectedStruct := &ec2metadata.InstanceAction{
+		Version:    version,
+		Id:         id,
+		DetailType: detailType,
+		Source:     source,
+		Account:    account,
+		Time:       time,
+		Region:     region,
+		Resources:  []string{resource},
+		Detail: ec2metadata.InstanceActionDetail{
+			InstanceId:     instanceId,
+			InstanceAction: instanceAction,
+		},
+	}
+
+	// Use URL from our local test server
+	imds := ec2metadata.New(server.URL, 1)
+
+	spotITN, err := imds.GetSpotITNEvent()
+	h.Ok(t, err)
+	h.Equals(t, expectedStruct, spotITN)
+}
+
+func TestGetSpotITNEvent404Success(t *testing.T) {
+	var requestPath string = "/latest/meta-data/spot/instance-action"
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Add("X-aws-ec2-metadata-token-ttl-seconds", "100")
+		if req.URL.String() == "/latest/api/token" {
+			rw.WriteHeader(200)
+			rw.Write([]byte(`token`))
+			return
+		}
+		h.Equals(t, req.Header.Get("X-aws-ec2-metadata-token"), "token")
+		h.Equals(t, req.URL.String(), requestPath)
+		rw.WriteHeader(404)
+	}))
+	defer server.Close()
+
+	// Use URL from our local test server
+	imds := ec2metadata.New(server.URL, 1)
+
+	spotITN, err := imds.GetSpotITNEvent()
+	h.Ok(t, err)
+	h.Assert(t, spotITN == nil, "SpotITN Event should be nil")
+}
+
+func TestGetSpotITNEventBadJSON(t *testing.T) {
+	var requestPath string = "/latest/meta-data/spot/instance-action"
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Add("X-aws-ec2-metadata-token-ttl-seconds", "100")
+		if req.URL.String() == "/latest/api/token" {
+			rw.WriteHeader(200)
+			rw.Write([]byte(`token`))
+			return
+		}
+		h.Equals(t, req.Header.Get("X-aws-ec2-metadata-token"), "token")
+		h.Equals(t, req.URL.String(), requestPath)
+		rw.Write([]byte(`{"version": false}`))
+	}))
+	defer server.Close()
+
+	// Use URL from our local test server
+	imds := ec2metadata.New(server.URL, 1)
+
+	_, err := imds.GetSpotITNEvent()
+	h.Assert(t, err != nil, "JSON returned should not be in the correct format")
+}
+
+func TestGetSpotITNEvent500Failure(t *testing.T) {
+	var requestPath string = "/latest/meta-data/spot/instance-action"
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Add("X-aws-ec2-metadata-token-ttl-seconds", "100")
+		if req.URL.String() == "/latest/api/token" {
+			rw.WriteHeader(200)
+			rw.Write([]byte(`token`))
+			return
+		}
+		h.Equals(t, req.Header.Get("X-aws-ec2-metadata-token"), "token")
+		h.Equals(t, req.URL.String(), requestPath)
+		rw.WriteHeader(500)
+	}))
+	defer server.Close()
+
+	// Use URL from our local test server
+	imds := ec2metadata.New(server.URL, 1)
+
+	_, err := imds.GetSpotITNEvent()
+	h.Assert(t, err != nil, "error expected on non-200 or non-404 status code")
+}
+
+func TestGetSpotITNEventRequestFailure(t *testing.T) {
+	// Use URL from our local test server
+	imds := ec2metadata.New("/some-path-that-will-error", 1)
+
+	_, err := imds.GetSpotITNEvent()
+	h.Assert(t, err != nil, "error expected because no server should be running")
+}
+
+func TestGetScheduledMaintenanceEventsSuccess(t *testing.T) {
+	const (
+		notBefore   = "21 Jan 2019 09:00:43 GMT"
+		notAfter    = "21 Jan 2019 09:17:23 GMT"
+		code        = "system-reboot"
+		description = "scheduled reboot"
+		eventId     = "instance-event-0d59937288b749b32"
+		state       = "active"
+	)
+	var requestPath string = "/latest/meta-data/events/maintenance/scheduled"
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Add("X-aws-ec2-metadata-token-ttl-seconds", "100")
+		if req.URL.String() == "/latest/api/token" {
+			rw.WriteHeader(200)
+			rw.Write([]byte(`token`))
+			return
+		}
+		h.Equals(t, req.Header.Get("X-aws-ec2-metadata-token"), "token")
+		h.Equals(t, req.URL.String(), requestPath)
+		rw.Write([]byte(fmt.Sprintf(`[ 
+			{
+			  "NotBefore" : "%s",
+			  "Code" : "%s",
+			  "Description" : "%s",
+			  "EventId" : "%s",
+			  "NotAfter" : "%s",
+			  "State" : "%s"
+			} 
+		  ]`, notBefore, code, description, eventId, notAfter, state)))
+	}))
+	defer server.Close()
+
+	expectedStructs := []ec2metadata.ScheduledEventDetail{
+		ec2metadata.ScheduledEventDetail{
+			NotBefore:   notBefore,
+			Code:        code,
+			Description: description,
+			EventID:     eventId,
+			NotAfter:    notAfter,
+			State:       state,
+		},
+	}
+
+	// Use URL from our local test server
+	imds := ec2metadata.New(server.URL, 1)
+
+	maintenanceEvents, err := imds.GetScheduledMaintenanceEvents()
+	h.Ok(t, err)
+	h.Equals(t, expectedStructs, maintenanceEvents)
+}
+
+func TestGetScheduledMaintenanceEvents500Failure(t *testing.T) {
+	var requestPath string = "/latest/meta-data/events/maintenance/scheduled"
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Add("X-aws-ec2-metadata-token-ttl-seconds", "100")
+		if req.URL.String() == "/latest/api/token" {
+			rw.WriteHeader(200)
+			rw.Write([]byte(`token`))
+			return
+		}
+		h.Equals(t, req.Header.Get("X-aws-ec2-metadata-token"), "token")
+		h.Equals(t, req.URL.String(), requestPath)
+		rw.WriteHeader(500)
+	}))
+	defer server.Close()
+
+	// Use URL from our local test server
+	imds := ec2metadata.New(server.URL, 1)
+
+	_, err := imds.GetScheduledMaintenanceEvents()
+	h.Assert(t, err != nil, "error expected on non-200 status code")
+}
+
+func TestGetScheduledMaintenanceEventsBadJSON(t *testing.T) {
+	var requestPath string = "/latest/meta-data/events/maintenance/scheduled"
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Add("X-aws-ec2-metadata-token-ttl-seconds", "100")
+		if req.URL.String() == "/latest/api/token" {
+			rw.WriteHeader(200)
+			rw.Write([]byte(`token`))
+			return
+		}
+		h.Equals(t, req.Header.Get("X-aws-ec2-metadata-token"), "token")
+		h.Equals(t, req.URL.String(), requestPath)
+		rw.Write([]byte(`{"notBefore": false}`))
+	}))
+	defer server.Close()
+
+	// Use URL from our local test server
+	imds := ec2metadata.New(server.URL, 1)
+
+	_, err := imds.GetScheduledMaintenanceEvents()
+	h.Assert(t, err != nil, "JSON returned should not be in the correct format")
+}
+
+func TestGetScheduledMaintenanceEventsRequestFailure(t *testing.T) {
+	// Use URL from our local test server
+	imds := ec2metadata.New("/some-path-that-will-error", 1)
+
+	_, err := imds.GetScheduledMaintenanceEvents()
+	h.Assert(t, err != nil, "error expected because no server should be running")
 }

--- a/test/e2e/imds-v2-test
+++ b/test/e2e/imds-v2-test
@@ -10,46 +10,42 @@ set -euo pipefail
 #   $EC2_METADATA_DOCKER_REPO
 #   $EC2_METADATA_DOCKER_TAG
 
-echo "Starting Webhook Test for Node Termination Handler"
+echo "Starting IMDSv2 Test for Node Termination Handler"
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-### LOCAL ONLY TESTS FOR 200 RESPONSE FROM LOCAL CLUSTER, MASTER WILL TEST WITH TRAVIS SECRET URL
-if [[ -z $(env | grep "WEBHOOK_URL=") ]]; then
-  WEBHOOK_URL="http://localhost:$IMDS_PORT"
-fi
-
 helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ \
-  --wait \
   --force \
   --namespace kube-system \
   --set instanceMetadataURL="http://localhost:$IMDS_PORT" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
-  --set webhookURL="$WEBHOOK_URL" \
   --set enableSpotInterruptionDraining="true" \
   --set enableScheduledEventDraining="true"
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
-  --wait \
   --force \
   --namespace default \
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
+  --set ec2MetadataTestProxy.enableSpotITN="true" \
+  --set ec2MetadataTestProxy.enableScheduledMaintenanceEvents="true" \
+  --set ec2MetadataTestProxy.enableIMDSV2="true" \
   --set ec2MetadataTestProxy.port="$IMDS_PORT"
 
 TAINT_CHECK_CYCLES=15
 TAINT_CHECK_SLEEP=15
 
 DEPLOYED=0
-for i in `seq 1 10`; do
+
+for i in `seq 1 10`; do 
     if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
         echo "✅ Verified regular-pod-test pod was scheduled and started!"
         DEPLOYED=1
         break
     fi
     sleep 5
-done
+done 
 
 if [[ $DEPLOYED -eq 0 ]]; then
     exit 2
@@ -58,10 +54,9 @@ fi
 for i in `seq 1 $TAINT_CHECK_CYCLES`; do
       if kubectl get nodes $CLUSTER_NAME-worker | grep SchedulingDisabled; then
           echo "✅ Verified the worker node was cordoned!"
-          NTH_POD_NAME=$(kubectl get pods -n kube-system -o json | jq '.items[] | select( .metadata.name | contains("node-termination-handler") ) | .metadata.name' -r | head -n 1)
-          if kubectl logs $NTH_POD_NAME -n kube-system | grep 'Webhook Success'; then
-              echo "✅ Verified the webhook message was sent!"
-              echo "✅ Webhook Test Passed $CLUSTER_NAME! ✅"
+          if [[ $(kubectl get deployments regular-pod-test -o=jsonpath='{.status.unavailableReplicas}') -eq 1 ]]; then
+              echo "✅ Verified the regular-pod-test pod was evicted!"
+              echo "✅ IMDSv2 Test Passed $CLUSTER_NAME! ✅"
               exit 0
           fi
       fi

--- a/test/e2e/maintenance-event-cancellation-test
+++ b/test/e2e/maintenance-event-cancellation-test
@@ -18,7 +18,7 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --wait \
   --force \
   --namespace kube-system \
-  --set instanceMetadataURL="http://localhost:1338" \
+  --set instanceMetadataURL="http://localhost:$IMDS_PORT" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
   --set enableSpotInterruptionDraining="true" \
@@ -31,7 +31,8 @@ helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-meta
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
   --set ec2MetadataTestProxy.enableScheduledMaintenanceEvents="true" \
-  --set ec2MetadataTestProxy.enableSpotITN="false"
+  --set ec2MetadataTestProxy.enableSpotITN="false" \
+  --set ec2MetadataTestProxy.port="$IMDS_PORT"
 
 TAINT_CHECK_CYCLES=15
 TAINT_CHECK_SLEEP=15
@@ -78,7 +79,8 @@ helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-meta
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
   --set ec2MetadataTestProxy.enableScheduledMaintenanceEvents="true" \
   --set ec2MetadataTestProxy.enableSpotITN="false" \
-  --set ec2MetadataTestProxy.scheduledEventStatus="cancelled"
+  --set ec2MetadataTestProxy.scheduledEventStatus="cancelled" \
+  --set ec2MetadataTestProxy.port="$IMDS_PORT"    
 
 for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     if kubectl get nodes $CLUSTER_NAME-worker --no-headers | grep -v SchedulingDisabled; then

--- a/test/e2e/maintenance-event-dry-run-test
+++ b/test/e2e/maintenance-event-dry-run-test
@@ -18,7 +18,7 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --wait \
   --force \
   --namespace kube-system \
-  --set instanceMetadataURL="http://localhost:1339" \
+  --set instanceMetadataURL="http://localhost:$IMDS_PORT" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
   --set dryRun="true" \
@@ -31,7 +31,7 @@ helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-meta
   --namespace default \
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
-  --set ec2MetadataTestProxy.port=1339
+  --set ec2MetadataTestProxy.port="$IMDS_PORT"
 
 POD_ID=$(kubectl get pods --namespace kube-system | grep -i node-termination-handler | grep Running | cut -d' ' -f1)
 

--- a/test/e2e/maintenance-event-reboot-test
+++ b/test/e2e/maintenance-event-reboot-test
@@ -10,18 +10,11 @@ echo "Starting Maintenance Event Cancellation Test for Node Termination Handler"
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-NODE_TERMINATION_HANDLER_DOCKER_IMG=$(cat $TMP_DIR/nth-docker-img)
-NODE_TERMINATION_HANDLER_DOCKER_REPO=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f1)
-NODE_TERMINATION_HANDLER_DOCKER_TAG=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f2)
-EC2_METADATA_DOCKER_IMG=$(cat $TMP_DIR/ec2-metadata-test-proxy-docker-img)
-EC2_METADATA_DOCKER_REPO=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f1)
-EC2_METADATA_DOCKER_TAG=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f2)
-
 helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ \
   --wait \
   --force \
   --namespace kube-system \
-  --set instanceMetadataURL="http://localhost:1340" \
+  --set instanceMetadataURL="http://localhost:$IMDS_PORT" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
   --set enableSpotInterruptionDraining="true" \
@@ -35,7 +28,7 @@ helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-meta
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
   --set ec2MetadataTestProxy.enableScheduledMaintenanceEvents="true" \
   --set ec2MetadataTestProxy.enableSpotITN="false" \
-  --set ec2MetadataTestProxy.port=1340
+  --set ec2MetadataTestProxy.port="$IMDS_PORT"
 
 TAINT_CHECK_CYCLES=15
 TAINT_CHECK_SLEEP=15
@@ -87,7 +80,7 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --wait \
   --force \
   --namespace kube-system \
-  --set instanceMetadataURL="http://ec2-metadata-test-proxy.default.svc.cluster.local:1340" \
+  --set instanceMetadataURL="http://localhost:$IMDS_PORT" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
   --set procUptimeFile="/uptime" \

--- a/test/e2e/maintenance-event-test
+++ b/test/e2e/maintenance-event-test
@@ -18,7 +18,7 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --wait \
   --force \
   --namespace kube-system \
-  --set instanceMetadataURL="http://localhost:1341" \
+  --set instanceMetadataURL="http://localhost:$IMDS_PORT" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
   --set enableSpotInterruptionDraining="true" \
@@ -33,7 +33,7 @@ helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-meta
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
   --set ec2MetadataTestProxy.enableScheduledMaintenanceEvents="true" \
   --set ec2MetadataTestProxy.enableSpotITN="false" \
-  --set ec2MetadataTestProxy.port=1341
+  --set ec2MetadataTestProxy.port="$IMDS_PORT"
 
 TAINT_CHECK_CYCLES=15
 TAINT_CHECK_SLEEP=15

--- a/test/e2e/spot-interruption-dry-run-test
+++ b/test/e2e/spot-interruption-dry-run-test
@@ -18,7 +18,7 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --wait \
   --force \
   --namespace kube-system \
-  --set instanceMetadataURL="http://localhost:1342" \
+  --set instanceMetadataURL="http://localhost:$IMDS_PORT" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
   --set dryRun="true" \
@@ -31,7 +31,7 @@ helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-meta
   --namespace default \
   --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
-  --set ec2MetadataTestProxy.port=1342
+  --set ec2MetadataTestProxy.port="$IMDS_PORT"
 
 POD_ID=$(kubectl get pods --namespace kube-system | grep -i node-termination-handler | grep Running | cut -d' ' -f1)
 

--- a/test/e2e/spot-interruption-test
+++ b/test/e2e/spot-interruption-test
@@ -18,13 +18,11 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --wait \
   --force \
   --namespace kube-system \
-  --set instanceMetadataURL="http://localhost:1343" \
+  --set instanceMetadataURL="http://localhost:$IMDS_PORT" \
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
-  --set enableSpotInterruptionDraining="true" \
   --set enableScheduledEventDraining="false" \
-  --set enableSpotInterruptionDraining="true" \
-  --set enableScheduledEventDraining="true"
+  --set enableSpotInterruptionDraining="true" 
 
 helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
   --wait \
@@ -34,7 +32,7 @@ helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-meta
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
   --set ec2MetadataTestProxy.enableSpotITN="true" \
   --set ec2MetadataTestProxy.enableScheduledMaintenanceEvents="false" \
-  --set ec2MetadataTestProxy.port=1343
+  --set ec2MetadataTestProxy.port="$IMDS_PORT"
 
 TAINT_CHECK_CYCLES=15
 TAINT_CHECK_SLEEP=15

--- a/test/ec2-metadata-test-proxy/cmd/ec2-metadata-test-proxy.go
+++ b/test/ec2-metadata-test-proxy/cmd/ec2-metadata-test-proxy.go
@@ -41,6 +41,11 @@ const (
 	scheduledMaintenanceEventPath    = "/latest/meta-data/events/maintenance/scheduled"
 	scheduledEventStatusConfigKey    = "SCHEDULED_EVENT_STATUS"
 	scheduledEventStatusDefault      = "active"
+	imdsV2TokenPath                  = "/latest/api/token"
+	imdsV2ConfigKey                  = "ENABLE_IMDS_V2"
+	imdsV2Token                      = "token"
+	tokenTTLHeader                   = "X-aws-ec2-metadata-token-ttl-seconds"
+	tokenRequestHeader               = "X-aws-ec2-metadata-token"
 )
 
 var startTime int64 = time.Now().Unix()
@@ -112,9 +117,34 @@ func handleRequest(res http.ResponseWriter, req *http.Request) {
 		interruptionDelay, _ = strconv.Atoi(interruptionNoticeDelayDefault)
 	}
 	interruptionDelayRemaining := int64(interruptionDelay) - (requestTime - startTime)
+	isV2Enabled, _ := strconv.ParseBool(getEnv(imdsV2ConfigKey, "false"))
+	if isV2Enabled {
+		log.Println("IMDSv2 is ENABLED! This means v1 API will not work.")
+		res.Header().Add(tokenTTLHeader, "1000")
+	} else {
+		log.Println("IMDSv2 is NOT enabled!")
+	}
+
+	if req.URL.Path == imdsV2TokenPath && isV2Enabled {
+		if req.Method != http.MethodPut {
+			res.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		log.Println("Received IMDSv2 token")
+		res.Write([]byte(imdsV2Token))
+		return
+	}
+
 	if interruptionDelayRemaining > 0 {
 		log.Printf("Interruption Notice Delay (%ds  will expire in %ds) has not been reached yet, passing through to metadata", interruptionDelay, interruptionDelayRemaining)
 	} else if req.URL.Path == spotInstanceActionPath {
+		log.Println("Handling Spot Instance Action Path")
+		if isV2Enabled {
+			if !isTokenValid(req) {
+				res.WriteHeader(http.StatusForbidden)
+				return
+			}
+		}
 		if !isPathEnabled(spotInstanceActionFlag) {
 			http.Error(res, "ec2-metadata-test-proxy feature not enabled", http.StatusNotFound)
 			return
@@ -140,6 +170,13 @@ func handleRequest(res http.ResponseWriter, req *http.Request) {
 		res.Write(js)
 		return
 	} else if req.URL.Path == scheduledMaintenanceEventPath {
+		log.Println("Handling Scheduled Maintenance Events Path")
+		if isV2Enabled {
+			if !isTokenValid(req) {
+				res.WriteHeader(http.StatusForbidden)
+				return
+			}
+		}
 		if !isPathEnabled(scheduledMaintenanceEventFlag) {
 			http.Error(res, "ec2-metadata-test-proxy feature not enabled", http.StatusNotFound)
 			return
@@ -176,6 +213,15 @@ func handleRequest(res http.ResponseWriter, req *http.Request) {
 	res.Header().Set("Content-Type", "application/json")
 	res.Write([]byte("{}"))
 	return
+}
+
+func isTokenValid(req *http.Request) bool {
+	token := req.Header.Get("X-aws-ec2-metadata-token")
+	log.Printf("Token evaluation: header(%s) -> %s", token, imdsV2Token)
+	if token != imdsV2Token {
+		return false
+	}
+	return true
 }
 
 func main() {

--- a/test/ec2-metadata-test-proxy/cmd/ec2-metadata-test-proxy.go
+++ b/test/ec2-metadata-test-proxy/cmd/ec2-metadata-test-proxy.go
@@ -136,7 +136,9 @@ func handleRequest(res http.ResponseWriter, req *http.Request) {
 	}
 
 	if interruptionDelayRemaining > 0 {
-		log.Printf("Interruption Notice Delay (%ds  will expire in %ds) has not been reached yet, passing through to metadata", interruptionDelay, interruptionDelayRemaining)
+		log.Printf("Interruption Notice Delay (%ds  will expire in %ds) has not been reached yet", interruptionDelay, interruptionDelayRemaining)
+		res.WriteHeader(404)
+		return
 	} else if req.URL.Path == spotInstanceActionPath {
 		log.Println("Handling Spot Instance Action Path")
 		if isV2Enabled {

--- a/test/k8s-local-cluster-test/run-test
+++ b/test/k8s-local-cluster-test/run-test
@@ -28,13 +28,6 @@ function clean_up {
         $SCRIPTPATH/../k8s-local-cluster-test/delete-cluster $DELETE_CLUSTER_ARGS || :
         return 
     fi 
-    labels_to_remove=($(kubectl get nodes -o json | jq '.items[].metadata.labels' | grep 'aws-node-termination-handler' | tr -d '[:blank:]' | tr -d '\"' | cut -d':' -f1))
-    for l in "${labels_to_remove[@]}"; do 
-      for n in $(kubectl get nodes -o json | jq -r '.items[].metadata.name'); do
-        echo "Deleting label $l on node $n"
-        kubectl label node $n "$l"-
-      done
-    done
     echo "To resume test with the same cluster use: \"-c $TMP_DIR\""""
 }
 
@@ -48,6 +41,7 @@ function exit_and_fail {
 }
 
 function reset_cluster {
+    echo "Resetting cluster"
     charts=$(helm ls --all --short)
     if [[ ! -z "$charts" ]]; then 
         helm del $charts || :
@@ -59,7 +53,21 @@ function reset_cluster {
     for node in $(kubectl get nodes | tail -n+2 | cut -d' ' -f1); do 
         kubectl uncordon $node
     done 
+    remove_labels || :   
     sleep 2
+}
+
+function remove_labels {
+    echo "Removing labels from NTH cluster nodes"
+    labels_to_remove=($(kubectl get nodes -o json | jq '.items[].metadata.labels' | grep 'aws-node-termination-handler' | tr -d '[:blank:]' | tr -d '\"' | cut -d':' -f1))
+    if [[ "${#labels_to_remove[@]}" -ne 0 ]]; then
+      for l in "${labels_to_remove[@]}"; do 
+        for n in $(kubectl get nodes -o json | jq -r '.items[].metadata.name'); do
+          echo "Deleting label $l on node $n"
+          kubectl label node $n "$l"-
+        done
+      done
+    fi
 }
 
 USAGE=$(cat << 'EOM'
@@ -185,8 +193,11 @@ export EC2_METADATA_DOCKER_REPO=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f1)
 export EC2_METADATA_DOCKER_TAG=$(echo $EC2_METADATA_DOCKER_IMG | cut -d':' -f2)
 ###
 
+i=0
 for assert_script in $ASSERTION_SCRIPTS; do
   reset_cluster
+  export IMDS_PORT=$(expr $i + 1338)
+  i=$(expr $i + 1)
   echo "======================================================================================================"
   echo "🥑 Running assertion script $(basename $assert_script)"
   echo "======================================================================================================"
@@ -199,7 +210,7 @@ for assert_script in $ASSERTION_SCRIPTS; do
   ## Resets cluster to run another test on the same cluster
   reset_cluster
   echo "✅ Assertion test $assert_script PASSED! ✅"
-done 
+done
 
 echo "======================================================================================================"
 echo "✅ All tests passed! ✅"


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-node-termination-handler/issues/22

Description of changes:
Support IMDSv2 w/ an IMDSv1 fallback. There is no configuration since imdsv2 should always be favored, but will fallback to imdsv1 if there is an issue or if it's blocked due to a container hop if not configured with a TTL of 2. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
