### PR TITLE
Fix assert unit tests

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -198,12 +198,12 @@ func TestParseCliArgsMissingNodeNameFailure(t *testing.T) {
 	resetFlagsForTest()
 	os.Setenv("NODE_NAME", "")
 	_, err := config.ParseCliArgs()
-	h.Assert(t, true, "Failed to return error when node-name not provided", err != nil)
+	h.Assert(t, err != nil, "Failed to return error when node-name not provided")
 }
 
 func TestParseCliArgsCreateFlagsFailure(t *testing.T) {
 	resetFlagsForTest()
 	os.Setenv("DELETE_LOCAL_DATA", "something not true or false")
 	_, err := config.ParseCliArgs()
-	h.Assert(t, true, "Failed to return error when creating flags", err != nil)
+	h.Assert(t, err != nil, "Failed to return error when creating flags")
 }

--- a/pkg/drainevent/scheduled-event_internal_test.go
+++ b/pkg/drainevent/scheduled-event_internal_test.go
@@ -75,16 +75,15 @@ func TestUncordonAfterRebootPreDrainSuccess(t *testing.T) {
 	err := uncordonAfterRebootPreDrain(drainEvent, *tNode)
 	h.Ok(t, err)
 }
-
 func TestUncordonAfterRebootPreDrainMarkWithEventIDFailure(t *testing.T) {
 	resetFlagsForTest()
 
 	tNode := getNode(t, getDrainHelper(fake.NewSimpleClientset()))
 	err := uncordonAfterRebootPreDrain(DrainEvent{}, *tNode)
-	h.Assert(t, true, "Failed to return error on MarkWithEventID failing to fetch node", err != nil)
+	h.Assert(t, err != nil, "Failed to return error on MarkWithEventID failing to fetch node")
 }
 
-func TestUncordonAfterRebootPreDrainUnschedulableFailure(t *testing.T) {
+func TestUncordonAfterRebootPreDrainNodeAlreadyMarkedSuccess(t *testing.T) {
 	resetFlagsForTest()
 
 	client := fake.NewSimpleClientset()
@@ -99,5 +98,5 @@ func TestUncordonAfterRebootPreDrainUnschedulableFailure(t *testing.T) {
 
 	tNode := getNode(t, getDrainHelper(client))
 	err := uncordonAfterRebootPreDrain(DrainEvent{}, *tNode)
-	h.Assert(t, true, "Failed to return error on MarkWithEventID failing to fetch node", err != nil)
+	h.Ok(t, err)
 }

--- a/pkg/drainevent/scheduled-event_test.go
+++ b/pkg/drainevent/scheduled-event_test.go
@@ -70,14 +70,18 @@ func TestMonitorForScheduledEventsSuccess(t *testing.T) {
 		h.Equals(t, expScheduledEventStartTimeFmt, result.StartTime.String())
 		h.Equals(t, expScheduledEventEndTimeFmt, result.EndTime.String())
 
-		h.Assert(t, true, "Drain event description does not contain scheduled event code",
-			strings.Contains(result.Description, scheduledEventCode))
-		h.Assert(t, true, "Drain event description does not contain start time",
-			strings.Contains(result.Description, expScheduledEventStartTimeFmt))
-		h.Assert(t, true, "Drain event description does not contain end time",
-			strings.Contains(result.Description, expScheduledEventEndTimeFmt))
-		h.Assert(t, true, "Drain event description does not contain event description",
-			strings.Contains(result.Description, scheduledEventDescription))
+		h.Assert(t, strings.Contains(result.Description, scheduledEventCode),
+			"Expected description to contain \""+scheduledEventCode+
+				"\"but received \""+result.Description+"\"")
+		h.Assert(t, strings.Contains(result.Description, scheduledEventStartTime),
+			"Expected description to contain \""+scheduledEventStartTime+
+				"\"but received \""+result.Description+"\"")
+		h.Assert(t, strings.Contains(result.Description, scheduledEventEndTime),
+			"Expected description to contain \""+scheduledEventEndTime+
+				"\"but received \""+result.Description+"\"")
+		h.Assert(t, strings.Contains(result.Description, scheduledEventDescription),
+			"Expected description to contain \""+scheduledEventDescription+
+				"\"but received \""+result.Description+"\"")
 
 	}()
 
@@ -117,14 +121,18 @@ func TestMonitorForScheduledEventsCancelledEvent(t *testing.T) {
 		h.Equals(t, expScheduledEventStartTimeFmt, result.StartTime.String())
 		h.Equals(t, expScheduledEventEndTimeFmt, result.EndTime.String())
 
-		h.Assert(t, true, "Drain event description does not contain scheduled event code",
-			strings.Contains(result.Description, scheduledEventCode))
-		h.Assert(t, true, "Drain event description does not contain start time",
-			strings.Contains(result.Description, expScheduledEventStartTimeFmt))
-		h.Assert(t, true, "Drain event description does not contain end time",
-			strings.Contains(result.Description, expScheduledEventEndTimeFmt))
-		h.Assert(t, true, "Drain event description does not contain event description",
-			strings.Contains(result.Description, scheduledEventDescription))
+		h.Assert(t, strings.Contains(result.Description, scheduledEventCode),
+			"Expected description to contain \""+scheduledEventCode+
+				"\"but received \""+result.Description+"\"")
+		h.Assert(t, strings.Contains(result.Description, scheduledEventStartTime),
+			"Expected description to contain \""+scheduledEventStartTime+
+				"\"but received \""+result.Description+"\"")
+		h.Assert(t, strings.Contains(result.Description, scheduledEventEndTime),
+			"Expected description to contain \""+scheduledEventEndTime+
+				"\"but received \""+result.Description+"\"")
+		h.Assert(t, strings.Contains(result.Description, scheduledEventDescription),
+			"Expected description to contain \""+scheduledEventDescription+
+				"\"but received \""+result.Description+"\"")
 
 	}()
 
@@ -149,7 +157,7 @@ func TestMonitorForScheduledEventsMetadataParseFailure(t *testing.T) {
 	imds := ec2metadata.New("bad url", 0)
 
 	err := drainevent.MonitorForScheduledEvents(drainChan, cancelChan, imds)
-	h.Assert(t, true, "Failed to return error when metadata parse fails", err != nil)
+	h.Assert(t, err != nil, "Failed to return error when metadata parse fails")
 }
 
 func TestMonitorForScheduledEvents404Response(t *testing.T) {
@@ -170,7 +178,7 @@ func TestMonitorForScheduledEvents404Response(t *testing.T) {
 	imds := ec2metadata.New(server.URL, 1)
 
 	err := drainevent.MonitorForScheduledEvents(drainChan, cancelChan, imds)
-	h.Assert(t, true, "Failed to return error when 404 response", err != nil)
+	h.Assert(t, err != nil, "Failed to return error when 404 response")
 }
 
 func TestMonitorForScheduledEventsStartTimeParseFail(t *testing.T) {
@@ -197,7 +205,7 @@ func TestMonitorForScheduledEventsStartTimeParseFail(t *testing.T) {
 	imds := ec2metadata.New(server.URL, 1)
 
 	err := drainevent.MonitorForScheduledEvents(drainChan, cancelChan, imds)
-	h.Assert(t, true, "Failed to return error when failed to parse start time", err != nil)
+	h.Assert(t, err != nil, "Failed to return error when failed to parse start time")
 }
 
 func TestMonitorForScheduledEventsEndTimeParseFail(t *testing.T) {
@@ -224,5 +232,5 @@ func TestMonitorForScheduledEventsEndTimeParseFail(t *testing.T) {
 	imds := ec2metadata.New(server.URL, 1)
 
 	err := drainevent.MonitorForScheduledEvents(drainChan, cancelChan, imds)
-	h.Assert(t, true, "Failed to return error when failed to parse end time", err != nil)
+	h.Assert(t, err != nil, "Failed to return error when failed to parse end time")
 }

--- a/pkg/drainevent/spot-itn-event_test.go
+++ b/pkg/drainevent/spot-itn-event_test.go
@@ -70,12 +70,12 @@ func TestMonitorForSpotITNEventsSuccess(t *testing.T) {
 		h.Equals(t, eventId, result.EventID)
 		h.Equals(t, drainevent.SpotITNKind, result.Kind)
 		h.Equals(t, expFormattedTime, result.StartTime.String())
-		h.Assert(t, true, "Drain event description does not contain instance id",
-			strings.Contains(result.Description, strconv.Itoa(instanceId)))
-		h.Assert(t, true, "Drain event description does not contain instance action",
-			strings.Contains(result.Description, instanceAction))
-		h.Assert(t, true, "Drain event description does not contain instance time",
-			strings.Contains(result.Description, startTime))
+		h.Assert(t, strings.Contains(result.Description, strconv.Itoa(instanceId)),
+			"Drain event description does not contain instance id")
+		h.Assert(t, strings.Contains(result.Description, instanceAction),
+			"Drain event description does not contain instance action")
+		h.Assert(t, strings.Contains(result.Description, startTime),
+			"Drain event description does not contain instance time")
 	}()
 
 	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, imds)
@@ -96,7 +96,7 @@ func TestMonitorForSpotITNEventsMetadataParseFailure(t *testing.T) {
 	imds := ec2metadata.New(server.URL, 1)
 
 	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, imds)
-	h.Assert(t, true, "Failed to return error metadata parse fails", err != nil)
+	h.Assert(t, err != nil, "Failed to return error metadata parse fails")
 }
 
 func TestMonitorForSpotITNEvents404Response(t *testing.T) {
@@ -138,7 +138,7 @@ func TestMonitorForSpotITNEvents500Response(t *testing.T) {
 	imds := ec2metadata.New(server.URL, 1)
 
 	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, imds)
-	h.Assert(t, true, "Failed to return error when 500 response", err != nil)
+	h.Assert(t, err != nil, "Failed to return error when 500 response")
 }
 
 func TestMonitorForSpotITNEventsInstanceActionDecodeFailure(t *testing.T) {
@@ -159,7 +159,7 @@ func TestMonitorForSpotITNEventsInstanceActionDecodeFailure(t *testing.T) {
 	imds := ec2metadata.New(server.URL, 1)
 
 	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, imds)
-	h.Assert(t, true, "Failed to return error when failed to decode instance action", err != nil)
+	h.Assert(t, err != nil, "Failed to return error when failed to decode instance action")
 }
 
 func TestMonitorForSpotITNEventsTimeParseFailure(t *testing.T) {
@@ -180,5 +180,5 @@ func TestMonitorForSpotITNEventsTimeParseFailure(t *testing.T) {
 	imds := ec2metadata.New(server.URL, 1)
 
 	err := drainevent.MonitorForSpotITNEvents(drainChan, cancelChan, imds)
-	h.Assert(t, true, "Failed to return error when failed to parse time", err != nil)
+	h.Assert(t, err != nil, "Failed to return error when failed to parse time")
 }

--- a/pkg/draineventstore/drain-event-store_test.go
+++ b/pkg/draineventstore/drain-event-store_test.go
@@ -67,8 +67,8 @@ func TestCancelDrainEvent(t *testing.T) {
 
 	storedEvent, isActive := store.GetActiveEvent()
 	h.Equals(t, false, isActive)
-	h.Assert(t, true, fmt.Sprintf("Event has not been canceled. Expected EventID ''"+
-		", but got %q", storedEvent.EventID), event.EventID != storedEvent.EventID)
+	h.Assert(t, event.EventID != storedEvent.EventID,
+		fmt.Sprintf("Event has not been canceled. Expected EventID '', but got %q", storedEvent.EventID))
 }
 
 func TestShouldDrainNode(t *testing.T) {

--- a/pkg/node/node_internal_test.go
+++ b/pkg/node/node_internal_test.go
@@ -52,5 +52,5 @@ func TestGetUptimeFailure(t *testing.T) {
 	err := ioutil.WriteFile("test.out", d1, 0644)
 
 	_, err = getSystemUptime("test.out")
-	h.Assert(t, true, "Failed to throw error for float64 parse", err != nil)
+	h.Assert(t, err != nil, "Failed to throw error for float64 parse")
 }

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -138,7 +138,7 @@ func TestUncordonFailure(t *testing.T) {
 
 	tNode := getNode(t, getDrainHelper(fake.NewSimpleClientset()))
 	err := tNode.Uncordon()
-	h.Assert(t, true, "Failed to return error on Uncordon failing to fetch node", err != nil)
+	h.Assert(t, err != nil, "Failed to return error on Uncordon failing to fetch node")
 }
 
 func TestIsUnschedulableSuccess(t *testing.T) {
@@ -158,7 +158,7 @@ func TestIsUnschedulableFailure(t *testing.T) {
 
 	tNode := getNode(t, getDrainHelper(fake.NewSimpleClientset()))
 	value, err := tNode.IsUnschedulable()
-	h.Assert(t, true, "Failed to return error on IsUnschedulable failing to fetch node", err != nil)
+	h.Assert(t, err != nil, "Failed to return error on IsUnschedulable failing to fetch node")
 	h.Equals(t, true, value)
 }
 
@@ -178,7 +178,7 @@ func TestMarkWithEventIDFailure(t *testing.T) {
 
 	tNode := getNode(t, getDrainHelper(fake.NewSimpleClientset()))
 	err := tNode.MarkWithEventID("EventID")
-	h.Assert(t, true, "Failed to return error on MarkWithEventID failing to fetch node", err != nil)
+	h.Assert(t, err != nil, "Failed to return error on MarkWithEventID failing to fetch node")
 }
 
 func TestRemoveNTHLablesFailure(t *testing.T) {
@@ -186,7 +186,7 @@ func TestRemoveNTHLablesFailure(t *testing.T) {
 
 	tNode := getNode(t, getDrainHelper(fake.NewSimpleClientset()))
 	err := tNode.RemoveNTHLabels()
-	h.Assert(t, true, "Failed to return error on failing RemoveNTHLabels", err != nil)
+	h.Assert(t, err != nil, "Failed to return error on failing RemoveNTHLabels")
 }
 
 func TestGetEventIDSuccess(t *testing.T) {
@@ -212,7 +212,7 @@ func TestGetEventIDNoNodeFailure(t *testing.T) {
 
 	tNode := getNode(t, getDrainHelper(fake.NewSimpleClientset()))
 	_, err := tNode.GetEventID()
-	h.Assert(t, true, "Failed to return error on GetEventID failed to find node", err != nil)
+	h.Assert(t, err != nil, "Failed to return error on GetEventID failed to find node")
 }
 
 func TestGetEventIDNoLabelFailure(t *testing.T) {
@@ -223,7 +223,7 @@ func TestGetEventIDNoLabelFailure(t *testing.T) {
 
 	tNode := getNode(t, getDrainHelper(client))
 	_, err := tNode.GetEventID()
-	h.Assert(t, true, "Failed to return error on GetEventID failed to find label", err != nil)
+	h.Assert(t, err != nil, "Failed to return error on GetEventID failed to find label")
 }
 
 func TestMarkForUncordonAfterRebootAddActionLabelFailure(t *testing.T) {
@@ -231,7 +231,7 @@ func TestMarkForUncordonAfterRebootAddActionLabelFailure(t *testing.T) {
 
 	tNode := getNode(t, getDrainHelper(fake.NewSimpleClientset()))
 	err := tNode.MarkForUncordonAfterReboot()
-	h.Assert(t, true, "Failed to return error on MarkForUncordonAfterReboot failing to add action Label", err != nil)
+	h.Assert(t, err != nil, "Failed to return error on MarkForUncordonAfterReboot failing to add action Label")
 }
 
 func TestIsLableledWithActionFailure(t *testing.T) {
@@ -239,7 +239,7 @@ func TestIsLableledWithActionFailure(t *testing.T) {
 
 	tNode := getNode(t, getDrainHelper(fake.NewSimpleClientset()))
 	_, err := tNode.IsLabeledWithAction()
-	h.Assert(t, true, "Failed to return error on IsLabeledWithAction failure", err != nil)
+	h.Assert(t, err != nil, "Failed to return error on IsLabeledWithAction failure")
 }
 
 func TestUncordonIfRebootedDefaultSuccess(t *testing.T) {
@@ -265,7 +265,7 @@ func TestUncordonIfRebootedNodeFetchFailure(t *testing.T) {
 
 	tNode := getNode(t, getDrainHelper(fake.NewSimpleClientset()))
 	err := tNode.UncordonIfRebooted()
-	h.Assert(t, true, "Failed to return error on UncordonIfReboted failure to find node", err != nil)
+	h.Assert(t, err != nil, "Failed to return error on UncordonIfReboted failure to find node")
 }
 
 func TestUncordonIfRebootedTimeParseFailure(t *testing.T) {
@@ -283,7 +283,7 @@ func TestUncordonIfRebootedTimeParseFailure(t *testing.T) {
 	})
 	tNode := getNode(t, getDrainHelper(client))
 	err := tNode.UncordonIfRebooted()
-	h.Assert(t, true, "Failed to return error on UncordonIfReboted failure to parse time", err != nil)
+	h.Assert(t, err != nil, "Failed to return error on UncordonIfReboted failure to parse time")
 }
 
 func TestUncordonIfRebootedFileReadError(t *testing.T) {
@@ -301,5 +301,5 @@ func TestUncordonIfRebootedFileReadError(t *testing.T) {
 	})
 	tNode := getNode(t, getDrainHelper(client))
 	err := tNode.UncordonIfRebooted()
-	h.Assert(t, true, "Failed to return error on UncordonIfReboted failure to read file", err != nil)
+	h.Assert(t, err != nil, "Failed to return error on UncordonIfReboted failure to read file")
 }

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -213,11 +213,11 @@ func TestValidateWebhookConfig(t *testing.T) {
 	nthConfig.WebhookURL = "http://123.123.123"
 	nthConfig.WebhookTemplate = "{{ "
 	err = webhook.ValidateWebhookConfig(nthConfig)
-	h.Assert(t, true, "Failed to return error for failing to parse webhook template", err != nil)
+	h.Assert(t, err != nil, "Failed to return error for failing to parse webhook template")
 
 	nthConfig.WebhookTemplate = "{{.cat}}"
 	err = webhook.ValidateWebhookConfig(nthConfig)
-	h.Assert(t, true, "Failed to return error for failing to execute webhook template", err != nil)
+	h.Assert(t, err != nil, "Failed to return error for failing to execute webhook template")
 
 	nthConfig.WebhookTemplate = testWebhookTemplate
 	err = webhook.ValidateWebhookConfig(nthConfig)


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Assert unit test args were not in the correct order. Fixed now. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
