### PR TITLE
Updating psp to support latest hostNetwork setting

### DIFF
--- a/config/helm/aws-node-termination-handler/templates/psp.yaml
+++ b/config/helm/aws-node-termination-handler/templates/psp.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   privileged: false
   hostIPC: false
-  hostNetwork: false
+  hostNetwork: true
   hostPID: false
   readOnlyRootFilesystem: false
   allowPrivilegeEscalation: false


### PR DESCRIPTION
Issue #, if available:
#74 
#85 

Description of changes:

With the latest changes to `hostNetwork`, podSecurityPolicy needs to allow that setting "`hostNetwork = true`"
