### PR TITLE
Fixed typo in "pre-dain" NodeAction

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -184,7 +184,7 @@ func drainOrCordonIfNecessary(interruptionEventStore *interruptioneventstore.Sto
 			if err != nil {
 				log.Log().Msgf("There was a problem executing the pre-drain task: %v", err)
 			}
-			metrics.NodeActionsInc("pre-dain", nodeName, err)
+			metrics.NodeActionsInc("pre-drain", nodeName, err)
 		}
 
 		if nthConfig.CordonOnly {

--- a/test/e2e/prometheus-metrics-test
+++ b/test/e2e/prometheus-metrics-test
@@ -105,10 +105,10 @@ else
     EXIT_STATUS=3
 fi
 
-if [[ $METRICS_RESPONSE == *"pre-dain"* ]]; then
+if [[ $METRICS_RESPONSE == *"pre-drain"* ]]; then
     echo "✅ Metric pre-drain!"
 else
-    echo "❌ Failed checking metric for pre-dain"
+    echo "❌ Failed checking metric for pre-drain"
     EXIT_STATUS=3
 fi
 


### PR DESCRIPTION
Description of changes:

There was a typo in the Prometheus metric's label.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
