### PR TITLE
Add support for Webhook URL as a Secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ helm upgrade --install aws-node-termination-handler \
   eks/aws-node-termination-handler
 ```
 
+Alternatively, pass Webhook URL as a Secret:
+```
+WEBHOOKURL_LITERAL="webhookurl=https://hooks.slack.com/services/YOUR/SLACK/URL"
+
+kubectl create secret -n kube-system generic webhooksecret --from-literal=$WEBHOOKURL_LITERAL
+```
+```
+helm upgrade --install aws-node-termination-handler \
+  --namespace kube-system \
+  --set webhookURLSecretName=webhooksecret \
+  eks/aws-node-termination-handler
+```
+
 For a full list of configuration options see our [Helm readme](https://github.com/aws/eks-charts/tree/master/stable/aws-node-termination-handler).
 
 ## Building

--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -60,6 +60,7 @@ Parameter | Description | Default
 `ignoreDaemonsSets` | Causes kubectl to skip daemon set managed pods | `true`
 `instanceMetadataURL` | The URL of EC2 instance metadata. This shouldn't need to be changed unless you are testing. | `http://169.254.169.254:80`
 `webhookURL` | Posts event data to URL upon instance interruption action | ``
+`webhookURLSecretName` | Pass Webhook URL as a secret. Secret Key: `webhookurl`, Value: `<WEBHOOK_URL>` | None
 `webhookProxy` | Uses the specified HTTP(S) proxy for sending webhooks | ``
 `webhookHeaders` | Replaces the default webhook headers. | `{"Content-type":"application/json"}`
 `webhookTemplate` | Replaces the default webhook message template. | `{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} - State: {{ .State }} - Start Time: {{ .StartTime }}"}`

--- a/config/helm/aws-node-termination-handler/templates/daemonset.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.yaml
@@ -93,8 +93,14 @@ spec:
             value: {{ .Values.instanceMetadataURL | quote }}
           - name: NODE_TERMINATION_GRACE_PERIOD
             value: {{ .Values.nodeTerminationGracePeriod | quote }}
-          - name: WEBHOOK_URL
+          {{- if .Values.webhookURLSecretName }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.webhookURLSecretName }}
+                key: webhookurl
+          {{- else }}
             value: {{ .Values.webhookURL | quote }}
+          {{- end }}
           - name: WEBHOOK_HEADERS
             value: {{ .Values.webhookHeaders | quote }}
           - name: WEBHOOK_TEMPLATE

--- a/config/helm/aws-node-termination-handler/templates/daemonset.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.yaml
@@ -93,6 +93,7 @@ spec:
             value: {{ .Values.instanceMetadataURL | quote }}
           - name: NODE_TERMINATION_GRACE_PERIOD
             value: {{ .Values.nodeTerminationGracePeriod | quote }}
+          - name: WEBHOOK_URL
           {{- if .Values.webhookURLSecretName }}
             valueFrom:
               secretKeyRef:

--- a/test/e2e/webhook-secret-test
+++ b/test/e2e/webhook-secret-test
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -euo pipefail
+
+# Available env vars:
+#   $TMP_DIR
+#   $CLUSTER_NAME
+#   $KUBECONFIG
+#   $NODE_TERMINATION_HANDLER_DOCKER_REPO
+#   $NODE_TERMINATION_HANDLER_DOCKER_TAG
+#   $EC2_METADATA_DOCKER_REPO
+#   $EC2_METADATA_DOCKER_TAG
+
+echo "Starting Webhook URL Secret Test for Node Termination Handler"
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+WEBHOOKURL_LITERAL="webhookurl=http://localhost:$IMDS_PORT"
+
+kubectl create secret -n kube-system generic webhooksecret --from-literal=$WEBHOOKURL_LITERAL
+
+helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ \
+  --wait \
+  --force \
+  --namespace kube-system \
+  --set instanceMetadataURL="http://localhost:$IMDS_PORT" \
+  --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
+  --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
+  --set webhookURLSecretName=webhooksecret \
+  --set webhookTemplate="\{\"Content\":\"[NTH][Instance Interruption] InstanceId: \{\{ \.InstanceID \}\} - InstanceType: \{\{ \.InstanceType \}\} - Kind: \{\{ \.Kind \}\} - Start Time: \{\{ \.StartTime \}\}\"\}" \
+  --set enableSpotInterruptionDraining="true" \
+  --set enableScheduledEventDraining="true"
+
+helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/ec2-metadata-test-proxy/ \
+  --wait \
+  --force \
+  --namespace default \
+  --set ec2MetadataTestProxy.image.repository="$EC2_METADATA_DOCKER_REPO" \
+  --set ec2MetadataTestProxy.image.tag="$EC2_METADATA_DOCKER_TAG" \
+  --set ec2MetadataTestProxy.port="$IMDS_PORT"
+
+TAINT_CHECK_CYCLES=15
+TAINT_CHECK_SLEEP=15
+
+DEPLOYED=0
+for i in `seq 1 10`; do
+    if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
+        echo "✅ Verified regular-pod-test pod was scheduled and started!"
+        DEPLOYED=1
+        break
+    fi
+    sleep 5
+done
+
+if [[ $DEPLOYED -eq 0 ]]; then
+    exit 2
+fi
+
+for i in `seq 1 $TAINT_CHECK_CYCLES`; do
+      if kubectl get nodes $CLUSTER_NAME-worker | grep SchedulingDisabled; then
+          echo "✅ Verified the worker node was cordoned!"
+          NTH_POD_NAME=$(get_nth_worker_pod)
+          if kubectl logs $NTH_POD_NAME -n kube-system | grep 'Webhook Success'; then
+              echo "✅ Verified the webhook message was sent!"
+              echo "✅ Webhook URL as a Secret Test Passed $CLUSTER_NAME! ✅"
+              exit 0
+          fi
+      fi
+    sleep $TAINT_CHECK_SLEEP
+done
+
+exit 1


### PR DESCRIPTION
Issue #170

Description of changes: `WEBHOOK_URL` is treated as a secret/private by some organizations since it gives the ability to send a message to a group of people e.g. in a slack channel. Allow users to specify Webhook URL as a secret.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
