### PR TITLE
removing security context from chart and updating tag version

### DIFF
--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -62,11 +62,9 @@ Parameter | Description | Default
 `webhookHeaders` | Replaces the default webhook headers. | `{"Content-type":"application/json"}`
 `webhookTemplate` | Replaces the default webhook message template. | `{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} - State: {{ .State }} - Start Time: {{ .StartTime }}"}`
 `affinity` | node/pod affinities | None
-`podSecurityContext` | Pod Security Context | `{}`
 `podAnnotations` | annotations to add to each pod | `{}`
 `priorityClassName` | Name of the priorityClass | `system-node-critical`
 `resources` | Resources for the pods | `requests.cpu: 50m, requests.memory: 64Mi, limits.cpu: 100m, limits.memory: 128Mi`
-`securityContext` | Container Security context | `privileged: true`
 `nodeSelector` | Tells the daemon set where to place the node-termination-handler pods. For example: `lifecycle: "Ec2Spot"`, `on-demand: "false"`, `aws.amazon.com/purchaseType: "spot"`, etc. Value must be a valid yaml expression. | `{}`
 `tolerations` | list of node taints to tolerate | `[]`
 `rbac.create` | if `true`, create and use RBAC resources | `true`

--- a/config/helm/aws-node-termination-handler/templates/daemonset.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.yaml
@@ -97,8 +97,6 @@ spec:
             value: {{ .Values.enableScheduledEventDraining | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/config/helm/aws-node-termination-handler/templates/psp.yaml
+++ b/config/helm/aws-node-termination-handler/templates/psp.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   privileged: false
   hostIPC: false
-  hostNetwork: false
+  hostNetwork: true
   hostPID: false
   readOnlyRootFilesystem: false
   allowPrivilegeEscalation: false

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: amazon/aws-node-termination-handler
-  tag: v1.1.0
+  tag: v1.2.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""
@@ -12,12 +12,7 @@ fullnameOverride: ""
 
 priorityClassName: system-node-critical
 
-podSecurityContext: {}
-
 podAnnotations: {}
-
-securityContext:
-  privileged: true
 
 resources:
   requests:


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
podSecurityContext was in readme and values, but not in any chart, so i removed it
securityContext - privileged was set to true when it didnt need to be
values image.tag 1.1.0 -> 1.2.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
