### PR TITLE
fix spelling of canceled for scheduled maintenance events

### DIFF
--- a/pkg/drainevent/scheduled-event.go
+++ b/pkg/drainevent/scheduled-event.go
@@ -26,7 +26,7 @@ const (
 	// ScheduledEventKind is a const to define a scheduled event kind of drainable event
 	ScheduledEventKind           = "SCHEDULED_EVENT"
 	scheduledEventStateCompleted = "completed"
-	scheduledEventStateCancelled = "cancelled"
+	scheduledEventStateCanceled  = "canceled"
 	scheduledEventDateFormat     = "02 Jan 2006 15:04:05 GMT"
 	instanceStopCode             = "instance-stop"
 	systemRebootCode             = "system-reboot"
@@ -42,7 +42,7 @@ func MonitorForScheduledEvents(drainChan chan<- DrainEvent, cancelChan chan<- Dr
 		return err
 	}
 	for _, drainEvent := range drainEvents {
-		if isStateCancelledOrCompleted(drainEvent.State) {
+		if isStateCanceledOrCompleted(drainEvent.State) {
 			log.Println("Sending cancel events to the cancel channel")
 			cancelChan <- drainEvent
 		} else {
@@ -62,7 +62,7 @@ func checkForScheduledEvents(imds *ec2metadata.Service) ([]DrainEvent, error) {
 	events := make([]DrainEvent, 0)
 	for _, scheduledEvent := range scheduledEvents {
 		var preDrainFunc preDrainTask
-		if isRestartEvent(scheduledEvent.Code) && !isStateCancelledOrCompleted(scheduledEvent.State) {
+		if isRestartEvent(scheduledEvent.Code) && !isStateCanceledOrCompleted(scheduledEvent.State) {
 			preDrainFunc = uncordonAfterRebootPreDrain
 		}
 		notBefore, err := time.Parse(scheduledEventDateFormat, scheduledEvent.NotBefore)
@@ -107,8 +107,8 @@ func uncordonAfterRebootPreDrain(drainEvent DrainEvent, node node.Node) error {
 	return nil
 }
 
-func isStateCancelledOrCompleted(state string) bool {
-	return state == scheduledEventStateCancelled ||
+func isStateCanceledOrCompleted(state string) bool {
+	return state == scheduledEventStateCanceled ||
 		state == scheduledEventStateCompleted
 }
 

--- a/pkg/drainevent/scheduled-event_test.go
+++ b/pkg/drainevent/scheduled-event_test.go
@@ -89,9 +89,9 @@ func TestMonitorForScheduledEventsSuccess(t *testing.T) {
 	h.Ok(t, err)
 }
 
-func TestMonitorForScheduledEventsCancelledEvent(t *testing.T) {
+func TestMonitorForScheduledEventsCanceledEvent(t *testing.T) {
 	var requestPath string = ec2metadata.ScheduledEventPath
-	var state = "cancelled"
+	var state = "canceled"
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if imdsV2TokenPath == req.URL.String() {
 			rw.WriteHeader(403)

--- a/pkg/draineventstore/drain-event-store.go
+++ b/pkg/draineventstore/drain-event-store.go
@@ -122,7 +122,7 @@ func (s *Store) IgnoreEvent(eventID string) {
 	s.ignoredEvents[eventID] = struct{}{}
 }
 
-// ShouldUncordonNode returns true if there was a drainable event but it was cancelled and the store is now empty or only consists of ignored events
+// ShouldUncordonNode returns true if there was a drainable event but it was canceled and the store is now empty or only consists of ignored events
 func (s *Store) ShouldUncordonNode() bool {
 	s.RLock()
 	defer s.RUnlock()

--- a/test/e2e/maintenance-event-cancellation-test
+++ b/test/e2e/maintenance-event-cancellation-test
@@ -79,7 +79,7 @@ helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-meta
   --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
   --set ec2MetadataTestProxy.enableScheduledMaintenanceEvents="true" \
   --set ec2MetadataTestProxy.enableSpotITN="false" \
-  --set ec2MetadataTestProxy.scheduledEventStatus="cancelled" \
+  --set ec2MetadataTestProxy.scheduledEventStatus="canceled" \
   --set ec2MetadataTestProxy.port="$IMDS_PORT"    
 
 for i in `seq 1 $TAINT_CHECK_CYCLES`; do

--- a/test/go-report-card-test/run-report-card-test.sh
+++ b/test/go-report-card-test/run-report-card-test.sh
@@ -19,6 +19,11 @@ else
     echo "✅ goimports found no formatting errors in go source files"
 fi
 
+if grep -r -i -e 'cancelled' --exclude-dir={build,$(basename $SCRIPTPATH)} $SCRIPTPATH/../../* ; then
+    echo "❌ Found a misspelling of 'canceled'!"
+    EXIT_CODE=3
+fi
+
 docker run -it -v $SCRIPTPATH/../../:/app go-report-card-cli /go/bin/goreportcard-cli -v -t $THRESHOLD
 
 exit $EXIT_CODE


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Was spelling canceled with two L's :(   Changed all occurrences and added a test to enforce the 1 L canceled variant. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
