### PR TITLE
cleanup webhook secret after each test run

### DIFF
--- a/test/e2e/webhook-secret-test
+++ b/test/e2e/webhook-secret-test
@@ -15,8 +15,15 @@ echo "Starting Webhook URL Secret Test for Node Termination Handler"
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 WEBHOOKURL_LITERAL="webhookurl=http://localhost:$IMDS_PORT"
+WEBHOOK_NAME="webhooksecret"
 
-kubectl create secret -n kube-system generic webhooksecret --from-literal=$WEBHOOKURL_LITERAL
+function cleanup {
+  kubectl delete secret -n kube-system "${WEBHOOK_NAME}" || :
+}
+
+kubectl create secret -n kube-system generic "${WEBHOOK_NAME}" --from-literal=$WEBHOOKURL_LITERAL
+
+trap "cleanup" EXIT INT TERM ERR
 
 helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ \
   --wait \


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Cleanup Webhook Secret after the test runs so that another test can be run on the same cluster

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
