### PR TITLE
remove + from major minor server version

### DIFF
--- a/config/helm/aws-node-termination-handler/templates/_helpers.tpl
+++ b/config/helm/aws-node-termination-handler/templates/_helpers.tpl
@@ -71,7 +71,7 @@ In 1.14 "beta.kubernetes.io" was deprecated and is scheduled for removal in 1.18
 See https://v1-14.docs.kubernetes.io/docs/setup/release/notes/#deprecations
 */}}
 {{- define "aws-node-termination-handler.defaultNodeSelectorTermsPrefix" -}}
-    {{- $k8sVersion := printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor -}}
+    {{- $k8sVersion := printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor | replace "+" "" -}}
     {{- semverCompare "<1.14" $k8sVersion | ternary "beta.kubernetes.io" "kubernetes.io" -}}
 {{- end -}}
 

--- a/config/helm/ec2-metadata-test-proxy/templates/daemonset.yaml
+++ b/config/helm/ec2-metadata-test-proxy/templates/daemonset.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ec2MetadataTestProxy.create -}}
 {{- $isWindows := (contains "windows" .Values.targetNodeOs) -}}
-{{- $k8sVersion := printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor -}}
+{{- $k8sVersion := printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor | replace "+" "" -}}
 {{- $osSelector := (semverCompare "<1.14" $k8sVersion | ternary "beta.kubernetes.io/os" "kubernetes.io/os") -}}
 apiVersion: apps/v1
 kind: DaemonSet

--- a/config/helm/ec2-metadata-test-proxy/templates/regular-pod-test.yaml
+++ b/config/helm/ec2-metadata-test-proxy/templates/regular-pod-test.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.regularPodTest.create -}}
 {{- $isWindows := (contains "windows" .Values.targetNodeOs) -}}
-{{- $k8sVersion := printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor -}}
+{{- $k8sVersion := printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor | replace "+" "" -}}
 {{- $osSelector := (semverCompare "<1.14" $k8sVersion | ternary "beta.kubernetes.io/os" "kubernetes.io/os") -}}
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-node-termination-handler/issues/193

Description of changes:
 - Fix semver comparison in the helm chart when the server provider's major number includes a "+" like in the case of EKS. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
