### PR TITLE
Add PodMonitor for Prometheus Metrics

### DIFF
--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -100,6 +100,10 @@ Parameter | Description | Default
 `targetNodeOs | Space separated list of node OS's to target, e.g. "linux", "windows", "linux windows".  Note: Windows support is experimental. | `"linux"`
 `enablePrometheusServer` | If true, start an http server exposing `/metrics` endpoint for prometheus. | `false`
 `prometheusServerPort` | Replaces the default HTTP port for exposing prometheus metrics. | `9092`
+`podMonitor.create` | if `true`, create a PodMonitor | `false`
+`podMonitor.interval` | Prometheus scrape interval | `30s`
+`podMonitor.sampleLimit` | Number of scraped samples accepted | `5000`
+`podMonitor.labels` | Additional PodMonitor metadata labels | `{}`
 
 ## Metrics endpoint consideration
 If prometheus server is enabled and since NTH is a daemonset with `host_networking=true`, nothing else will be able to bind to `:9092` (or the port configured) in the root network namespace

--- a/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -151,6 +151,13 @@ spec:
             value: {{ .Values.prometheusServerPort | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.enablePrometheusServer }}
+          ports:
+          - containerPort: {{ .Values.prometheusServerPort | quote }}
+            hostPort: {{ .Values.prometheusServerPort | quote }}
+            name: http-metrics
+            protocol: TCP
+          {{- end }}
       nodeSelector:
         {{ include "aws-node-termination-handler.nodeSelectorTermsOs" . }}: linux
         {{- with .Values.nodeSelector }}

--- a/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -153,8 +153,8 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.enablePrometheusServer }}
           ports:
-          - containerPort: {{ .Values.prometheusServerPort | quote }}
-            hostPort: {{ .Values.prometheusServerPort | quote }}
+          - containerPort: {{ .Values.prometheusServerPort }}
+            hostPort: {{ .Values.prometheusServerPort }}
             name: http-metrics
             protocol: TCP
           {{- end }}

--- a/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -123,6 +123,13 @@ spec:
             value: {{ .Values.prometheusServerPort | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.enablePrometheusServer }}
+          ports:
+          - containerPort: {{ .Values.prometheusServerPort | quote }}
+            hostPort: {{ .Values.prometheusServerPort | quote }}
+            name: http-metrics
+            protocol: TCP
+          {{- end }}
       nodeSelector:
         {{ include "aws-node-termination-handler.nodeSelectorTermsOs" . }}: windows
         {{- with .Values.nodeSelector }}

--- a/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -125,8 +125,8 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.enablePrometheusServer }}
           ports:
-          - containerPort: {{ .Values.prometheusServerPort | quote }}
-            hostPort: {{ .Values.prometheusServerPort | quote }}
+          - containerPort: {{ .Values.prometheusServerPort  }}
+            hostPort: {{ .Values.prometheusServerPort }}
             name: http-metrics
             protocol: TCP
           {{- end }}

--- a/config/helm/aws-node-termination-handler/templates/podmonitor.yaml
+++ b/config/helm/aws-node-termination-handler/templates/podmonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.podMonitor.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ template "aws-node-termination-handler.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "aws-node-termination-handler.labels" . | indent 4 }}
+{{- with .Values.podMonitor.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+ spec:
+  jobLabel: {{ include "aws-node-termination-handler.name" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+  - interval: {{ .Values.podMonitor.interval }}
+    path: /metrics
+    port: http-metrics
+  sampleLimit: {{ .Values.podMonitor.sampleLimit }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "aws-node-termination-handler.name" . }}
+{{- end }}

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -117,3 +117,13 @@ rbac:
   pspEnabled: true
 
 dnsPolicy: ""
+
+podMonitor:
+  # Specifies whether PodMonitor should be created
+  create: false
+   # The Prometheus scrape interval
+  interval: 30s
+  # The number of scraped samples that will be accepted
+  sampleLimit: 5000
+   # Additional labels to add to the metadata
+  labels: {}


### PR DESCRIPTION
## Description of changes:
Since Prometheus metrics are now available, we want to be able to scrape those metrics. This PR adds a container port for the prometheus metrics and creates a `PodMonitor` to scrape the `/metrics` endpoint. Fixes issue: https://github.com/aws/aws-node-termination-handler/issues/204

By adding the following values

```
podMonitor:
  # Specifies whether PodMonitor should be created
  create: true
   # The Prometheus scrape interval
  interval: 30s
  # The number of scraped samples that will be accepted
  sampleLimit: 5000
   # Additional labels to add to the metadata
  labels:
    prometheus: kube-prometheus
```

Generates the following PodMonitor

```
apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  name: release-name-aws-node-termination-handler
  namespace: default
  labels:
    app.kubernetes.io/name: aws-node-termination-handler
    helm.sh/chart: aws-node-termination-handler-0.9.1
    app.kubernetes.io/instance: release-name
    k8s-app: aws-node-termination-handler
    app.kubernetes.io/version: "1.6.1"
    app.kubernetes.io/managed-by: Tiller
    prometheus: kube-prometheus
    
 spec:
  jobLabel: aws-node-termination-handler
  namespaceSelector:
    matchNames:
    - default
  podMetricsEndpoints:
  - interval: 30s
    path: /metrics
    port: http-metrics
  sampleLimit: 5000
  selector:
    matchLabels:
      app.kubernetes.io/name: aws-node-termination-handler
```
Ports
```
apiVersion: apps/v1
kind: DaemonSet
          ports:
          - containerPort: "9092"
            hostPort: "9092"
            name: http-metrics
            protocol: TCP
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
