### PR TITLE
Add standalone yaml templates and update docs

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -59,11 +59,11 @@ We use Kustomize to create a master Kubernetes yaml file. You can apply the base
 
 ```
 ## Apply base kustomize directly kubernetes
-kubectl apply -k $REPO_ROOT/config/base 
+kubectl apply -k $REPO_ROOT/config/base/deploy 
 
 ## OR apply an overlay specifying a node selector to run the daemonset only on spot instances
 ## This will use the base and add a node selector into the daemonset K8s object definition
-kubectl apply -k $REPO_ROOT/config/overlays/spot-node-selector 
+kubectl apply -k $REPO_ROOT/config/deploy/overlays/spot-node-selector 
 ```
 
 Read more about Kustomize and Overlays: https://kustomize.io

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ You can run the termination handler on any Kubernetes cluster running on AWS, in
 
 The termination handler installs into your cluster a [ServiceAccount](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/), [ClusterRole](https://kubernetes.io/docs/reference/access-authn-authz/rbac/), [ClusterRoleBinding](https://kubernetes.io/docs/reference/access-authn-authz/rbac/), and a [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/). All four of these Kubernetes constructs are required for the termination handler to run properly.
 
+### Helm
+
 The easiest way to install the termination handler is via [helm](https://helm.sh/).  The chart for this project is hosted in the [eks-charts](https://github.com/aws/eks-charts) repository.
 
 To get started you need to add the eks-charts repo to helm
@@ -91,6 +93,23 @@ helm upgrade --install aws-node-termination-handler \
 ```
 
 For a full list of configuration options see our [Helm readme](https://github.com/aws/eks-charts/tree/master/stable/aws-node-termination-handler).
+
+### Standalone YAML templates
+
+Standalone templates are useful in case you are not using Helm, but instead using for example [Flux](https://github.com/fluxcd/flux) (The GitOps Kubernetes operator).
+
+You can create and run all of these at once on your own Kubernetes cluster by running the following command:
+```
+kubectl apply -k https://github.com/aws/aws-node-termination-handler/config/deploy/base?ref=master
+```
+
+By default, the aws-node-termination-handler will run on all of your nodes (on-demand and spot). If your spot instances are labeled, you can configure aws-node-termination-handler to only run on your labeled spot nodes. If you're using the tag `lifecycle=Ec2Spot`, you can run the following to apply our spot-node-selector overlay:
+
+```
+kubectl apply -k 'https://github.com/aws/aws-node-termination-handler/config/deploy/overlays/spot-node-selector?ref=master'
+```
+
+If you're using a different key/value tag to label your spot nodes, you can write your own overlay to set a spot-node-selector while still receiving updates of the base kubernetes resource files. See our [spot-node-selector](https://github.com/aws/aws-node-termination-handler/tree/master/config/deploy/overlays/spot-node-selector) overlay for an example.
 
 ## Building
 For build instructions please consult [BUILD.md](./BUILD.md).

--- a/config/deploy/base/cluster-role-binding.yaml
+++ b/config/deploy/base/cluster-role-binding.yaml
@@ -1,0 +1,11 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: node-termination-handler
+subjects:
+- kind: ServiceAccount
+  name: node-termination-handler
+roleRef:
+  kind: ClusterRole
+  name: node-termination-handler
+  apiGroup: rbac.authorization.k8s.io

--- a/config/deploy/base/cluster-role.yaml
+++ b/config/deploy/base/cluster-role.yaml
@@ -1,0 +1,34 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: node-termination-handler
+rules:
+- apiGroups:
+  - "apps"
+  resources:
+  - "daemonsets"
+  verbs:
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete

--- a/config/deploy/base/daemonset.yaml
+++ b/config/deploy/base/daemonset.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: aws-node-termination-handler
+  name: aws-node-termination-handler
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: aws-node-termination-handler
+  template:
+    metadata:
+      labels:
+        app: aws-node-termination-handler
+    spec:
+      nodeSelector:
+        lifecycle: Ec2Spot
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+      containers:
+      - env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: SPOT_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: DELETE_LOCAL_DATA
+          value: "true"
+        - name: IGNORE_DAEMON_SETS
+          value: "true"
+        - name: NODE_TERMINATION_GRACE_PERIOD
+          value: "120"
+        - name: POD_TERMINATION_GRACE_PERIOD
+          value: "10"
+        image: amazon/aws-node-termination-handler:v1.2.0
+        imagePullPolicy: IfNotPresent
+        name: aws-node-termination-handler
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          privileged: true
+      dnsPolicy: ClusterFirst
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      serviceAccount: aws-node-termination-handler
+      serviceAccountName: aws-node-termination-handler
+      hostNetwork: true
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate

--- a/config/deploy/base/kustomization.yaml
+++ b/config/deploy/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+commonLabels:
+  app: node-termination-handler
+resources:
+- cluster-role.yaml
+- service-account.yaml
+- cluster-role-binding.yaml
+- daemonset.yaml

--- a/config/deploy/base/service-account.yaml
+++ b/config/deploy/base/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-termination-handler

--- a/config/deploy/overlays/spot-node-selector/daemonset-spot-node-selector.yaml
+++ b/config/deploy/overlays/spot-node-selector/daemonset-spot-node-selector.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-termination-handler
+spec:
+  template:
+    spec:
+      nodeSelector:
+        lifecycle: Ec2Spot

--- a/config/deploy/overlays/spot-node-selector/kustomization.yaml
+++ b/config/deploy/overlays/spot-node-selector/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../../base
+
+patchesStrategicMerge:
+  - daemonset-spot-node-selector.yaml


### PR DESCRIPTION
Description of changes:

Re-add standalone YAML templates that can used to deploy aws-node-termination-handler without using HELM. 

Personally, I am using Flux GitOps operator which deploys and syncs yaml templates for me and therefore I am not using helm at all.