### PR TITLE
Remove unnecessary delete daemonset permission

### DIFF
--- a/config/helm/aws-node-termination-handler/Chart.yaml
+++ b/config/helm/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.7.3
+version: 0.7.4
 appVersion: 1.3.1
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/config/helm/aws-node-termination-handler/templates/clusterrole.yaml
+++ b/config/helm/aws-node-termination-handler/templates/clusterrole.yaml
@@ -36,4 +36,3 @@ rules:
     - daemonsets
   verbs:
     - get
-    - delete

--- a/config/helm/aws-node-termination-handler/templates/clusterrole.yaml
+++ b/config/helm/aws-node-termination-handler/templates/clusterrole.yaml
@@ -26,7 +26,6 @@ rules:
 - apiGroups:
     - extensions
   resources:
-    - replicasets
     - daemonsets
   verbs:
     - get

--- a/config/helm/ec2-metadata-test-proxy/templates/clusterrole.yaml
+++ b/config/helm/ec2-metadata-test-proxy/templates/clusterrole.yaml
@@ -26,7 +26,6 @@ rules:
 - apiGroups:
     - extensions
   resources:
-    - replicasets
     - daemonsets
   verbs:
     - get
@@ -36,4 +35,3 @@ rules:
     - daemonsets
   verbs:
     - get
-    - delete


### PR DESCRIPTION
Issue #138, if available:

Description of changes:

Deleted the the line in the cluster role config file that gives NTH permission to delete daemonsets. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
