### PR TITLE
pre-pull golang docker image builder to work around travis timing out…

### DIFF
--- a/test/k8s-local-cluster-test/run-test
+++ b/test/k8s-local-cluster-test/run-test
@@ -150,6 +150,9 @@ CLUSTER_NAME=$(cat $TMP_DIR/clustername)
 
 ## Build and Load Docker Images
 
+## Pre-pull golang builder to prevent intermittent timeouts from dockerhub
+timeout 120 docker pull golang:1.14-- || :
+
 if [ -z "$NODE_TERMINATION_HANDLER_DOCKER_IMG" ]; then 
     echo "🥑 Building the node-termination-handler docker image"
     docker build $DOCKER_ARGS -t $DEFAULT_NODE_TERMINATION_HANDLER_DOCKER_IMG "$SCRIPTPATH/../../." 


### PR DESCRIPTION
Issue #, if available:
N/A 

Description of changes:
 -  When looking at previous e2e test timeout, the golang builder image will stall (no stdout). Travis will mark the build as failed if there is no stdout for 10 minutes. 
 - E2E tests run via travis intermittently timeout due to a dockerhub pull timeout. This change will try to pull the builder image from dockerhub and timeout at 120 sec (should be plenty of time for the pull). If it times out on the builder pull, the tests will continue running and will have a second chance on the normal flow of building the NTH image. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
