### PR TITLE
Update DrainEvent metadata

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,7 +41,7 @@ const (
 	webhookHeadersConfigKey                 = "WEBHOOK_HEADERS"
 	webhookHeadersDefault                   = `{"Content-type":"application/json"}`
 	webhookTemplateConfigKey                = "WEBHOOK_TEMPLATE"
-	webhookTemplateDefault                  = `{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} - State: {{ .State }} - Start Time: {{ .StartTime }}"}`
+	webhookTemplateDefault                  = `{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} - Start Time: {{ .StartTime }}"}`
 	enableScheduledEventDrainingConfigKey   = "ENABLE_SCHEDULED_EVENT_DRAINING"
 	enableScheduledEventDrainingDefault     = false
 	enableSpotInterruptionDrainingConfigKey = "ENABLE_SPOT_INTERRUPTION_DRAINING"

--- a/pkg/drainevent/spot-itn-event_test.go
+++ b/pkg/drainevent/spot-itn-event_test.go
@@ -16,7 +16,6 @@ package drainevent_test
 import (
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -26,26 +25,14 @@ import (
 )
 
 const (
-	eventId          = "12345678-1234-1234-1234-123456789012"
 	startTime        = "2017-09-18T08:22:00Z"
 	expFormattedTime = "2017-09-18 08:22:00 +0000 UTC"
-	instanceId       = 12345
 	instanceAction   = "INSTANCE_ACTION"
 )
 
 var instanceActionResponse = []byte(`{
-    "version": "0",
-    "id": "` + eventId + `",
-    "detail-type": "EC2 Spot Instance Interruption Warning",
-    "source": "aws.ec2",
-    "account": "123456789012",
-    "time": "` + startTime + `",
-    "region": "us-east-2",
-    "resources": ["arn:aws:ec2:us-east-2:123456789012:instance/i-1234567890abcdef0"],
-    "detail": {
-        "instance-id": "` + strconv.Itoa(instanceId) + `",
-        "instance-action": "` + instanceAction + `"
-    }
+	"action": "terminate",
+	"time":"` + startTime + `"
 }`)
 
 func TestMonitorForSpotITNEventsSuccess(t *testing.T) {
@@ -67,11 +54,8 @@ func TestMonitorForSpotITNEventsSuccess(t *testing.T) {
 
 	go func() {
 		result := <-drainChan
-		h.Equals(t, eventId, result.EventID)
 		h.Equals(t, drainevent.SpotITNKind, result.Kind)
 		h.Equals(t, expFormattedTime, result.StartTime.String())
-		h.Assert(t, true, "Drain event description does not contain instance id",
-			strings.Contains(result.Description, strconv.Itoa(instanceId)))
 		h.Assert(t, true, "Drain event description does not contain instance action",
 			strings.Contains(result.Description, instanceAction))
 		h.Assert(t, true, "Drain event description does not contain instance time",

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/aws/aws-node-termination-handler/pkg/config"
 	"github.com/aws/aws-node-termination-handler/pkg/drainevent"
+	"github.com/aws/aws-node-termination-handler/pkg/ec2metadata"
 	h "github.com/aws/aws-node-termination-handler/pkg/test"
 	"github.com/aws/aws-node-termination-handler/pkg/webhook"
 )
@@ -34,7 +35,7 @@ import (
 const (
 	testDateFormat      = "02 Jan 2006 15:04:05 GMT"
 	testWebhookHeaders  = `{"Content-type":"application/json"}`
-	testWebhookTemplate = `{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} - State: {{ .State }} - Start Time: {{ .StartTime }}"}`
+	testWebhookTemplate = `{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} - Start Time: {{ .StartTime }}"}`
 )
 
 func parseScheduledEventTime(inputTime string) time.Time {
@@ -104,7 +105,9 @@ func TestPostSuccess(t *testing.T) {
 		WebhookTemplate: testWebhookTemplate,
 	}
 
-	webhook.Post(event, nthconfig)
+	nodeMetadata := ec2metadata.NodeMetadata{}
+
+	webhook.Post(nodeMetadata, event, nthconfig)
 }
 
 func TestPostTemplateParseError(t *testing.T) {
@@ -119,7 +122,9 @@ func TestPostTemplateParseError(t *testing.T) {
 		WebhookTemplate: "{{ ",
 	}
 
-	webhook.Post(event, nthconfig)
+	nodeMetadata := ec2metadata.NodeMetadata{}
+
+	webhook.Post(nodeMetadata, event, nthconfig)
 }
 
 func TestPostTemplateExecutionError(t *testing.T) {
@@ -134,7 +139,9 @@ func TestPostTemplateExecutionError(t *testing.T) {
 		WebhookTemplate: `{{.cat}}`,
 	}
 
-	webhook.Post(event, nthconfig)
+	nodeMetadata := ec2metadata.NodeMetadata{}
+
+	webhook.Post(nodeMetadata, event, nthconfig)
 }
 
 func TestPostNewHttpRequestError(t *testing.T) {
@@ -148,8 +155,9 @@ func TestPostNewHttpRequestError(t *testing.T) {
 		WebhookURL:      "\t",
 		WebhookTemplate: testWebhookTemplate,
 	}
+	nodeMetadata := ec2metadata.NodeMetadata{}
 
-	webhook.Post(event, nthconfig)
+	webhook.Post(nodeMetadata, event, nthconfig)
 }
 
 func TestPostHeaderParseFail(t *testing.T) {
@@ -163,8 +171,9 @@ func TestPostHeaderParseFail(t *testing.T) {
 		WebhookURL:      server.URL,
 		WebhookTemplate: testWebhookTemplate,
 	}
+	nodeMetadata := ec2metadata.NodeMetadata{}
 
-	webhook.Post(event, nthconfig)
+	webhook.Post(nodeMetadata, event, nthconfig)
 }
 
 func TestPostTimeout(t *testing.T) {
@@ -181,8 +190,9 @@ func TestPostTimeout(t *testing.T) {
 		WebhookTemplate: testWebhookTemplate,
 		WebhookHeaders:  testWebhookHeaders,
 	}
+	nodeMetadata := ec2metadata.NodeMetadata{}
 
-	webhook.Post(event, nthconfig)
+	webhook.Post(nodeMetadata, event, nthconfig)
 	h.Equals(t, 1, requestCount)
 }
 
@@ -200,8 +210,9 @@ func TestPostBadResponseCode(t *testing.T) {
 		WebhookTemplate: testWebhookTemplate,
 		WebhookHeaders:  testWebhookHeaders,
 	}
+	nodeMetadata := ec2metadata.NodeMetadata{}
 
-	webhook.Post(event, nthconfig)
+	webhook.Post(nodeMetadata, event, nthconfig)
 	h.Equals(t, 1, requestCount)
 }
 

--- a/test/e2e/webhook-test
+++ b/test/e2e/webhook-test
@@ -27,7 +27,7 @@ helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
   --set webhookURL="$WEBHOOK_URL" \
-  --set webhookTemplate="\{\"Content\":\"[NTH][Instance Interruption] EventID: \{\{ \.EventID \}\} - Kind: \{\{ \.Kind \}\} - State: \{\{ \.State \}\} - Start Time: \{\{ \.StartTime \}\}\"\}" \
+  --set webhookTemplate="\{\"Content\":\"[NTH][Instance Interruption] InstanceId: \{\{ \.InstanceID \}\} - InstanceType: \{\{ \.InstanceType \}\} - Kind: \{\{ \.Kind \}\} - Start Time: \{\{ \.StartTime \}\}\"\}" \
   --set enableSpotInterruptionDraining="true" \
   --set enableScheduledEventDraining="true"
 


### PR DESCRIPTION
Issue #104 #94 , if available:

https://github.com/aws/aws-node-termination-handler/issues/104
https://github.com/aws/aws-node-termination-handler/issues/94

Description of changes:

Updating the metadata associated with a drain event. The information returned from the event itself is now correctly populating the InstanceAction object. Additional relevant node metadata is retrieved from the instance metadata service. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
