### PR TITLE
Add option for logging in JSON format

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"syscall"
@@ -27,6 +26,8 @@ import (
 	"github.com/aws/aws-node-termination-handler/pkg/interruptioneventstore"
 	"github.com/aws/aws-node-termination-handler/pkg/node"
 	"github.com/aws/aws-node-termination-handler/pkg/webhook"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -37,22 +38,29 @@ const (
 type monitorFunc func(chan<- interruptionevent.InterruptionEvent, chan<- interruptionevent.InterruptionEvent, *ec2metadata.Service) error
 
 func main() {
+	// Zerolog uses json formatting by default, so change that to a human-readable format instead
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339, NoColor: true})
+
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGTERM)
 	defer signal.Stop(signalChan)
 
 	nthConfig, err := config.ParseCliArgs()
 	if err != nil {
-		log.Fatalln("Failed to parse cli args: ", err)
+		log.Fatal().Err(err).Msg("Failed to parse cli args,")
 	}
 
 	err = webhook.ValidateWebhookConfig(nthConfig)
 	if err != nil {
-		log.Fatalln("Webhook validation failed: ", err)
+		log.Fatal().Err(err).Msg("Webhook validation failed,")
 	}
 	node, err := node.New(nthConfig)
 	if err != nil {
-		log.Fatalln("Unable to instantiate a node for various kubernetes node functions: ", err)
+		log.Fatal().Err(err).Msg("Unable to instantiate a node for various kubernetes node functions,")
+	}
+
+	if nthConfig.JsonLogging {
+		log.Logger = zerolog.New(os.Stderr).With().Timestamp().Logger()
 	}
 
 	imds := ec2metadata.New(nthConfig.MetadataURL, nthConfig.MetadataTries)
@@ -63,7 +71,7 @@ func main() {
 	if nthConfig.EnableScheduledEventDraining {
 		err = handleRebootUncordon(interruptionEventStore, *node)
 		if err != nil {
-			log.Printf("Unable to complete the uncordon after reboot workflow on startup: %v\n", err)
+			log.Printf("Unable to complete the uncordon after reboot workflow on startup: %v", err)
 		}
 	}
 
@@ -93,11 +101,11 @@ func main() {
 	}
 
 	go watchForInterruptionEvents(interruptionChan, interruptionEventStore, nodeMetadata)
-	log.Println("Started watching for interruption events")
-	log.Println("Kubernetes AWS Node Termination Handler has started successfully!")
+	log.Print("Started watching for interruption events")
+	log.Print("Kubernetes AWS Node Termination Handler has started successfully!")
 
 	go watchForCancellationEvents(cancelChan, interruptionEventStore, node, nodeMetadata)
-	log.Println("Started watching for event cancellations")
+	log.Print("Started watching for event cancellations")
 
 	for range time.NewTicker(1 * time.Second).C {
 		select {
@@ -108,7 +116,7 @@ func main() {
 			drainOrCordonIfNecessary(interruptionEventStore, *node, nthConfig, nodeMetadata)
 		}
 	}
-	log.Println("AWS Node Termination Handler is shutting down")
+	log.Print("AWS Node Termination Handler is shutting down")
 }
 
 func handleRebootUncordon(interruptionEventStore *interruptioneventstore.Store, node node.Node) error {
@@ -134,7 +142,7 @@ func handleRebootUncordon(interruptionEventStore *interruptioneventstore.Store, 
 func watchForInterruptionEvents(interruptionChan <-chan interruptionevent.InterruptionEvent, interruptionEventStore *interruptioneventstore.Store, nodeMetadata ec2metadata.NodeMetadata) {
 	for {
 		interruptionEvent := <-interruptionChan
-		log.Printf("Got interruption event from channel %+v %+v\n", nodeMetadata, interruptionEvent)
+		log.Printf("Got interruption event from channel %+v %+v", nodeMetadata, interruptionEvent)
 		interruptionEventStore.AddInterruptionEvent(&interruptionEvent)
 	}
 }
@@ -142,17 +150,17 @@ func watchForInterruptionEvents(interruptionChan <-chan interruptionevent.Interr
 func watchForCancellationEvents(cancelChan <-chan interruptionevent.InterruptionEvent, interruptionEventStore *interruptioneventstore.Store, node *node.Node, nodeMetadata ec2metadata.NodeMetadata) {
 	for {
 		interruptionEvent := <-cancelChan
-		log.Printf("Got cancel event from channel %+v %+v\n", nodeMetadata, interruptionEvent)
+		log.Printf("Got cancel event from channel %+v %+v", nodeMetadata, interruptionEvent)
 		interruptionEventStore.CancelInterruptionEvent(interruptionEvent.EventID)
 		if interruptionEventStore.ShouldUncordonNode() {
-			log.Println("Uncordoning the node due to a cancellation event")
+			log.Print("Uncordoning the node due to a cancellation event")
 			err := node.Uncordon()
 			if err != nil {
 				log.Printf("Uncordoning the node failed: %v", err)
 			}
 			node.RemoveNTHLabels()
 		} else {
-			log.Println("Another interruption event is active, not uncordoning the node")
+			log.Print("Another interruption event is active, not uncordoning the node")
 		}
 	}
 }
@@ -162,23 +170,23 @@ func drainOrCordonIfNecessary(interruptionEventStore *interruptioneventstore.Sto
 		if drainEvent.PreDrainTask != nil {
 			err := drainEvent.PreDrainTask(*drainEvent, node)
 			if err != nil {
-				log.Println("There was a problem executing the pre-drain task: ", err)
+				log.Printf("There was a problem executing the pre-drain task: %v", err)
 			}
 		}
 		if nthConfig.CordonOnly {
 			err := node.Cordon()
 			if err != nil {
-				log.Println("There was a problem while trying to cordon the node: ", err)
+				log.Printf("There was a problem while trying to cordon the node: %v", err)
 				os.Exit(1)
 			}
-			log.Printf("Node %q successfully cordoned.\n", nthConfig.NodeName)
+			log.Printf("Node %q successfully cordoned.", nthConfig.NodeName)
 		} else {
 			err := node.CordonAndDrain()
 			if err != nil {
-				log.Println("There was a problem while trying to cordon and drain the node: ", err)
+				log.Printf("There was a problem while trying to cordon and drain the node: %v", err)
 				os.Exit(1)
 			}
-			log.Printf("Node %q successfully cordoned and drained.\n", nthConfig.NodeName)
+			log.Printf("Node %q successfully cordoned and drained.", nthConfig.NodeName)
 		}
 		interruptionEventStore.MarkAllAsDrained()
 		if nthConfig.WebhookURL != "" {

--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -67,6 +67,7 @@ Parameter | Description | Default
 `enableSpotInterruptionDraining` | If true, drain nodes when the spot interruption termination notice is received | `true`
 `metadataTries` | The number of times to try requesting metadata. If you would like 2 retries, set metadata-tries to 3. | `3`
 `cordonOnly` | If true, nodes will be cordoned but not drained when an interruption event occurs. | `false`
+`jsonLogging` | If true, use JSON-formatted logs instead of human readable logs. | `false`
 `affinity` | node/pod affinities | None
 `podAnnotations` | annotations to add to each pod | `{}`
 `priorityClassName` | Name of the priorityClass | `system-node-critical`

--- a/config/helm/aws-node-termination-handler/templates/daemonset.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.yaml
@@ -109,6 +109,8 @@ spec:
             value: {{ .Values.metadataTries | quote }}
           - name: CORDON_ONLY
             value: {{ .Values.cordonOnly | quote }}
+          - name: JSON_LOGGING
+            value: {{ .Values.jsonLogging | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/aws/aws-node-termination-handler
 go 1.14
 
 require (
+	github.com/rs/zerolog v1.18.0
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0 // indirect
 	k8s.io/api v0.0.0-20191010143144-fbf594f18f80
 	k8s.io/apimachinery v0.0.0-20191016060620-86f2f1b9c076

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -153,6 +154,7 @@ github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQ
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -164,6 +166,9 @@ github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/zerolog v1.18.0 h1:CbAm3kP2Tptby1i9sYy2MGRg0uxIN9cyDb59Ys7W8z8=
+github.com/rs/zerolog v1.18.0/go.mod h1:9nvC1axdVrAHcu/s9taAVfBuIdTZLVQmKQyvrUjF5+I=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
@@ -187,6 +192,7 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -214,6 +220,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJV
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc h1:gkKoSkUmnU6bpS/VhkuO27bzQeSA51uaEfbOW5dNb68=
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -257,6 +264,8 @@ golang.org/x/tools v0.0.0-20190312151545-0bb0c0a6e846/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmKJ7gzohV1XkqsFehRA2FbsbkopSuQ=
@@ -309,7 +318,6 @@ k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf h1:EYm5AW/UUDbnmnI+gK0TJD
 k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/kubectl v0.0.0-20191016234702-5d0b8f240400 h1:IeGIAmvzKqd9LLSWCXXFKbenbJCu9faeIulMgYz77YY=
 k8s.io/kubectl v0.0.0-20191016234702-5d0b8f240400/go.mod h1:939lYu2PWLrk5t7xWN3amNIvJlJCa7KQfPZ2+cLrnJA=
-k8s.io/kubernetes v1.17.2 h1:g1UFZqFQsYx88xMUks4PKC6tsNcekxe0v06fcVGRwVE=
 k8s.io/metrics v0.0.0-20191014074242-8b0351268f72/go.mod h1:ie2c8bq97BFtf7noiNVVJmLhEjShRhE4KBVFxeZCSjs=
 k8s.io/utils v0.0.0-20191010214722-8d271d903fe4 h1:Gi+/O1saihwDqnlmC8Vhv1M5Sp4+rbOmK9TbsLn8ZEA=
 k8s.io/utils v0.0.0-20191010214722-8d271d903fe4/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,9 +16,10 @@ package config
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"strconv"
+
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -49,6 +50,8 @@ const (
 	metadataTriesConfigKey                  = "METADATA_TRIES"
 	metadataTriesDefault                    = 3
 	cordonOnly                              = "CORDON_ONLY"
+	jsonLoggingConfigKey                    = "JSON_LOGGING"
+	jsonLoggingDefault                      = false
 )
 
 //Config arguments set via CLI, environment variables, or defaults
@@ -69,6 +72,7 @@ type Config struct {
 	EnableSpotInterruptionDraining bool
 	MetadataTries                  int
 	CordonOnly                     bool
+	JsonLogging                    bool
 }
 
 //ParseCliArgs parses cli arguments and uses environment variables as fallback values
@@ -99,13 +103,14 @@ func ParseCliArgs() (config Config, err error) {
 	flag.BoolVar(&config.EnableSpotInterruptionDraining, "enable-spot-interruption-draining", getBoolEnv(enableSpotInterruptionDrainingConfigKey, enableSpotInterruptionDrainingDefault), "If true, drain nodes when the spot interruption termination notice is received")
 	flag.IntVar(&config.MetadataTries, "metadata-tries", getIntEnv(metadataTriesConfigKey, metadataTriesDefault), "The number of times to try requesting metadata. If you would like 2 retries, set metadata-tries to 3.")
 	flag.BoolVar(&config.CordonOnly, "cordon-only", getBoolEnv(cordonOnly, false), "If true, nodes will be cordoned but not drained when an interruption event occurs.")
+	flag.BoolVar(&config.JsonLogging, "json-logging", getBoolEnv(jsonLoggingConfigKey, jsonLoggingDefault), "If true, use JSON-formatted logs instead of human readable logs.")
 
 	flag.Parse()
 
 	if isConfigProvided("pod-termination-grace-period", podTerminationGracePeriodConfigKey) && isConfigProvided("grace-period", gracePeriodConfigKey) {
-		log.Println("Deprecated argument \"grace-period\" and the replacement argument \"pod-termination-grace-period\" was provided. Using the newer argument \"pod-termination-grace-period\"")
+		log.Print("Deprecated argument \"grace-period\" and the replacement argument \"pod-termination-grace-period\" was provided. Using the newer argument \"pod-termination-grace-period\"")
 	} else if isConfigProvided("grace-period", gracePeriodConfigKey) {
-		log.Println("Deprecated argument \"grace-period\" was provided. This argument will eventually be removed. Please switch to \"pod-termination-grace-period\" instead.")
+		log.Print("Deprecated argument \"grace-period\" was provided. This argument will eventually be removed. Please switch to \"pod-termination-grace-period\" instead.")
 		config.PodTerminationGracePeriod = gracePeriod
 	}
 
@@ -132,7 +137,8 @@ func ParseCliArgs() (config Config, err error) {
 			"\tenable-scheduled-event-draining: %t,\n"+
 			"\tenable-spot-interruption-draining: %t,\n"+
 			"\tmetadata-tries: %d,\n"+
-			"\tcordon-only: %t,\n",
+			"\tcordon-only: %t,\n"+
+			"\tjson-logging: %t,\n",
 
 		config.DryRun,
 		config.NodeName,
@@ -147,6 +153,7 @@ func ParseCliArgs() (config Config, err error) {
 		config.EnableSpotInterruptionDraining,
 		config.MetadataTries,
 		config.CordonOnly,
+		config.JsonLogging,
 	)
 
 	return config, err

--- a/pkg/ec2metadata/ec2metadata.go
+++ b/pkg/ec2metadata/ec2metadata.go
@@ -17,12 +17,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"math/rand"
 	"net/http"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -218,7 +219,7 @@ func (e *Service) getV2Token() (string, int, error) {
 	httpReq := func() (*http.Response, error) {
 		return e.httpClient.Do(req)
 	}
-	log.Println("Trying to get token from IMDSv2")
+	log.Print("Trying to get token from IMDSv2")
 	resp, err := retry(1, 2*time.Second, httpReq)
 	if err != nil {
 		return "", -1, err
@@ -235,7 +236,7 @@ func (e *Service) getV2Token() (string, int, error) {
 	if err != nil {
 		return "", -1, fmt.Errorf("IMDS v2 Token TTL header not sent in response: %w", err)
 	}
-	log.Println("Got token from IMDSv2")
+	log.Print("Got token from IMDSv2")
 	return string(token), ttl, nil
 }
 
@@ -258,8 +259,8 @@ func retry(attempts int, sleep time.Duration, httpReq func() (*http.Response, er
 			jitter := time.Duration(rand.Int63n(int64(sleep)))
 			sleep = sleep + jitter/2
 
-			log.Printf("Request failed. Attempts remaining: %d\n", attempts)
-			log.Printf("Sleep for %s seconds\n", sleep)
+			log.Printf("Request failed. Attempts remaining: %d", attempts)
+			log.Printf("Sleep for %s seconds", sleep)
 			time.Sleep(sleep)
 			return retry(attempts, 2*sleep, httpReq)
 		}

--- a/pkg/interruptionevent/scheduled-event.go
+++ b/pkg/interruptionevent/scheduled-event.go
@@ -15,11 +15,11 @@ package interruptionevent
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/aws/aws-node-termination-handler/pkg/ec2metadata"
 	"github.com/aws/aws-node-termination-handler/pkg/node"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -42,10 +42,10 @@ func MonitorForScheduledEvents(interruptionChan chan<- InterruptionEvent, cancel
 	}
 	for _, interruptionEvent := range interruptionEvents {
 		if isStateCanceledOrCompleted(interruptionEvent.State) {
-			log.Println("Sending cancel events to the cancel channel")
+			log.Print("Sending cancel events to the cancel channel")
 			cancelChan <- interruptionEvent
 		} else {
-			log.Println("Sending interruption events to the interruption channel")
+			log.Print("Sending interruption events to the interruption channel")
 			interruptionChan <- interruptionEvent
 		}
 	}
@@ -93,7 +93,7 @@ func uncordonAfterRebootPreDrain(interruptionEvent InterruptionEvent, node node.
 	// if the node is already marked as unschedulable, then don't do anything
 	unschedulable, err := node.IsUnschedulable()
 	if err == nil && unschedulable {
-		log.Println("Node is already marked unschedulable, not taking any action to add uncordon label.")
+		log.Print("Node is already marked unschedulable, not taking any action to add uncordon label.")
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("Encountered an error while checking if the node is unschedulable. Not setting an uncordon label: %w", err)
@@ -102,7 +102,7 @@ func uncordonAfterRebootPreDrain(interruptionEvent InterruptionEvent, node node.
 	if err != nil {
 		return fmt.Errorf("Unable to mark the node for uncordon: %w", err)
 	}
-	log.Println("Successfully applied uncordon after reboot action label to node.")
+	log.Print("Successfully applied uncordon after reboot action label to node.")
 	return nil
 }
 

--- a/pkg/interruptionevent/spot-itn-event.go
+++ b/pkg/interruptionevent/spot-itn-event.go
@@ -16,10 +16,10 @@ package interruptionevent
 import (
 	"crypto/sha256"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/aws/aws-node-termination-handler/pkg/ec2metadata"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -34,7 +34,7 @@ func MonitorForSpotITNEvents(interruptionChan chan<- InterruptionEvent, cancelCh
 		return err
 	}
 	if interruptionEvent != nil && interruptionEvent.Kind == SpotITNKind {
-		log.Println("Sending interruption event to the interruption channel")
+		log.Print("Sending interruption event to the interruption channel")
 		interruptionChan <- *interruptionEvent
 	}
 	return nil

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -17,13 +17,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/aws/aws-node-termination-handler/pkg/config"
+	"github.com/rs/zerolog/log"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -74,7 +74,7 @@ func NewWithValues(nthConfig config.Config, drainHelper *drain.Helper) (*Node, e
 // CordonAndDrain will cordon the node and evict pods based on the config
 func (n Node) CordonAndDrain() error {
 	if n.nthConfig.DryRun {
-		log.Printf("Node %s would have been cordoned and drained, but dry-run flag was set\n", n.nthConfig.NodeName)
+		log.Printf("Node %s would have been cordoned and drained, but dry-run flag was set", n.nthConfig.NodeName)
 		return nil
 	}
 	err := n.Cordon()
@@ -92,7 +92,7 @@ func (n Node) CordonAndDrain() error {
 // Cordon will add a NoSchedule on the node
 func (n Node) Cordon() error {
 	if n.nthConfig.DryRun {
-		log.Printf("Node %s would have been cordoned, but dry-run flag was set\n", n.nthConfig.NodeName)
+		log.Printf("Node %s would have been cordoned, but dry-run flag was set", n.nthConfig.NodeName)
 		return nil
 	}
 	node, err := n.fetchKubernetesNode()
@@ -126,7 +126,7 @@ func (n Node) Uncordon() error {
 // IsUnschedulable checks if the node is marked as unschedulable
 func (n Node) IsUnschedulable() (bool, error) {
 	if n.nthConfig.DryRun {
-		log.Println("IsUnschedulable returning false since dry-run is set")
+		log.Print("IsUnschedulable returning false since dry-run is set")
 		return false, nil
 	}
 	node, err := n.fetchKubernetesNode()
@@ -274,7 +274,7 @@ func (n Node) UncordonIfRebooted() error {
 	}
 	timeVal, ok := k8sNode.Labels[ActionLabelTimeKey]
 	if !ok {
-		log.Printf("There was no %s label found requiring action label handling\n", ActionLabelTimeKey)
+		log.Printf("There was no %s label found requiring action label handling", ActionLabelTimeKey)
 		return nil
 	}
 	timeValNum, err := strconv.ParseInt(timeVal, 10, 64)
@@ -289,7 +289,7 @@ func (n Node) UncordonIfRebooted() error {
 			return err
 		}
 		if secondsSinceLabel < int64(uptime) {
-			log.Println("The system has not restarted yet.")
+			log.Print("The system has not restarted yet.")
 			return nil
 		}
 		err = n.Uncordon()
@@ -300,9 +300,9 @@ func (n Node) UncordonIfRebooted() error {
 		if err != nil {
 			return err
 		}
-		log.Printf("Successfully completed action %s.\n", UncordonAfterRebootLabelVal)
+		log.Printf("Successfully completed action %s.", UncordonAfterRebootLabelVal)
 	default:
-		log.Println("There are no label actions to handle.")
+		log.Print("There are no label actions to handle.")
 	}
 	return nil
 }

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -30,6 +29,7 @@ import (
 	"github.com/aws/aws-node-termination-handler/pkg/interruptionevent"
 	h "github.com/aws/aws-node-termination-handler/pkg/test"
 	"github.com/aws/aws-node-termination-handler/pkg/webhook"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -46,7 +46,7 @@ func parseScheduledEventTime(inputTime string) time.Time {
 func getExpectedMessage(event *interruptionevent.InterruptionEvent) string {
 	webhookTemplate, err := template.New("").Parse(testWebhookTemplate)
 	if err != nil {
-		log.Printf("Webhook Error: Template parsing failed - %s\n", err)
+		log.Printf("Webhook Error: Template parsing failed - %s", err)
 		return ""
 	}
 


### PR DESCRIPTION
Issue #, if available: #142 

Description of changes:

Add the option to use JSON logging instead of human-readable logging. Human-readable remains the default logging format, though the format of the logs themselves change slightly. 

Previously: 
`2020/04/23 19:49:52 Sending drain event to the drain channel`

Now: 
`2020-04-30T19:24:00Z DBG Sending interruption event to the interruption channel`

The date format follows [RFC3339](https://tools.ietf.org/html/rfc3339).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
