### PR TITLE
stabilize e2e tests

### DIFF
--- a/test/e2e/prometheus-metrics-test
+++ b/test/e2e/prometheus-metrics-test
@@ -85,10 +85,15 @@ if [[ $EXIT_STATUS -eq 3 ]];then
 fi
 
 
-POD_NAME=$(kubectl -n kube-system get pods -l k8s-app=aws-node-termination-handler -o jsonpath='{.items[0].metadata.name}')
+POD_NAME=$(get_nth_worker_pod)
 echo "✅ Fetched the pod $POD_NAME "
 
 kubectl -n kube-system port-forward $POD_NAME 7000:9092 &
+PORT_FORWARD_PID=$!
+function kill_port_forward() {
+    kill $1
+}
+trap "kill_port_forward ${PORT_FORWARD_PID}" EXIT SIGINT SIGTERM ERR
 echo "✅ Port-forwarded pod $POD_NAME"
 
 sleep 1

--- a/test/e2e/prometheus-metrics-test
+++ b/test/e2e/prometheus-metrics-test
@@ -90,10 +90,7 @@ echo "✅ Fetched the pod $POD_NAME "
 
 kubectl -n kube-system port-forward $POD_NAME 7000:9092 &
 PORT_FORWARD_PID=$!
-function kill_port_forward() {
-    kill $1
-}
-trap "kill_port_forward ${PORT_FORWARD_PID}" EXIT SIGINT SIGTERM ERR
+trap "kill ${PORT_FORWARD_PID}" EXIT SIGINT SIGTERM ERR
 echo "✅ Port-forwarded pod $POD_NAME"
 
 sleep 1

--- a/test/e2e/webhook-http-proxy-test
+++ b/test/e2e/webhook-http-proxy-test
@@ -89,7 +89,7 @@ for i in `seq 1 $TAINT_CHECK_CYCLES`; do
                 ## queries for the squid pod on the worker node
                 squid_worker_pods=$(echo $pods | jq '.items[] | select( .metadata.name | contains("squid") ) | .metadata.name as $name | select( .spec.nodeName | contains("worker") ) | .spec.nodeName as $nodename | $name' -r)
                 ## return only 1 pod
-                if kubectl exec -it $(echo $squid_worker_pods | cut -d' ' -f1) -- cat /var/log/squid/access.log | grep -e 'TCP_MISS/200' -e 'TCP_TUNNEL/200'; then
+                if kubectl exec -it $(echo $squid_worker_pods | cut -d' ' -f1) -- cat /var/log/squid/access.log | grep -e 'TCP_MISS/200' -e 'TCP_TUNNEL/200' -e 'TCP_MISS_ABORTED/200'; then
                     echo "✅ Verified the webhook POST used the http proxy"
                     exit 0
                 fi

--- a/test/k8s-local-cluster-test/run-test
+++ b/test/k8s-local-cluster-test/run-test
@@ -73,11 +73,11 @@ function remove_labels {
 }
 
 function get_nth_worker_pod {
-    echo $(kubectl get pods -n kube-system \
+    kubectl get pods -n kube-system \
       --selector 'app.kubernetes.io/name=aws-node-termination-handler' \
       --field-selector="spec.nodeName=$CLUSTER_NAME-worker,status.phase=Running" \
       --sort-by=.metadata.creationTimestamp \
-      --output jsonpath='{.items[-1].metadata.name}')
+      --output jsonpath='{.items[-1].metadata.name}'
 }
 
 USAGE=$(cat << 'EOM'

--- a/test/k8s-local-cluster-test/run-test
+++ b/test/k8s-local-cluster-test/run-test
@@ -73,11 +73,11 @@ function remove_labels {
 }
 
 function get_nth_worker_pod {
-    pods=$(kubectl get pods -n kube-system -o json)
-    ## queries for the nth pod on the worker node
-    nth_worker_pods=$(echo $pods | jq '.items[] | select( .metadata.name | contains("node-termination-handler") ) | .metadata.name as $name | select( .spec.nodeName | contains("worker") ) | .spec.nodeName as $nodename | $name' -r)
-    ## return only 1 pod
-    echo $(echo $nth_worker_pods | cut -d' ' -f1)
+    echo $(kubectl get pods -n kube-system \
+      --selector 'app.kubernetes.io/name=aws-node-termination-handler' \
+      --field-selector="spec.nodeName=$CLUSTER_NAME-worker,status.phase=Running" \
+      --sort-by=.metadata.creationTimestamp \
+      --output jsonpath='{.items[-1].metadata.name}')
 }
 
 USAGE=$(cat << 'EOM'
@@ -151,9 +151,6 @@ fi
 CLUSTER_NAME=$(cat $TMP_DIR/clustername)
 
 ## Build and Load Docker Images
-
-## Pre-pull golang builder to prevent intermittent timeouts from dockerhub
-timeout 120 docker pull golang:1.14-- || :
 
 if [ -z "$NODE_TERMINATION_HANDLER_DOCKER_IMG" ]; then 
     echo "🥑 Building the node-termination-handler docker image"


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
From local tests, this stabilizes the end-to-end tests....

Issues found:
 1. There was a timing issue when selecting the worker pod if a pod from another test had recently been terminated and was still displayed with kubectl get pods. This is fixed by sorting by creationTime (taking the newest launched) and only look for running pods.
 1. The webhook-http-proxy test checks the squid access logs to make sure it received the webhook, but the logged entry was a TCP_MISSED_ABORT/200 which was not being accepted as a success, but it should have been. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
