### PR TITLE
enable PodSecurityPolicy admission controller on e2e test clusters

### DIFF
--- a/config/helm/ec2-metadata-test-proxy/templates/_helpers.tpl
+++ b/config/helm/ec2-metadata-test-proxy/templates/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ec2-metadata-test-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ec2-metadata-test-proxy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "ec2-metadata-test-proxy.labels" -}}
+app.kubernetes.io/name: {{ include "ec2-metadata-test-proxy.name" . }}
+helm.sh/chart: {{ include "ec2-metadata-test-proxy.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+k8s-app: ec2-metadata-test-proxy
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ec2-metadata-test-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ec2-metadata-test-proxy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "ec2-metadata-test-proxy.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/config/helm/ec2-metadata-test-proxy/templates/clusterrole.yaml
+++ b/config/helm/ec2-metadata-test-proxy/templates/clusterrole.yaml
@@ -1,0 +1,39 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "ec2-metadata-test-proxy.fullname" . }}
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - nodes
+  verbs:
+    - get
+    - patch
+    - update
+- apiGroups:
+    - ""
+  resources:
+    - pods
+  verbs:
+    - list
+- apiGroups:
+    - ""
+  resources:
+    - pods/eviction
+  verbs:
+    - create
+- apiGroups:
+    - extensions
+  resources:
+    - replicasets
+    - daemonsets
+  verbs:
+    - get
+- apiGroups:
+    - apps
+  resources:
+    - daemonsets
+  verbs:
+    - get
+    - delete

--- a/config/helm/ec2-metadata-test-proxy/templates/clusterrolebinding.yaml
+++ b/config/helm/ec2-metadata-test-proxy/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "ec2-metadata-test-proxy.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "ec2-metadata-test-proxy.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "ec2-metadata-test-proxy.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/config/helm/ec2-metadata-test-proxy/templates/daemonset.yaml
+++ b/config/helm/ec2-metadata-test-proxy/templates/daemonset.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: {{ .Values.ec2MetadataTestProxy.label }}
     spec:
+      serviceAccountName: {{ template "ec2-metadata-test-proxy.serviceAccountName" . }}
       hostNetwork: true
       containers:
       - name: {{ .Values.ec2MetadataTestProxy.label }}

--- a/config/helm/ec2-metadata-test-proxy/templates/psp.yaml
+++ b/config/helm/ec2-metadata-test-proxy/templates/psp.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "ec2-metadata-test-proxy.fullname" . }}
+  labels:
+{{ include "ec2-metadata-test-proxy.labels" . | indent 4 }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: false
+  hostIPC: false
+  hostNetwork: true
+  hostPorts:
+    - min: 1024
+      max: 65535
+  hostPID: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: false
+  allowedCapabilities:
+    - '*'
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - '*'
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "ec2-metadata-test-proxy.fullname" . }}-psp
+  labels:
+{{ include "ec2-metadata-test-proxy.labels" . | indent 4 }}
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+      - {{ template "ec2-metadata-test-proxy.fullname" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "ec2-metadata-test-proxy.fullname" . }}-psp
+  labels:
+{{ include "ec2-metadata-test-proxy.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "ec2-metadata-test-proxy.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "ec2-metadata-test-proxy.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/config/helm/ec2-metadata-test-proxy/templates/regular-pod-test.yaml
+++ b/config/helm/ec2-metadata-test-proxy/templates/regular-pod-test.yaml
@@ -14,6 +14,11 @@ spec:
       labels:
         app: {{ .Values.regularPodTest.label }}
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
+      serviceAccountName: {{ template "ec2-metadata-test-proxy.serviceAccountName" . }}
       containers:
       - name: {{ .Values.regularPodTest.label }}
         image: {{ .Values.ec2MetadataTestProxy.image.repository }}:{{ .Values.ec2MetadataTestProxy.image.tag }}

--- a/config/helm/ec2-metadata-test-proxy/templates/serviceaccount.yaml
+++ b/config/helm/ec2-metadata-test-proxy/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "ec2-metadata-test-proxy.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  labels:
+{{ include "ec2-metadata-test-proxy.labels" . | indent 4 }}

--- a/config/helm/ec2-metadata-test-proxy/values.yaml
+++ b/config/helm/ec2-metadata-test-proxy/values.yaml
@@ -1,3 +1,14 @@
+
+nameOverride: ""
+fullnameOverride: ""
+priorityClassName: system-node-critical
+podAnnotations: {}
+rbac:
+    pspEnabled: true
+serviceAccount:
+    name: emtp-sa
+    create: true
+    annotations: {}
 # The ec2-metadata-test-proxy is for testing purposes
 ec2MetadataTestProxy:
     create: true

--- a/test/k8s-local-cluster-test/kind-two-node-cluster.yaml
+++ b/test/k8s-local-cluster-test/kind-two-node-cluster.yaml
@@ -2,4 +2,13 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  kubeadmConfigPatches:
+    - |
+      apiVersion: kubeadm.k8s.io/v1beta2
+      kind: ClusterConfiguration
+      metadata:
+        name: config
+      apiServer:
+        extraArgs:
+          "enable-admission-plugins": "NodeRestriction,PodSecurityPolicy"
 - role: worker

--- a/test/k8s-local-cluster-test/provision-cluster
+++ b/test/k8s-local-cluster-test/provision-cluster
@@ -120,7 +120,7 @@ fi
 echoerr "🥑 Creating k8s cluster using \"kind\""
 for i in $(seq 0 5); do
   if [[ -z $(kind get clusters | grep $CLUSTER_NAME) ]]; then
-      kind create cluster -q --name "$CLUSTER_NAME" --image $K8_VERSION --config "$SCRIPTPATH/kind-two-node-cluster.yaml" --wait "$CLUSTER_CREATION_TIMEOUT_IN_SEC"s --kubeconfig $TMP_DIR/kubeconfig 1>&2 || :
+      kind create cluster -q --name "$CLUSTER_NAME" --image $K8_VERSION --config "$SCRIPTPATH/kind-two-node-cluster.yaml" --kubeconfig $TMP_DIR/kubeconfig 1>&2 || :
   else
       break
   fi
@@ -128,5 +128,8 @@ done
 
 echo "$CLUSTER_NAME" > $TMP_DIR/clustername
 echoerr "👍 Created k8s cluster using \"kind\""
+
+kubectl apply -f "$SCRIPTPATH/psp-default.yaml" --context kind-$CLUSTER_NAME --kubeconfig $TMP_DIR/kubeconfig 1>&2 
+kubectl apply -f "$SCRIPTPATH/psp-privileged.yaml" --context kind-$CLUSTER_NAME --kubeconfig $TMP_DIR/kubeconfig 1>&2 
 
 echo $TMP_DIR

--- a/test/k8s-local-cluster-test/psp-default.yaml
+++ b/test/k8s-local-cluster-test/psp-default.yaml
@@ -1,0 +1,71 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+  name: default
+spec:
+  allowedCapabilities: []  # default set of capabilities are implicitly allowed
+  allowPrivilegeEscalation: false
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  privileged: false
+  readOnlyRootFilesystem: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  volumes:
+  - 'configMap'
+  - 'downwardAPI'
+  - 'emptyDir'
+  - 'persistentVolumeClaim'
+  - 'projected'
+  - 'secret'
+
+---
+
+# Cluster role which grants access to the default pod security policy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: default-psp
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+
+---
+
+# Cluster role binding for default pod security policy granting all authenticated users access
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: default-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-psp
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated

--- a/test/k8s-local-cluster-test/psp-privileged.yaml
+++ b/test/k8s-local-cluster-test/psp-privileged.yaml
@@ -1,0 +1,70 @@
+# Should grant access to very few pods, i.e. kube-system system pods and possibly CNI pods
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    # See https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+  name: privileged
+spec:
+  allowedCapabilities:
+  - '*'
+  allowPrivilegeEscalation: true
+  fsGroup:
+    rule: 'RunAsAny'
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  privileged: true
+  readOnlyRootFilesystem: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  volumes:
+  - '*'
+
+---
+
+# Cluster role which grants access to the privileged pod security policy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: privileged-psp
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - privileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+
+---
+
+# Role binding for kube-system - allow nodes and kube-system service accounts - should take care of CNI i.e. flannel running in the kube-system namespace
+# Assumes access to the kube-system is restricted
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kube-system-psp
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: privileged-psp
+subjects:
+# For the kubeadm kube-system nodes
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:nodes
+# For all service accounts in the kube-system namespace
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:kube-system


### PR DESCRIPTION
Issue #, if available:

Description of changes:
This change enables the PodSecurityPolicy Admission Controller to make the integration tests look more like a production environment. This is especially important since NTH ships with a PSP that previously had not been exercised during integration testing. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
