### PR TITLE
Revert date format in human-readable logs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,9 +108,9 @@ func ParseCliArgs() (config Config, err error) {
 	flag.Parse()
 
 	if isConfigProvided("pod-termination-grace-period", podTerminationGracePeriodConfigKey) && isConfigProvided("grace-period", gracePeriodConfigKey) {
-		log.Print("Deprecated argument \"grace-period\" and the replacement argument \"pod-termination-grace-period\" was provided. Using the newer argument \"pod-termination-grace-period\"")
+		log.Log().Msg("Deprecated argument \"grace-period\" and the replacement argument \"pod-termination-grace-period\" was provided. Using the newer argument \"pod-termination-grace-period\"")
 	} else if isConfigProvided("grace-period", gracePeriodConfigKey) {
-		log.Print("Deprecated argument \"grace-period\" was provided. This argument will eventually be removed. Please switch to \"pod-termination-grace-period\" instead.")
+		log.Log().Msg("Deprecated argument \"grace-period\" was provided. This argument will eventually be removed. Please switch to \"pod-termination-grace-period\" instead.")
 		config.PodTerminationGracePeriod = gracePeriod
 	}
 

--- a/pkg/ec2metadata/ec2metadata.go
+++ b/pkg/ec2metadata/ec2metadata.go
@@ -184,7 +184,7 @@ func (e *Service) Request(contextPath string) (*http.Response, error) {
 		if err != nil {
 			e.v2Token = ""
 			e.tokenTTL = -1
-			log.Printf("Unable to retrieve an IMDSv2 token, continuing with IMDSv1: %v", err)
+			log.Log().Msgf("Unable to retrieve an IMDSv2 token, continuing with IMDSv1: %v", err)
 		} else {
 			e.v2Token = token
 			e.tokenTTL = ttl
@@ -219,7 +219,7 @@ func (e *Service) getV2Token() (string, int, error) {
 	httpReq := func() (*http.Response, error) {
 		return e.httpClient.Do(req)
 	}
-	log.Print("Trying to get token from IMDSv2")
+	log.Log().Msg("Trying to get token from IMDSv2")
 	resp, err := retry(1, 2*time.Second, httpReq)
 	if err != nil {
 		return "", -1, err
@@ -236,7 +236,7 @@ func (e *Service) getV2Token() (string, int, error) {
 	if err != nil {
 		return "", -1, fmt.Errorf("IMDS v2 Token TTL header not sent in response: %w", err)
 	}
-	log.Print("Got token from IMDSv2")
+	log.Log().Msg("Got token from IMDSv2")
 	return string(token), ttl, nil
 }
 
@@ -259,8 +259,8 @@ func retry(attempts int, sleep time.Duration, httpReq func() (*http.Response, er
 			jitter := time.Duration(rand.Int63n(int64(sleep)))
 			sleep = sleep + jitter/2
 
-			log.Printf("Request failed. Attempts remaining: %d", attempts)
-			log.Printf("Sleep for %s seconds", sleep)
+			log.Log().Msgf("Request failed. Attempts remaining: %d", attempts)
+			log.Log().Msgf("Sleep for %s seconds", sleep)
 			time.Sleep(sleep)
 			return retry(attempts, 2*sleep, httpReq)
 		}
@@ -279,7 +279,7 @@ func (e *Service) GetNodeMetadata() NodeMetadata {
 	metadata.LocalHostname, _ = e.GetMetadataInfo(LocalHostnamePath)
 	metadata.LocalIP, _ = e.GetMetadataInfo(LocalIPPath)
 
-	log.Printf("Startup Metadata Retrieved: %+v", metadata)
+	log.Log().Msgf("Startup Metadata Retrieved: %+v", metadata)
 
 	return metadata
 }

--- a/pkg/interruptionevent/scheduled-event.go
+++ b/pkg/interruptionevent/scheduled-event.go
@@ -42,10 +42,10 @@ func MonitorForScheduledEvents(interruptionChan chan<- InterruptionEvent, cancel
 	}
 	for _, interruptionEvent := range interruptionEvents {
 		if isStateCanceledOrCompleted(interruptionEvent.State) {
-			log.Print("Sending cancel events to the cancel channel")
+			log.Log().Msg("Sending cancel events to the cancel channel")
 			cancelChan <- interruptionEvent
 		} else {
-			log.Print("Sending interruption events to the interruption channel")
+			log.Log().Msg("Sending interruption events to the interruption channel")
 			interruptionChan <- interruptionEvent
 		}
 	}
@@ -93,7 +93,7 @@ func uncordonAfterRebootPreDrain(interruptionEvent InterruptionEvent, node node.
 	// if the node is already marked as unschedulable, then don't do anything
 	unschedulable, err := node.IsUnschedulable()
 	if err == nil && unschedulable {
-		log.Print("Node is already marked unschedulable, not taking any action to add uncordon label.")
+		log.Log().Msg("Node is already marked unschedulable, not taking any action to add uncordon label.")
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("Encountered an error while checking if the node is unschedulable. Not setting an uncordon label: %w", err)
@@ -102,7 +102,7 @@ func uncordonAfterRebootPreDrain(interruptionEvent InterruptionEvent, node node.
 	if err != nil {
 		return fmt.Errorf("Unable to mark the node for uncordon: %w", err)
 	}
-	log.Print("Successfully applied uncordon after reboot action label to node.")
+	log.Log().Msg("Successfully applied uncordon after reboot action label to node.")
 	return nil
 }
 

--- a/pkg/interruptionevent/spot-itn-event.go
+++ b/pkg/interruptionevent/spot-itn-event.go
@@ -34,7 +34,7 @@ func MonitorForSpotITNEvents(interruptionChan chan<- InterruptionEvent, cancelCh
 		return err
 	}
 	if interruptionEvent != nil && interruptionEvent.Kind == SpotITNKind {
-		log.Print("Sending interruption event to the interruption channel")
+		log.Log().Msg("Sending interruption event to the interruption channel")
 		interruptionChan <- *interruptionEvent
 	}
 	return nil

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -74,7 +74,7 @@ func NewWithValues(nthConfig config.Config, drainHelper *drain.Helper) (*Node, e
 // CordonAndDrain will cordon the node and evict pods based on the config
 func (n Node) CordonAndDrain() error {
 	if n.nthConfig.DryRun {
-		log.Printf("Node %s would have been cordoned and drained, but dry-run flag was set", n.nthConfig.NodeName)
+		log.Log().Msgf("Node %s would have been cordoned and drained, but dry-run flag was set", n.nthConfig.NodeName)
 		return nil
 	}
 	err := n.Cordon()
@@ -92,7 +92,7 @@ func (n Node) CordonAndDrain() error {
 // Cordon will add a NoSchedule on the node
 func (n Node) Cordon() error {
 	if n.nthConfig.DryRun {
-		log.Printf("Node %s would have been cordoned, but dry-run flag was set", n.nthConfig.NodeName)
+		log.Log().Msgf("Node %s would have been cordoned, but dry-run flag was set", n.nthConfig.NodeName)
 		return nil
 	}
 	node, err := n.fetchKubernetesNode()
@@ -109,7 +109,7 @@ func (n Node) Cordon() error {
 // Uncordon will remove the NoSchedule on the node
 func (n Node) Uncordon() error {
 	if n.nthConfig.DryRun {
-		log.Printf("Node %s would have been uncordoned, but dry-run flag was set", n.nthConfig.NodeName)
+		log.Log().Msgf("Node %s would have been uncordoned, but dry-run flag was set", n.nthConfig.NodeName)
 		return nil
 	}
 	node, err := n.fetchKubernetesNode()
@@ -126,7 +126,7 @@ func (n Node) Uncordon() error {
 // IsUnschedulable checks if the node is marked as unschedulable
 func (n Node) IsUnschedulable() (bool, error) {
 	if n.nthConfig.DryRun {
-		log.Print("IsUnschedulable returning false since dry-run is set")
+		log.Log().Msg("IsUnschedulable returning false since dry-run is set")
 		return false, nil
 	}
 	node, err := n.fetchKubernetesNode()
@@ -164,7 +164,7 @@ func (n Node) GetEventID() (string, error) {
 	}
 	val, ok := node.Labels[EventIDLabelKey]
 	if n.nthConfig.DryRun && !ok {
-		log.Printf("Would have returned Error: Event ID Lable %s was not found on the node, but dry-run flag was set", EventIDLabelKey)
+		log.Log().Msgf("Would have returned Error: Event ID Lable %s was not found on the node, but dry-run flag was set", EventIDLabelKey)
 		return "", nil
 	}
 	if !ok {
@@ -214,7 +214,7 @@ func (n Node) addLabel(key string, value string) error {
 		return err
 	}
 	if n.nthConfig.DryRun {
-		log.Printf("Would have added label (%s=%s) to node %s, but dry-run flag was set", key, value, n.nthConfig.NodeName)
+		log.Log().Msgf("Would have added label (%s=%s) to node %s, but dry-run flag was set", key, value, n.nthConfig.NodeName)
 		return nil
 	}
 	_, err = n.drainHelper.Client.CoreV1().Nodes().Patch(node.Name, types.StrategicMergePatchType, payloadBytes)
@@ -245,7 +245,7 @@ func (n Node) removeLabel(key string) error {
 		return err
 	}
 	if n.nthConfig.DryRun {
-		log.Printf("Would have removed label with key %s from node %s, but dry-run flag was set", key, n.nthConfig.NodeName)
+		log.Log().Msgf("Would have removed label with key %s from node %s, but dry-run flag was set", key, n.nthConfig.NodeName)
 		return nil
 	}
 	_, err = n.drainHelper.Client.CoreV1().Nodes().Patch(node.Name, types.JSONPatchType, payload)
@@ -274,7 +274,7 @@ func (n Node) UncordonIfRebooted() error {
 	}
 	timeVal, ok := k8sNode.Labels[ActionLabelTimeKey]
 	if !ok {
-		log.Printf("There was no %s label found requiring action label handling", ActionLabelTimeKey)
+		log.Log().Msgf("There was no %s label found requiring action label handling", ActionLabelTimeKey)
 		return nil
 	}
 	timeValNum, err := strconv.ParseInt(timeVal, 10, 64)
@@ -289,7 +289,7 @@ func (n Node) UncordonIfRebooted() error {
 			return err
 		}
 		if secondsSinceLabel < int64(uptime) {
-			log.Print("The system has not restarted yet.")
+			log.Log().Msg("The system has not restarted yet.")
 			return nil
 		}
 		err = n.Uncordon()
@@ -300,9 +300,9 @@ func (n Node) UncordonIfRebooted() error {
 		if err != nil {
 			return err
 		}
-		log.Printf("Successfully completed action %s.", UncordonAfterRebootLabelVal)
+		log.Log().Msgf("Successfully completed action %s.", UncordonAfterRebootLabelVal)
 	default:
-		log.Print("There are no label actions to handle.")
+		log.Log().Msg("There are no label actions to handle.")
 	}
 	return nil
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -37,7 +37,7 @@ func Post(additionalInfo ec2metadata.NodeMetadata, event *interruptionevent.Inte
 
 	webhookTemplate, err := template.New("message").Parse(nthconfig.WebhookTemplate)
 	if err != nil {
-		log.Printf("Webhook Error: Template parsing failed - %s", err)
+		log.Log().Msgf("Webhook Error: Template parsing failed - %s", err)
 		return
 	}
 
@@ -46,20 +46,20 @@ func Post(additionalInfo ec2metadata.NodeMetadata, event *interruptionevent.Inte
 	var byteBuffer bytes.Buffer
 	err = webhookTemplate.Execute(&byteBuffer, combined)
 	if err != nil {
-		log.Printf("Webhook Error: Template execution failed - %s", err)
+		log.Log().Msgf("Webhook Error: Template execution failed - %s", err)
 		return
 	}
 
 	request, err := http.NewRequest("POST", nthconfig.WebhookURL, &byteBuffer)
 	if err != nil {
-		log.Printf("Webhook Error: Http NewRequest failed - %s", err)
+		log.Log().Msgf("Webhook Error: Http NewRequest failed - %s", err)
 		return
 	}
 
 	headerMap := make(map[string]interface{})
 	err = json.Unmarshal([]byte(nthconfig.WebhookHeaders), &headerMap)
 	if err != nil {
-		log.Printf("Webhook Error: Header Unmarshal failed - %s", err)
+		log.Log().Msgf("Webhook Error: Header Unmarshal failed - %s", err)
 		return
 	}
 	for key, value := range headerMap {
@@ -71,18 +71,18 @@ func Post(additionalInfo ec2metadata.NodeMetadata, event *interruptionevent.Inte
 	}
 	response, err := client.Do(request)
 	if err != nil {
-		log.Printf("Webhook Error: Client Do failed - %s", err)
+		log.Log().Msgf("Webhook Error: Client Do failed - %s", err)
 		return
 	}
 
 	defer response.Body.Close()
 
 	if response.StatusCode < 200 || response.StatusCode > 299 {
-		log.Printf("Webhook Error: Received Status Code %d", response.StatusCode)
+		log.Log().Msgf("Webhook Error: Received Status Code %d", response.StatusCode)
 		return
 	}
 
-	log.Print("Webhook Success: Notification Sent!")
+	log.Log().Msg("Webhook Success: Notification Sent!")
 }
 
 // ValidateWebhookConfig will check if the template provided in nthConfig with parse and execute

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -46,7 +46,7 @@ func parseScheduledEventTime(inputTime string) time.Time {
 func getExpectedMessage(event *interruptionevent.InterruptionEvent) string {
 	webhookTemplate, err := template.New("").Parse(testWebhookTemplate)
 	if err != nil {
-		log.Log().Msg("Webhook Error: Template parsing failed - %s", err)
+		log.Log().Msgf("Webhook Error: Template parsing failed - %s", err)
 		return ""
 	}
 

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -46,7 +46,7 @@ func parseScheduledEventTime(inputTime string) time.Time {
 func getExpectedMessage(event *interruptionevent.InterruptionEvent) string {
 	webhookTemplate, err := template.New("").Parse(testWebhookTemplate)
 	if err != nil {
-		log.Printf("Webhook Error: Template parsing failed - %s", err)
+		log.Log().Msg("Webhook Error: Template parsing failed - %s", err)
 		return ""
 	}
 


### PR DESCRIPTION
Issue #, if available: none

Description of changes:

This reverts the date format in the logs back to how it was before PR https://github.com/aws/aws-node-termination-handler/pull/152. This doesn't affect the ability to use JSON logging, it only changes the human-readable format. 

The thinking is that it was wrong to modify the format in a minor release, so we'll revisit changing the log format when we're close to version 2.0.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
