### PR TITLE
streamline builds scripts for binaries and docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,5 @@ matrix:
       script: make sync-readme-to-dockerhub
     - stage: Deploy
       if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(DOCKER_USERNAME) IS present
-      script: make docker-build-and-push
-    - stage: Deploy
-      if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(DOCKER_USERNAME) IS present
       script: make release
 

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
 VERSION = $(shell git describe --tags --always --dirty)
 IMG ?= amazon/aws-node-termination-handler
-IMG_W_TAG = ${IMG}:${VERSION}
+IMG_TAG ?= ${VERSION}
+IMG_W_TAG = ${IMG}:${IMG_TAG}
 DOCKER_USERNAME ?= ""
 DOCKER_PASSWORD ?= ""
-GOOS ?= "linux"
-GOARCH ?= "amd64"
+GOOS ?= linux
+GOARCH ?= amd64
 GOPROXY ?= "https://proxy.golang.org,direct"
 MAKEFILE_PATH = $(dir $(realpath -s $(firstword $(MAKEFILE_LIST))))
 BUILD_DIR_PATH = ${MAKEFILE_PATH}/build
+SUPPORTED_PLATFORMS ?= "linux/amd64,linux/arm64,linux/arm"
 
 compile:
 	@echo ${MAKEFILE_PATH}
-	go build -a -o ${BUILD_DIR_PATH}/node-termination-handler ${MAKEFILE_PATH}/cmd/node-termination-handler.go
+	go build -a -tags nth${GOOS} -o ${BUILD_DIR_PATH}/node-termination-handler ${MAKEFILE_PATH}/cmd/node-termination-handler.go
 
 create-build-dir:
 	mkdir -p ${BUILD_DIR_PATH}
@@ -23,7 +25,7 @@ fmt:
 	goimports -w ./
 
 docker-build:
-	docker build --build-arg GOOS=${GOOS} --build-arg GOARCH=${GOARCH} --build-arg GOPROXY=${GOPROXY} ${MAKEFILE_PATH} -t ${IMG_W_TAG}
+	${MAKEFILE_PATH}/scripts/build-docker-images -d -p ${GOOS}/${GOARCH} -r ${IMG} -v ${VERSION}
 
 docker-run:
 	docker run ${IMG_W_TAG}
@@ -31,6 +33,12 @@ docker-run:
 docker-push:
 	@echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
 	docker push ${IMG_W_TAG}
+
+build-docker-images:
+	${MAKEFILE_PATH}/scripts/build-docker-images -d -p ${SUPPORTED_PLATFORMS} -r ${IMG} -v ${VERSION}
+
+push-docker-images:
+	${MAKEFILE_PATH}/scripts/push-docker-images -p ${SUPPORTED_PLATFORMS} -r ${IMG} -v ${VERSION} -m
 
 version:
 	@echo ${VERSION}
@@ -57,7 +65,7 @@ helm-version-sync-test:
 	${MAKEFILE_PATH}/test/helm-sync-test/run-helm-version-sync-test
 
 build-binaries:
-	${MAKEFILE_PATH}/scripts/build-binaries
+	${MAKEFILE_PATH}/scripts/build-binaries -d -p ${SUPPORTED_PLATFORMS} -v ${VERSION}
 
 upload-resources-to-github:
 	${MAKEFILE_PATH}/scripts/upload-resources-to-github
@@ -70,9 +78,7 @@ sync-readme-to-dockerhub:
 
 helm-tests: helm-sync-test helm-version-sync-test
 
-release: create-build-dir build-binaries generate-k8s-yaml upload-resources-to-github
-
-docker-build-and-push: docker-build docker-push
+release: create-build-dir build-binaries build-docker-images push-docker-images generate-k8s-yaml upload-resources-to-github
 
 test: e2e-test compatibility-test license-test go-report-card-test helm-sync-test
 

--- a/scripts/build-docker-images
+++ b/scripts/build-docker-images
@@ -5,32 +5,36 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 REPO_ROOT_PATH=$SCRIPTPATH/../
 MAKE_FILE_PATH=$REPO_ROOT_PATH/Makefile
-mkdir -p $SCRIPTPATH/../build/bin
 
 VERSION=$(make -s -f $MAKE_FILE_PATH version)
 PLATFORMS=("linux/amd64")
-PASS_THRU_ARGS=""
+GOPROXY="https://proxy.golang.org,direct"
+
 
 USAGE=$(cat << 'EOM'
-  Usage: build-binaries  [-p <platform pairs>]
-  Builds static binaries for the platform pairs passed in
+  Usage: build-docker-images  [-p <platform pairs>]
+  Builds docker images for the platform pair
 
-  Example: build-binaries -p "linux/amd64,linux/arm"
+  Example: build-docker-images -p "linux/amd64,linux/arm"
           Optional:
             -p          Platform pair list (os/architecture) [DEFAULT: linux/amd64]
             -d          DIRECT: Set GOPROXY=direct to bypass go proxies
+            -r          IMAGE REPO: set the docker image repo
             -v          VERSION: The application version of the docker image [DEFAULT: output of `make version`]
 EOM
 )
 
 # Process our input arguments
-while getopts "dp:v:" opt; do
+while getopts "dp:r:v:" opt; do
   case ${opt} in
     p ) # Platform Pairs
         IFS=',' read -ra PLATFORMS <<< "$OPTARG"
       ;;
-    d ) # sets GOPROXY=direct
-        PASS_THRU_ARGS="$PASS_THRU_ARGS -d"
+    d ) # GOPROXY=direct
+        GOPROXY="direct"
+      ;;
+    r ) # Image Repo
+        IMAGE_REPO="$OPTARG"
       ;;
     v ) # Image Version
         VERSION="$OPTARG"
@@ -45,12 +49,13 @@ done
 for os_arch in "${PLATFORMS[@]}"; do
     os=$(echo $os_arch | cut -d'/' -f1)
     arch=$(echo $os_arch | cut -d'/' -f2)
-    container_name="extract-nth-$os-$arch"
-    repo_name="anth-bin"
-    bin_name="node-termination-handler-$os-$arch"
 
-    docker container rm $container_name || :
-    $SCRIPTPATH/build-docker-images -p $os_arch -v $VERSION -r $repo_name $PASS_THRU_ARGS
-    docker container create --rm --name $container_name "$repo_name:$VERSION-$os-$arch"
-    docker container cp $container_name:/node-termination-handler $SCRIPTPATH/../build/bin/$bin_name
+    img_tag="$IMAGE_REPO:$VERSION-$os-$arch"
+
+    docker build \
+        --build-arg GOOS=${os} \
+        --build-arg GOARCH=${arch} \
+        --build-arg GOPROXY=${GOPROXY} \
+        -t ${img_tag} \
+        ${REPO_ROOT_PATH}
 done

--- a/scripts/push-docker-images
+++ b/scripts/push-docker-images
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+REPO_ROOT_PATH=$SCRIPTPATH/../
+MAKE_FILE_PATH=$REPO_ROOT_PATH/Makefile
+
+VERSION=$(make -s -f $MAKE_FILE_PATH version)
+PLATFORMS=("linux/amd64")
+MANIFEST_IMAGES=""
+MANIFEST=""
+
+USAGE=$(cat << 'EOM'
+  Usage: push-docker-images  [-p <platform pairs>]
+  Pushes docker images for the platform pairs passed in w/ a dockerhub manifest
+
+  Example: push-docker-images -p "linux/amd64,linux/arm"
+          Optional:
+            -p          Platform pair list (os/architecture) [DEFAULT: linux/amd64]
+            -r          IMAGE REPO: set the docker image repo
+            -v          VERSION: The application version of the docker image [DEFAULT: output of `make version`]
+            -m          Create a docker manifest
+EOM
+)
+
+# Process our input arguments
+while getopts "mp:r:v:" opt; do
+  case ${opt} in
+    p ) # Platform Pairs
+        IFS=',' read -ra PLATFORMS <<< "$OPTARG"
+      ;;
+    r ) # Image Repo
+        IMAGE_REPO="$OPTARG"
+      ;;
+    v ) # Image Version
+        VERSION="$OPTARG"
+      ;;
+    m ) # Docker manifest
+        MANIFEST="true"
+      ;;
+    \? )
+        echo "$USAGE" 1>&2
+        exit
+      ;;
+  esac
+done
+
+if [[ ${#PLATFORMS[@]} -gt 1 && $MANIFEST != "true" ]]; then 
+    echo "Only one platform can be pushed if you do not create a manifest."
+    echo "Try again with the -m option"
+    exit 1
+fi
+
+for os_arch in "${PLATFORMS[@]}"; do
+    os=$(echo $os_arch | cut -d'/' -f1)
+    arch=$(echo $os_arch | cut -d'/' -f2)
+
+    img_tag_w_platform="$IMAGE_REPO:$VERSION-$os-$arch"
+
+    if [[ $MANIFEST == "true" ]]; then
+        img_tag=$img_tag_w_platform
+    else 
+        img_tag="$IMAGE_REPO:$VERSION"
+        docker tag $img_tag_w_platform $img_tag
+    fi
+
+    docker push $img_tag
+    MANIFEST_IMAGES="$MANIFEST_IMAGES $img_tag"
+done
+
+if [[ $MANIFEST == "true" ]]; then
+    if [[ $(cat $HOME/.docker/config.json | jq .experimental) != "enabled" ]]; then
+        perl -i -pe's/experimental\"[ ]*\:[ ]*\"disabled\"/experimental\":\"enabled\"/g' $HOME/.docker/config.json
+        echo "Enabled experimental CLI features to create the docker manifest"
+    fi
+    docker manifest create $IMAGE_REPO:$VERSION $MANIFEST_IMAGES
+
+    for os_arch in "${PLATFORMS[@]}"; do
+        os=$(echo $os_arch | cut -d'/' -f1)
+        arch=$(echo $os_arch | cut -d'/' -f2)
+
+        img_tag="$IMAGE_REPO:$VERSION-$os-$arch"
+
+        docker manifest annotate $IMAGE_REPO:$VERSION $img_tag --arch $arch --os $os
+    done
+
+    docker manifest push $IMAGE_REPO:$VERSION
+fi


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-node-termination-handler/issues/8 (not quite to windows support yet, but this is a good first step) 

Description of changes:
 - Added multi-arch build scripts w/ a manifest for docker images 
 - Separated the building and pushing of docker images
 - Changed build-binaries to look like the build-docker-images script 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
