### PR TITLE
do not fail when scheduled event does not have end date

### DIFF
--- a/pkg/interruptionevent/scheduled-event.go
+++ b/pkg/interruptionevent/scheduled-event.go
@@ -66,11 +66,11 @@ func checkForScheduledEvents(imds *ec2metadata.Service) ([]InterruptionEvent, er
 		}
 		notBefore, err := time.Parse(scheduledEventDateFormat, scheduledEvent.NotBefore)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to parsed scheduled event start time: %w", err)
+			return nil, fmt.Errorf("Unable to parse scheduled event start time: %w", err)
 		}
 		notAfter, err := time.Parse(scheduledEventDateFormat, scheduledEvent.NotAfter)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to parsed scheduled event end time: %w", err)
+			log.Log().Msgf("Unable to parse scheduled event end time, continuing: %w", err)
 		}
 		events = append(events, InterruptionEvent{
 			EventID:      scheduledEvent.EventID,

--- a/pkg/interruptionevent/scheduled-event.go
+++ b/pkg/interruptionevent/scheduled-event.go
@@ -70,7 +70,8 @@ func checkForScheduledEvents(imds *ec2metadata.Service) ([]InterruptionEvent, er
 		}
 		notAfter, err := time.Parse(scheduledEventDateFormat, scheduledEvent.NotAfter)
 		if err != nil {
-			log.Log().Msgf("Unable to parse scheduled event end time, continuing: %w", err)
+			notAfter = notBefore
+			log.Log().Msgf("Unable to parse scheduled event end time, continuing: %v", err)
 		}
 		events = append(events, InterruptionEvent{
 			EventID:      scheduledEvent.EventID,

--- a/pkg/interruptionevent/scheduled-event_test.go
+++ b/pkg/interruptionevent/scheduled-event_test.go
@@ -231,6 +231,26 @@ func TestMonitorForScheduledEventsEndTimeParseFail(t *testing.T) {
 	cancelChan := make(chan interruptionevent.InterruptionEvent)
 	imds := ec2metadata.New(server.URL, 1)
 
+	go func() {
+		result := <-drainChan
+		h.Equals(t, scheduledEventId, result.EventID)
+		h.Equals(t, interruptionevent.ScheduledEventKind, result.Kind)
+		h.Equals(t, scheduledEventState, result.State)
+		h.Equals(t, expScheduledEventStartTimeFmt, result.StartTime.String())
+		h.Equals(t, expScheduledEventStartTimeFmt, result.EndTime.String())
+
+		h.Assert(t, strings.Contains(result.Description, scheduledEventCode),
+			"Expected description to contain \""+scheduledEventCode+
+				"\"but received \""+result.Description+"\"")
+		h.Assert(t, strings.Contains(result.Description, scheduledEventStartTime),
+			"Expected description to contain \""+scheduledEventStartTime+
+				"\"but received \""+result.Description+"\"")
+		h.Assert(t, strings.Contains(result.Description, scheduledEventDescription),
+			"Expected description to contain \""+scheduledEventDescription+
+				"\"but received \""+result.Description+"\"")
+
+	}()
+
 	err := interruptionevent.MonitorForScheduledEvents(drainChan, cancelChan, imds)
-	h.Assert(t, err != nil, "Failed to return error when failed to parse end time")
+	h.Ok(t, err)
 }


### PR DESCRIPTION
Overview:
When processing scheduled maintenance events, do not fail when scheduled event does not have an end date. This information is not present for all events and is not utilized in the functionality of aws-node-termination-handler. It only serves as additional, nice-to-have information for logging/webhook msg purposes. 

Issue #, if available:
https://github.com/aws/aws-node-termination-handler/issues/147

Description of changes:
 - Made end-time parsing optional for scheduled event processing. Still logging that the parsing failed, but it will now continue to send the event over the channel for potential cordon+drain.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
