### PR TITLE
Don't schedule aws-node-termination-handler on fargate nodes

### DIFF
--- a/config/helm/aws-node-termination-handler/Chart.yaml
+++ b/config/helm/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.9.0
+version: 0.9.1
 appVersion: 1.6.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -58,6 +58,10 @@ spec:
                     - amd64
                     - arm64
                     - arm
+                - key: "eks.amazonaws.com/compute-type"
+                  operator: NotIn
+                  values:
+                    - fargate
         {{- with .Values.affinity }}
           {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Issue aws/eks-charts#198, if available:

Description of changes:
* Add affinity to aws-node-termination-handler to not schedule on a
fargate node

Per https://github.com/aws/eks-charts/pull/199#issuecomment-655545982 I'm creating a PR on this repo instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.