### PR TITLE
allow squid to tolerate all taints to stabilize e2e tests

### DIFF
--- a/config/helm/squid/templates/daemonset.yaml
+++ b/config/helm/squid/templates/daemonset.yaml
@@ -31,4 +31,8 @@ spec:
         - name: squid-config
           configMap: 
             name: {{ .Values.squid.configMap }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
             

--- a/config/helm/squid/values.yaml
+++ b/config/helm/squid/values.yaml
@@ -15,4 +15,6 @@ squid:
     image:
         repository: squid
         tag: customtest
+tolerations: 
+  - operator: "Exists"
         


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Make squid http proxy tolerate all taints for e2e tests. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
