### PR TITLE
Fix explanation of ignore-daemon-sets flag

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -105,7 +105,7 @@ func ParseCliArgs() (config Config, err error) {
 	flag.BoolVar(&config.DryRun, "dry-run", getBoolEnv(dryRunConfigKey, false), "If true, only log if a node would be drained")
 	flag.StringVar(&config.NodeName, "node-name", getEnv(nodeNameConfigKey, ""), "The kubernetes node name")
 	flag.StringVar(&config.MetadataURL, "metadata-url", getEnv(instanceMetadataURLConfigKey, defaultInstanceMetadataURL), "The URL of EC2 instance metadata. This shouldn't need to be changed unless you are testing.")
-	flag.BoolVar(&config.IgnoreDaemonSets, "ignore-daemon-sets", getBoolEnv(ignoreDaemonSetsConfigKey, true), "If true, drain daemon sets when a spot interrupt is received.")
+	flag.BoolVar(&config.IgnoreDaemonSets, "ignore-daemon-sets", getBoolEnv(ignoreDaemonSetsConfigKey, true), "If true, ignore daemon sets and drain other pods when a spot interrupt is received.")
 	flag.BoolVar(&config.DeleteLocalData, "delete-local-data", getBoolEnv(deleteLocalDataConfigKey, true), "If true, do not drain pods that are using local node storage in emptyDir")
 	flag.StringVar(&config.KubernetesServiceHost, "kubernetes-service-host", getEnv(kubernetesServiceHostConfigKey, ""), "[ADVANCED] The k8s service host to send api calls to.")
 	flag.StringVar(&config.KubernetesServicePort, "kubernetes-service-port", getEnv(kubernetesServicePortConfigKey, ""), "[ADVANCED] The k8s service port to send api calls to.")


### PR DESCRIPTION
The `ignore-daemon-sets` flag is [compatible with `kubectl drain --ignore-daemonsets`](--ignore-daemonsets). It literally ignores daemon sets to proceed a drain. However, the description of `ignore-daemon-sets` flag says

>If true, drain daemon sets when a spot interrupt is received.

This is the opposite meaning of what exactly this flag wants to do.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
