### PR TITLE
squid fixes for webhook-http-proxy-test

### DIFF
--- a/test/e2e/webhook-http-proxy-test
+++ b/test/e2e/webhook-http-proxy-test
@@ -126,6 +126,19 @@ if [[ $deployed -eq 0 ]]; then
     fail_end_exit 2
 fi
 
+## Squid can take a while to start, try to get a squid worker pod, if not, hope for the best when assertions are checked
+squid_worker_pods=""
+for i in `seq 1 10`; do
+  echo "Checking if squid http-proxy has started..."
+  squid_worker_pods=$(kubectl get pods -o json | jq '.items[] | select( .metadata.name | contains("squid") ) | .metadata.name as $name | select( .spec.nodeName | contains("worker") ) | .spec.nodeName as $nodename | $name' -r || :)
+  if [[ -z "${squid_worker_pods}" ]]; then 
+    echo "Still waiting on squid..." 
+    sleep 10
+  else
+    break
+  fi
+done
+
 cordoned=0
 evicted=0
 sent=0
@@ -144,10 +157,10 @@ for i in `seq 1 $TAINT_CHECK_CYCLES`; do
   if [[ $evicted -eq 1 && $sent -eq 0 ]] && kubectl logs $pod_id -n kube-system | grep 'Webhook Success' >/dev/null; then
     echo "✅ Verified that webhook successfully sent"
     sent=1
-    squid_worker_pods=$(kubectl get pods -o json | jq '.items[] | select( .metadata.name | contains("squid") ) | .metadata.name as $name | select( .spec.nodeName | contains("worker") ) | .spec.nodeName as $nodename | $name' -r)
   fi
 
-  if [[ $sent -eq 1 ]] && kubectl exec -it $(echo $squid_worker_pods | cut -d' ' -f1) -- cat /var/log/squid/access.log | grep "${WEBHOOK_URL}" >/dev/null; then
+  webhook_hostname=$(echo "${WEBHOOK_URL}" |sed -e 's|^[^/]*//||' -e 's|/.*$||')
+  if [[ $sent -eq 1 ]] && kubectl exec -it $(echo $squid_worker_pods | cut -d' ' -f1) -- cat /var/log/squid/access.log | grep "${webhook_hostname}" >/dev/null; then
      echo "✅ Verified the webhook POST used the http proxy"
         exit 0
   fi

--- a/test/e2e/webhook-http-proxy-test
+++ b/test/e2e/webhook-http-proxy-test
@@ -12,16 +12,59 @@ set -euo pipefail
 #   $AEMM_URL
 #   $AEMM_VERSION
 
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+SQUID_DOCKERHUB_IMG="sameersbn/squid:3.5.27-2@sha256:e98299069f0c6e3d9b9188903518e2f44ac36b1fa5007e879af518e1c0a234af"
+SQUID_DOCKER_IMG="squid:customtest"
+
 function fail_and_exit {
     echo "❌ Webhook HTTP Proxy Test failed $CLUSTER_NAME ❌"
     exit ${1:-1}
 }
 
-echo "Starting Webhook HTTP Proxy Test for Node Termination Handler"
+function get_squild_worker_pod() {
+  kubectl get pods -o json | \
+    jq '.items[] | select( .metadata.name | contains("squid") ) | .metadata.name as $name | select( .spec.nodeName | contains("worker") ) | .spec.nodeName as $nodename | $name' -r 2> /dev/null || echo ""
+}
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-SQUID_DOCKERHUB_IMG="sameersbn/squid:3.5.27-2@sha256:e98299069f0c6e3d9b9188903518e2f44ac36b1fa5007e879af518e1c0a234af"
-SQUID_DOCKER_IMG="squid:customtest"
+function start_squid() {
+  kubectl delete configmap squid-config || :
+  kubectl create configmap squid-config --from-file=$SCRIPTPATH/../assets/squid.conf
+
+  old_squid_pods=""
+  for i in `seq 1 10`; do
+    echo "Checking if squid http-proxy has been terminated from previous run..."
+    old_squid_pods="$(get_squild_worker_pod)"
+    if [[ -n "${old_squid_pods}" ]]; then 
+      echo "Still waiting on squid to terminate from last run..."
+      sleep 10
+    else
+      break
+    fi
+  done
+
+  helm upgrade --install $CLUSTER_NAME-squid $SCRIPTPATH/../../config/helm/squid/ \
+    --force \
+    --wait \
+    --namespace default \
+    --set squid.configMap="squid-config" \
+    --set squid.image.repository="squid" \
+    --set squid.image.tag="customtest"
+
+  ## Squid can take a while to start, try to get a squid worker pod, if not, hope for the best when assertions are checked
+  squid_worker_pods=""
+  for i in `seq 1 10`; do
+    echo "Checking if squid http-proxy has started..."
+    squid_worker_pods="$(get_squild_worker_pod)"
+    if [[ -z "${squid_worker_pods}" ]]; then 
+      echo "Still waiting on squid..."
+      sleep 10
+    else
+      break
+    fi
+  done
+}
+
+echo "Starting Webhook HTTP Proxy Test for Node Termination Handler"
 
 ### LOCAL ONLY TESTS FOR 200 RESPONSE FROM LOCAL CLUSTER, MASTER WILL TEST WITH TRAVIS SECRET URL
 if [[ -z "${WEBHOOK_URL-}" ]]; then
@@ -32,18 +75,9 @@ docker pull $SQUID_DOCKERHUB_IMG
 docker tag $SQUID_DOCKERHUB_IMG $SQUID_DOCKER_IMG
 kind load docker-image --name $CLUSTER_NAME --nodes=$CLUSTER_NAME-worker,$CLUSTER_NAME-control-plane $SQUID_DOCKER_IMG
 
-kubectl delete configmap squid-config || :
-kubectl create configmap squid-config --from-file=$SCRIPTPATH/../assets/squid.conf
-
-helm upgrade --install $CLUSTER_NAME-squid $SCRIPTPATH/../../config/helm/squid/ \
-  --force \
-  --wait \
-  --namespace default \
-  --set squid.configMap="squid-config" \
-  --set squid.image.repository="squid" \
-  --set squid.image.tag="customtest"
-
-sleep 20
+## Starts squid and waits for pods to be ready
+start_squid
+squid_worker_pods=$(get_squild_worker_pod)
 
 common_helm_args=()
 [[ "${TEST_WINDOWS-}" == "true" ]] && common_helm_args+=(--set targetNodeOs="windows")
@@ -56,6 +90,7 @@ anth_helm_args=(
   $SCRIPTPATH/../../config/helm/aws-node-termination-handler/
   --force
   --namespace kube-system
+  --wait
   --set instanceMetadataURL="http://$AEMM_URL:$IMDS_PORT"
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
@@ -126,19 +161,6 @@ if [[ $deployed -eq 0 ]]; then
     fail_end_exit 2
 fi
 
-## Squid can take a while to start, try to get a squid worker pod, if not, hope for the best when assertions are checked
-squid_worker_pods=""
-for i in `seq 1 10`; do
-  echo "Checking if squid http-proxy has started..."
-  squid_worker_pods=$(kubectl get pods -o json | jq '.items[] | select( .metadata.name | contains("squid") ) | .metadata.name as $name | select( .spec.nodeName | contains("worker") ) | .spec.nodeName as $nodename | $name' -r || :)
-  if [[ -z "${squid_worker_pods}" ]]; then 
-    echo "Still waiting on squid..." 
-    sleep 10
-  else
-    break
-  fi
-done
-
 cordoned=0
 evicted=0
 sent=0
@@ -159,7 +181,7 @@ for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     sent=1
   fi
 
-  webhook_hostname=$(echo "${WEBHOOK_URL}" |sed -e 's|^[^/]*//||' -e 's|/.*$||')
+  webhook_hostname=$(echo "${WEBHOOK_URL}" | sed -e 's@^[^/]*//@@' -e 's@/.*$@@')
   if [[ $sent -eq 1 ]] && kubectl exec -it $(echo $squid_worker_pods | cut -d' ' -f1) -- cat /var/log/squid/access.log | grep "${webhook_hostname}" >/dev/null; then
      echo "✅ Verified the webhook POST used the http proxy"
         exit 0


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-node-termination-handler/pull/214

Description of changes:
 - Turns out the changes in https://github.com/aws/aws-node-termination-handler/pull/214 breaks the tests on a real webhook endpoint (or at least an endpoint with a context path).
 - The squid access logs only log the domain, not the context path, so need to truncate the full URL to just the domain. 
 - Also, sometimes squid takes an eternity to start up, so added a while loop to wait for it to come up

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
