### PR TITLE
set idle conns timeout on webhook http client

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -70,6 +70,7 @@ func Post(additionalInfo ec2metadata.NodeMetadata, event *interruptionevent.Inte
 	client := http.Client{
 		Timeout: time.Duration(5 * time.Second),
 		Transport: &http.Transport{
+			IdleConnTimeout: 1 * time.Second,
 			Proxy: func(req *http.Request) (*url.URL, error) {
 				if nthconfig.WebhookProxy == "" {
 					return nil, nil

--- a/test/assets/squid.conf
+++ b/test/assets/squid.conf
@@ -9,3 +9,4 @@ refresh_pattern ^gopher:	1440	0%	1440
 refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
 refresh_pattern (Release|Packages(.gz)*)$      0       20%     2880
 refresh_pattern .		0	20%	4320
+access_log stdio:/var/log/squid/access.log all

--- a/test/e2e/webhook-http-proxy-test
+++ b/test/e2e/webhook-http-proxy-test
@@ -13,7 +13,7 @@ set -euo pipefail
 echo "Starting Webhook HTTP Proxy Test for Node Termination Handler"
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-SQUID_DOCKERHUB_IMG="sameersbn/squid:3.5.27-2"
+SQUID_DOCKERHUB_IMG="sameersbn/squid:3.5.27-2@sha256:e98299069f0c6e3d9b9188903518e2f44ac36b1fa5007e879af518e1c0a234af"
 SQUID_DOCKER_IMG="squid:customtest"
 
 
@@ -32,6 +32,7 @@ kubectl create configmap squid-config --from-file=$SCRIPTPATH/../assets/squid.co
 
 helm upgrade --install $CLUSTER_NAME-squid $SCRIPTPATH/../../config/helm/squid/ \
   --force \
+  --wait \
   --namespace default \
   --set squid.configMap="squid-config" \
   --set squid.image.repository="squid" \
@@ -89,7 +90,7 @@ for i in `seq 1 $TAINT_CHECK_CYCLES`; do
                 ## queries for the squid pod on the worker node
                 squid_worker_pods=$(echo $pods | jq '.items[] | select( .metadata.name | contains("squid") ) | .metadata.name as $name | select( .spec.nodeName | contains("worker") ) | .spec.nodeName as $nodename | $name' -r)
                 ## return only 1 pod
-                if kubectl exec -it $(echo $squid_worker_pods | cut -d' ' -f1) -- cat /var/log/squid/access.log | grep -i 'TCP_MISS/200' | grep '200'; then
+                if kubectl exec -it $(echo $squid_worker_pods | cut -d' ' -f1) -- cat /var/log/squid/access.log | grep -e 'TCP_MISS/200' -e 'TCP_TUNNEL/200'; then
                     echo "✅ Verified the webhook POST used the http proxy"
                     exit 0
                 fi


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
The newly added webhook-http-proxy-test was failing when testing with an actual https endpoint because the squid access log was not being written until the connection was closed. However, the go http client was keeping the connection open in the connection pool for reuse. There's no reason to reuse the http connection since the webhook is a one-time request and most often the instance is about to be terminated. 

- Set IdleConnTimeout to 1 second on the webhook http client
- Switch Squid from daemon logging to stdio logging for instant flush
- Use the full docker image hash for squid 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
