### PR TITLE
changing text proxy to avoid integ test webhook spam

### DIFF
--- a/test/ec2-metadata-test-proxy/cmd/ec2-metadata-test-proxy.go
+++ b/test/ec2-metadata-test-proxy/cmd/ec2-metadata-test-proxy.go
@@ -51,7 +51,7 @@ const (
 )
 
 var startTime int64 = time.Now().Unix()
-var spotInterruptionTime string = time.Now().Local().Add(time.Minute * time.Duration(2)).Format(time.RFC3339)
+var spotInterruptionTime string = time.Now().UTC().Add(time.Minute * time.Duration(2)).Format(time.RFC3339)
 
 // ScheduledEventDetail metadata structure for json parsing
 type ScheduledEventDetail struct {
@@ -184,8 +184,8 @@ func handleRequest(res http.ResponseWriter, req *http.Request) {
 		//     "State" : "active"
 		//   }
 		// ]
-		timePlus2Min := time.Now().Local().Add(time.Minute * 2).Format(scheduledActionDateFormat)
-		timePlus4Min := time.Now().Local().Add(time.Minute * 4).Format(scheduledActionDateFormat)
+		timePlus2Min := time.Now().UTC().Add(time.Minute * 2).Format(scheduledActionDateFormat)
+		timePlus4Min := time.Now().UTC().Add(time.Minute * 4).Format(scheduledActionDateFormat)
 		scheduledEvent := ScheduledEventDetail{
 			NotBefore:   timePlus2Min,
 			Code:        "system-reboot",

--- a/test/ec2-metadata-test-proxy/cmd/ec2-metadata-test-proxy.go
+++ b/test/ec2-metadata-test-proxy/cmd/ec2-metadata-test-proxy.go
@@ -51,6 +51,7 @@ const (
 )
 
 var startTime int64 = time.Now().Unix()
+var spotInterruptionTime string = time.Now().Local().Add(time.Minute * time.Duration(2)).Format(time.RFC3339)
 
 // ScheduledEventDetail metadata structure for json parsing
 type ScheduledEventDetail struct {
@@ -143,9 +144,8 @@ func handleRequest(res http.ResponseWriter, req *http.Request) {
 			http.Error(res, "ec2-metadata-test-proxy feature not enabled", http.StatusNotFound)
 			return
 		}
-		timePlus2Min := time.Now().Local().Add(time.Minute * time.Duration(2)).Format(time.RFC3339)
 		instanceAction := InstanceAction{
-			Time:   timePlus2Min,
+			Time:   spotInterruptionTime,
 			Action: "terminate",
 		}
 		js, err := json.Marshal(instanceAction)


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
spot itn time is now fixed in the metadata proxy

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
