### PR TITLE
fix time parsing for scheduled maintenance events

### DIFF
--- a/pkg/interruptionevent/scheduled-event.go
+++ b/pkg/interruptionevent/scheduled-event.go
@@ -27,7 +27,7 @@ const (
 	ScheduledEventKind           = "SCHEDULED_EVENT"
 	scheduledEventStateCompleted = "completed"
 	scheduledEventStateCanceled  = "canceled"
-	scheduledEventDateFormat     = "02 Jan 2006 15:04:05 GMT"
+	scheduledEventDateFormat     = "2 Jan 2006 15:04:05 GMT"
 	instanceStopCode             = "instance-stop"
 	systemRebootCode             = "system-reboot"
 	instanceRebootCode           = "instance-reboot"

--- a/test/ec2-metadata-test-proxy/cmd/ec2-metadata-test-proxy.go
+++ b/test/ec2-metadata-test-proxy/cmd/ec2-metadata-test-proxy.go
@@ -25,7 +25,7 @@ import (
 const (
 	interruptionNoticeDelayConfigKey = "INTERRUPTION_NOTICE_DELAY"
 	interruptionNoticeDelayDefault   = "0"
-	scheduledActionDateFormat        = "02 Jan 2006 15:04:05 GMT"
+	scheduledActionDateFormat        = "2 Jan 2006 15:04:05 GMT"
 	spotInstanceActionFlag           = "ENABLE_SPOT_ITN"
 	spotInstanceActionPath           = "/latest/meta-data/spot/instance-action"
 	scheduledMaintenanceEventFlag    = "ENABLE_SCHEDULED_MAINTENANCE_EVENTS"


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-node-termination-handler/issues/147

Description of changes:
Fix bug where scheduled maintenance events times were parsed wrong. This would cause scheduled event handling to fail when the date of the start or end time was a 1 digit day.  We were assuming the day digit would always be padded with a 0 to make it two digits. 

Updated the test and date parsing string.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
