### PR TITLE
Kube version helm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,16 +24,19 @@ jobs:
       name: Unit Tests
       after_success: bash <(curl -s https://codecov.io/bash) -v
     - stage: Test
+      script: make helm-lint
+      name: Helm v2 and v3 Lint
+    - stage: Test
       script: test/go-report-card-test/run-report-card-test.sh
       name: Go Report Card Test
     - stage: Test
-      script: make create-build-dir build-binaries
+      script: make build-binaries
       name: Build Binaries
     - stage: Test
-      script: make create-build-dir build-docker-images
+      script: make build-docker-images
       name: Build Docker Images
     - stage: Test
-      script: make create-build-dir generate-k8s-yaml
+      script: make generate-k8s-yaml
       name: Generate K8s yaml files
     - stage: Test
       if: type = push AND env(GITHUB_TOKEN) IS present

--- a/config/helm/aws-node-termination-handler/templates/_helpers.tpl
+++ b/config/helm/aws-node-termination-handler/templates/_helpers.tpl
@@ -71,7 +71,8 @@ In 1.14 "beta.kubernetes.io" was deprecated and is scheduled for removal in 1.18
 See https://v1-14.docs.kubernetes.io/docs/setup/release/notes/#deprecations
 */}}
 {{- define "aws-node-termination-handler.defaultNodeSelectorTermsPrefix" -}}
-    {{- semverCompare "<1.14" .Capabilities.KubeVersion.Version | ternary "beta.kubernetes.io" "kubernetes.io" -}}
+    {{- $k8sVersion := printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor -}}
+    {{- semverCompare "<1.14" $k8sVersion | ternary "beta.kubernetes.io" "kubernetes.io" -}}
 {{- end -}}
 
 {{/*

--- a/config/helm/ec2-metadata-test-proxy/templates/daemonset.yaml
+++ b/config/helm/ec2-metadata-test-proxy/templates/daemonset.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ec2MetadataTestProxy.create -}}
 {{- $isWindows := (contains "windows" .Values.targetNodeOs) -}}
-{{- $osSelector := (semverCompare "<1.14" .Capabilities.KubeVersion.Version | ternary "beta.kubernetes.io/os" "kubernetes.io/os") -}}
+{{- $k8sVersion := printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor -}}
+{{- $osSelector := (semverCompare "<1.14" $k8sVersion | ternary "beta.kubernetes.io/os" "kubernetes.io/os") -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/config/helm/ec2-metadata-test-proxy/templates/regular-pod-test.yaml
+++ b/config/helm/ec2-metadata-test-proxy/templates/regular-pod-test.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.regularPodTest.create -}}
 {{- $isWindows := (contains "windows" .Values.targetNodeOs) -}}
-{{- $osSelector := (semverCompare "<1.14" .Capabilities.KubeVersion.Version | ternary "beta.kubernetes.io/os" "kubernetes.io/os") -}}
+{{- $k8sVersion := printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor -}}
+{{- $osSelector := (semverCompare "<1.14" $k8sVersion | ternary "beta.kubernetes.io/os" "kubernetes.io/os") -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/scripts/generate-k8s-yaml
+++ b/scripts/generate-k8s-yaml
@@ -26,13 +26,16 @@ EOM
 )
 
 # Process our input arguments
-while getopts "n:" opt; do
+while getopts "vn:" opt; do
   case ${opt} in
     n ) # K8s namespace
         NAMESPACE=$OPTARG
       ;;
+    v ) # Verbose
+        set -x 
+      ;;
     \? )
-        echoerr "$USAGE" 1>&2
+        echo "$USAGE" 1>&2
         exit
       ;;
   esac

--- a/test/helm/helm-lint
+++ b/test/helm/helm-lint
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+TMP_DIR="$SCRIPTPATH/../../build"
+PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
+HELM3_VERSION="3.2.4"
+HELM2_VERSION="2.16.9"
+
+mkdir -p $TMP_DIR
+
+if [ ! -x "$TMP_DIR/helm" ]; then
+    echo "🥑 Downloading the \"helm3\" binary"
+    curl -L https://get.helm.sh/helm-v$HELM3_VERSION-$PLATFORM-amd64.tar.gz | tar zxf - -C $TMP_DIR
+    mv $TMP_DIR/$PLATFORM-amd64/helm $TMP_DIR/.
+    chmod +x $TMP_DIR/helm
+    echo "👍 Downloaded the \"helm\" binary"
+fi
+
+if [ ! -x "$TMP_DIR/helm2" ]; then
+    echo "🥑 Downloading the \"helm2\" binary"
+    curl -L https://get.helm.sh/helm-v$HELM2_VERSION-$PLATFORM-amd64.tar.gz | tar zxf - -C $TMP_DIR
+    mv $TMP_DIR/$PLATFORM-amd64/helm $TMP_DIR/helm2
+    chmod +x $TMP_DIR/helm2
+    echo "👍 Downloaded the \"helm2\" binary"
+fi
+export PATH=$TMP_DIR:$PATH
+
+echo "=============================================================================="
+echo "                     Linting Helm Chart w/ Helm v3"
+echo "=============================================================================="
+helm lint $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ 
+
+echo "=============================================================================="
+echo "                     Linting Helm Chart w/ Helm v2"
+echo "=============================================================================="
+helm2 lint $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ 
+
+echo "✅ Helm Linting for v2 and v3 have successfully completed!"


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Change helm helper kube-version retrieval to use Major/Minor instead of Version since it's supported in helm v2 and v3
 - Add helm v2 and v3 linting to travis

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
