### PR TITLE
helm template default to tolerate all taints

### DIFF
--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -68,7 +68,7 @@ Parameter | Description | Default
 `resources` | Resources for the pods | `requests.cpu: 50m, requests.memory: 64Mi, limits.cpu: 100m, limits.memory: 128Mi`
 `dnsPolicy` | DaemonSet DNS policy | `ClusterFirstWithHostNet`
 `nodeSelector` | Tells the daemon set where to place the node-termination-handler pods. For example: `lifecycle: "Ec2Spot"`, `on-demand: "false"`, `aws.amazon.com/purchaseType: "spot"`, etc. Value must be a valid yaml expression. | `{}`
-`tolerations` | list of node taints to tolerate | `[]`
+`tolerations` | list of node taints to tolerate | `[ {"operator": "Exists"} ]`
 `rbac.create` | if `true`, create and use RBAC resources | `true`
 `rbac.pspEnabled` | If `true`, create and use a restricted pod security policy | `false`
 `serviceAccount.create` | If `true`, create a new service account | `true`

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -70,7 +70,8 @@ procUptimeFile: "/proc/uptime"
 # pods. By default, this value is empty and every node will receive a pod.
 nodeSelector: {}
 
-tolerations: []
+tolerations: 
+  - operator: "Exists"
 
 affinity: {}
 

--- a/test/e2e/maintenance-event-dry-run-test
+++ b/test/e2e/maintenance-event-dry-run-test
@@ -33,9 +33,8 @@ helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-meta
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
   --set ec2MetadataTestProxy.port="$IMDS_PORT"
 
-POD_ID=$(kubectl get pods --namespace kube-system | grep -i node-termination-handler | grep Running | cut -d' ' -f1)
-
 for i in $(seq 0 10); do
+  POD_ID=$(get_nth_worker_pod)
   if [[ ! -z $(kubectl logs $POD_ID -n kube-system | grep -i -e 'would have been cordoned and drained') ]]; then
       echo "✅ Verified the dryrun logs were executed"
       if kubectl get nodes $CLUSTER_NAME-worker --no-headers | grep -v SchedulingDisabled; then

--- a/test/e2e/maintenance-event-reboot-test
+++ b/test/e2e/maintenance-event-reboot-test
@@ -67,9 +67,12 @@ if [[ $CORDONED -eq 0 ]]; then
     exit 3
 fi
 
-## Copy uptime file to Kind k8s worker node
-docker cp $SCRIPTPATH/../assets/uptime-reboot $CLUSTER_NAME-worker:/uptime
-docker exec $CLUSTER_NAME-worker sh -c "chmod 0444 /uptime && chown root /uptime && chgrp root /uptime"
+## Copy uptime file to Kind k8s nodes
+for node in $(kubectl get nodes -o json | jq -r '.items[].metadata.name'); do
+    docker exec $node sh -c "rm -rf /uptime"
+    docker cp $SCRIPTPATH/../assets/uptime-reboot $node:/uptime
+    docker exec $node sh -c "chmod 0444 /uptime && chown root /uptime && chgrp root /uptime"
+done
 
 ## Remove ec2-metadata-test-proxy to prevent another drain event but keep regular-test-pod
 daemonset=$(kubectl get daemonsets | grep 'ec2-metadata-test-proxy' | cut -d' ' -f1)

--- a/test/e2e/spot-interruption-dry-run-test
+++ b/test/e2e/spot-interruption-dry-run-test
@@ -33,9 +33,9 @@ helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-meta
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
   --set ec2MetadataTestProxy.port="$IMDS_PORT"
 
-POD_ID=$(kubectl get pods --namespace kube-system | grep -i node-termination-handler | grep Running | cut -d' ' -f1)
 
 for i in $(seq 0 10); do
+  POD_ID=$(get_nth_worker_pod)
   if [[ ! -z $(kubectl logs $POD_ID -n kube-system | grep -i -e 'would have been cordoned and drained') ]]; then
       echo "✅ Verified the dryrun logs were executed"
       if kubectl get nodes $CLUSTER_NAME-worker --no-headers | grep -v SchedulingDisabled; then

--- a/test/e2e/webhook-test
+++ b/test/e2e/webhook-test
@@ -59,7 +59,7 @@ fi
 for i in `seq 1 $TAINT_CHECK_CYCLES`; do
       if kubectl get nodes $CLUSTER_NAME-worker | grep SchedulingDisabled; then
           echo "✅ Verified the worker node was cordoned!"
-          NTH_POD_NAME=$(kubectl get pods -n kube-system -o json | jq '.items[] | select( .metadata.name | contains("node-termination-handler") ) | .metadata.name' -r | head -n 1)
+          NTH_POD_NAME=$(get_nth_worker_pod)
           if kubectl logs $NTH_POD_NAME -n kube-system | grep 'Webhook Success'; then
               echo "✅ Verified the webhook message was sent!"
               echo "✅ Webhook Test Passed $CLUSTER_NAME! ✅"

--- a/test/k8s-local-cluster-test/run-test
+++ b/test/k8s-local-cluster-test/run-test
@@ -70,6 +70,14 @@ function remove_labels {
     fi
 }
 
+function get_nth_worker_pod {
+    pods=$(kubectl get pods -n kube-system -o json)
+    ## queries for the nth pod on the worker node
+    nth_worker_pods=$(echo $pods | jq '.items[] | select( .metadata.name | contains("node-termination-handler") ) | .metadata.name as $name | select( .spec.nodeName | contains("worker") ) | .spec.nodeName as $nodename | $name' -r)
+    ## return only 1 pod
+    echo $(echo $nth_worker_pods | cut -d' ' -f1)
+}
+
 USAGE=$(cat << 'EOM'
   Usage: run-test [-p] [-d] [-o] [-a <ASSERTION_SCRIPT] [-b <TEST_BASE_NAME] [-c <CLUSTER_CONTEXT_DIR] [-n <NTH_DOCKER_IMG>] [-e <IMDS_DOCKER_IMG>] [-v K8S_VERSION]
   Executes a test within a provisioned kubernetes cluster with NTH and IMDS pre-loaded.
@@ -185,6 +193,7 @@ export TMP_DIR
 export CLUSTER_NAME
 export -f timeout
 export -f relpath
+export -f get_nth_worker_pod
 export NODE_TERMINATION_HANDLER_DOCKER_IMG=$(cat $TMP_DIR/nth-docker-img)
 export NODE_TERMINATION_HANDLER_DOCKER_REPO=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f1)
 export NODE_TERMINATION_HANDLER_DOCKER_TAG=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f2)
@@ -205,7 +214,7 @@ for assert_script in $ASSERTION_SCRIPTS; do
   $assert_script
   assert_end=$(date +%s)
   echo "⏰ Took $(expr $assert_end - $assert_start)sec"
-  POD_ID=$(kubectl get pods --namespace kube-system | grep -i node-termination-handler | grep -i -e Running -e CrashLoop | cut -d' ' -f1 || :)
+  POD_ID=$(get_nth_worker_pod || :)
   kubectl logs $POD_ID --namespace kube-system || :
   ## Resets cluster to run another test on the same cluster
   reset_cluster


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-node-termination-handler/issues/127

Description of changes:
 - Default the helm chart to tolerate all taints so that NTH runs on all nodes.
 - Fix integ tests to check worker pod since NTH is now running on worker and control-plane node

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
