### PR TITLE
httpclient conn pool and request timeout config

### DIFF
--- a/pkg/ec2metadata/ec2metadata.go
+++ b/pkg/ec2metadata/ec2metadata.go
@@ -103,7 +103,13 @@ func New(metadataURL string, tries int) *Service {
 	return &Service{
 		metadataURL: metadataURL,
 		tries:       tries,
-		httpClient:  http.Client{},
+		httpClient: http.Client{
+			Timeout: 5 * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConns:    10,
+				IdleConnTimeout: 30 * time.Second,
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-node-termination-handler/issues/121

Description of changes:
 - Configures the http client connection pool and client timeout so that connections are appropriately closed. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
