### PR TITLE
only deploy to worker node on e2e tests

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -11,7 +11,7 @@ ARG GOPROXY="https://proxy.golang.org,direct"
 WORKDIR /node-termination-handler
 COPY go.mod .
 COPY go.sum .
-RUN go mod download
+RUN go mod download -x
 
 # Build
 COPY . .

--- a/config/helm/squid/templates/daemonset.yaml
+++ b/config/helm/squid/templates/daemonset.yaml
@@ -14,8 +14,6 @@ spec:
         app: {{ .Values.squid.label }}
     spec:
       serviceAccountName: {{ template "squid.serviceAccountName" . }}
-      hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: {{ .Values.squid.label }}
         image: {{ .Values.squid.image.repository }}:{{ .Values.squid.image.tag }}

--- a/config/helm/squid/templates/service.yaml
+++ b/config/helm/squid/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.squid.label }}
+spec:
+  selector:
+    app: {{ .Values.squid.label }}
+  ports:
+  - port: {{ .Values.squid.port }}
+    protocol: TCP
+

--- a/config/helm/webhook-test-proxy/templates/daemonset.yaml
+++ b/config/helm/webhook-test-proxy/templates/daemonset.yaml
@@ -20,9 +20,6 @@ spec:
       serviceAccountName: {{ template "webhook-test-proxy.serviceAccountName" . }}
       nodeSelector:
         {{ $osSelector }}: {{ $isWindows | ternary "windows" "linux" }}
-      {{- if (not $isWindows) }}
-      hostNetwork: true
-      {{- end }}
       containers:
         - name: {{ .Values.webhookTestProxy.label }}
           image: {{ .Values.webhookTestProxy.image.repository }}:{{ .Values.webhookTestProxy.image.tag }}

--- a/test/e2e/webhook-http-proxy-test
+++ b/test/e2e/webhook-http-proxy-test
@@ -103,7 +103,7 @@ emtp_helm_args=(
   $SCRIPTPATH/../../config/helm/webhook-test-proxy/
   --wait
   --namespace default
-  --set webhookTestProxy.port="$IMDS_PORT"
+  --set webhookTestProxy.port="$(echo ${WEBHOOK_URL} | rev | cut -d':' -f1 | rev)"
   --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
   --set webhookTestProxy.image.tag="$WEBHOOK_DOCKER_TAG"
 )

--- a/test/e2e/webhook-http-proxy-test
+++ b/test/e2e/webhook-http-proxy-test
@@ -15,13 +15,15 @@ set -euo pipefail
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 SQUID_DOCKERHUB_IMG="sameersbn/squid:3.5.27-2@sha256:e98299069f0c6e3d9b9188903518e2f44ac36b1fa5007e879af518e1c0a234af"
 SQUID_DOCKER_IMG="squid:customtest"
+SQUID_PORT="3128"
+SQUID_URL="tcp://squid.default.svc.cluster.local:$SQUID_PORT"
 
 function fail_and_exit {
     echo "❌ Webhook HTTP Proxy Test failed $CLUSTER_NAME ❌"
     exit ${1:-1}
 }
 
-function get_squild_worker_pod() {
+function get_squid_worker_pod() {
   kubectl get pods -o json | \
     jq '.items[] | select( .metadata.name | contains("squid") ) | .metadata.name as $name | select( .spec.nodeName | contains("worker") ) | .spec.nodeName as $nodename | $name' -r 2> /dev/null || echo ""
 }
@@ -33,7 +35,7 @@ function start_squid() {
   old_squid_pods=""
   for i in `seq 1 10`; do
     echo "Checking if squid http-proxy has been terminated from previous run..."
-    old_squid_pods="$(get_squild_worker_pod)"
+    old_squid_pods="$(get_squid_worker_pod)"
     if [[ -n "${old_squid_pods}" ]]; then 
       echo "Still waiting on squid to terminate from last run..."
       sleep 10
@@ -54,7 +56,7 @@ function start_squid() {
   squid_worker_pods=""
   for i in `seq 1 10`; do
     echo "Checking if squid http-proxy has started..."
-    squid_worker_pods="$(get_squild_worker_pod)"
+    squid_worker_pods="$(get_squid_worker_pod)"
     if [[ -z "${squid_worker_pods}" ]]; then 
       echo "Still waiting on squid..."
       sleep 10
@@ -66,18 +68,13 @@ function start_squid() {
 
 echo "Starting Webhook HTTP Proxy Test for Node Termination Handler"
 
-### LOCAL ONLY TESTS FOR 200 RESPONSE FROM LOCAL CLUSTER, MASTER WILL TEST WITH TRAVIS SECRET URL
-if [[ -z "${WEBHOOK_URL-}" ]]; then
-  WEBHOOK_URL="http://127.0.0.1:$IMDS_PORT"
-fi
-
 docker pull $SQUID_DOCKERHUB_IMG
 docker tag $SQUID_DOCKERHUB_IMG $SQUID_DOCKER_IMG
 kind load docker-image --name $CLUSTER_NAME --nodes=$CLUSTER_NAME-worker,$CLUSTER_NAME-control-plane $SQUID_DOCKER_IMG
 
 ## Starts squid and waits for pods to be ready
 start_squid
-squid_worker_pods=$(get_squild_worker_pod)
+squid_worker_pods=$(get_squid_worker_pod)
 
 common_helm_args=()
 [[ "${TEST_WINDOWS-}" == "true" ]] && common_helm_args+=(--set targetNodeOs="windows")
@@ -92,6 +89,8 @@ aemm_helm_args=(
   --namespace default
   --set servicePort="$IMDS_PORT"
 )
+[[ ${#common_helm_args[@]} -gt 0 ]] &&
+    aemm_helm_args+=("${common_helm_args[@]}")
 
 set -x
 helm "${aemm_helm_args[@]}"
@@ -132,10 +131,12 @@ anth_helm_args=(
   --set enableScheduledEventDraining="true"
   --set webhookURL="$WEBHOOK_URL"
   --set webhookTemplate="\{\"Content\":\"[NTH][Instance Interruption] InstanceId: \{\{ \.InstanceID \}\} - InstanceType: \{\{ \.InstanceType \}\} - Kind: \{\{ \.Kind \}\} - Start Time: \{\{ \.StartTime \}\}\"\}"
-  --set webhookProxy="tcp://localhost:3128"
+  --set webhookProxy="$SQUID_URL"
 )
+[[ -n "${NODE_TERMINATION_HANDLER_DOCKER_PULL_POLICY-}" ]] &&
+    anth_helm_args+=(--set image.pullPolicy="$NODE_TERMINATION_HANDLER_DOCKER_PULL_POLICY")
 [[ ${#common_helm_args[@]} -gt 0 ]] &&
-    aemm_helm_args+=("${common_helm_args[@]}")
+    anth_helm_args+=("${common_helm_args[@]}")
 
 set -x
 helm "${anth_helm_args[@]}"

--- a/test/e2e/webhook-http-proxy-test
+++ b/test/e2e/webhook-http-proxy-test
@@ -83,30 +83,18 @@ common_helm_args=()
 [[ "${TEST_WINDOWS-}" == "true" ]] && common_helm_args+=(--set targetNodeOs="windows")
 [[ -n "${NTH_WORKER_LABEL-}" ]] && common_helm_args+=(--set nodeSelector."$NTH_WORKER_LABEL")
 
-anth_helm_args=(
+aemm_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-anth
-  $SCRIPTPATH/../../config/helm/aws-node-termination-handler/
-  --force
-  --namespace kube-system
+  $CLUSTER_NAME-aemm
+  $AEMM_DL_URL
   --wait
-  --set instanceMetadataURL="http://$AEMM_URL:$IMDS_PORT"
-  --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
-  --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
-  --set enableSpotInterruptionDraining="true"
-  --set enableScheduledEventDraining="true"
-  --set webhookURL="$WEBHOOK_URL"
-  --set webhookTemplate="\{\"Content\":\"[NTH][Instance Interruption] InstanceId: \{\{ \.InstanceID \}\} - InstanceType: \{\{ \.InstanceType \}\} - Kind: \{\{ \.Kind \}\} - Start Time: \{\{ \.StartTime \}\}\"\}"
-  --set webhookProxy="tcp://localhost:3128"
+  --namespace default
+  --set servicePort="$IMDS_PORT"
 )
-[[ -n "${NODE_TERMINATION_HANDLER_DOCKER_PULL_POLICY-}" ]] &&
-    anth_helm_args+=(--set image.pullPolicy="$NODE_TERMINATION_HANDLER_DOCKER_PULL_POLICY")
-[[ ${#common_helm_args[@]} -gt 0 ]] &&
-    anth_helm_args+=("${common_helm_args[@]}")
 
 set -x
-helm "${anth_helm_args[@]}"
+helm "${aemm_helm_args[@]}"
 set +x
 
 emtp_helm_args=(
@@ -129,20 +117,28 @@ set -x
 helm "${emtp_helm_args[@]}"
 set +x
 
-aemm_helm_args=(
+anth_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-aemm
-  $AEMM_DL_URL
+  $CLUSTER_NAME-anth
+  $SCRIPTPATH/../../config/helm/aws-node-termination-handler/
+  --force
+  --namespace kube-system
   --wait
-  --namespace default
-  --set servicePort="$IMDS_PORT"
+  --set instanceMetadataURL="http://$AEMM_URL:$IMDS_PORT"
+  --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
+  --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
+  --set enableSpotInterruptionDraining="true"
+  --set enableScheduledEventDraining="true"
+  --set webhookURL="$WEBHOOK_URL"
+  --set webhookTemplate="\{\"Content\":\"[NTH][Instance Interruption] InstanceId: \{\{ \.InstanceID \}\} - InstanceType: \{\{ \.InstanceType \}\} - Kind: \{\{ \.Kind \}\} - Start Time: \{\{ \.StartTime \}\}\"\}"
+  --set webhookProxy="tcp://localhost:3128"
 )
 [[ ${#common_helm_args[@]} -gt 0 ]] &&
     aemm_helm_args+=("${common_helm_args[@]}")
 
 set -x
-helm "${aemm_helm_args[@]}"
+helm "${anth_helm_args[@]}"
 set +x
 
 TAINT_CHECK_CYCLES=15

--- a/test/e2e/webhook-secret-test
+++ b/test/e2e/webhook-secret-test
@@ -52,7 +52,7 @@ emtp_helm_args=(
   $SCRIPTPATH/../../config/helm/webhook-test-proxy/
   --wait
   --namespace default
-  --set webhookTestProxy.port="$IMDS_PORT"
+  --set webhookTestProxy.port="$(echo ${WEBHOOK_URL} | rev | cut -d':' -f1 | rev)"
   --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
   --set webhookTestProxy.image.tag="$WEBHOOK_DOCKER_TAG"
 )

--- a/test/e2e/webhook-secret-test
+++ b/test/e2e/webhook-secret-test
@@ -14,7 +14,7 @@ echo "Starting Webhook URL Secret Test for Node Termination Handler"
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-WEBHOOKURL_LITERAL="webhookurl=http://localhost:$IMDS_PORT"
+WEBHOOKURL_LITERAL="webhookurl=${WEBHOOK_URL}"
 WEBHOOK_NAME="webhooksecret"
 
 function cleanup {
@@ -25,28 +25,70 @@ kubectl create secret -n kube-system generic "${WEBHOOK_NAME}" --from-literal=$W
 
 trap "cleanup" EXIT INT TERM ERR
 
-helm upgrade --install $CLUSTER_NAME-anth $SCRIPTPATH/../../config/helm/aws-node-termination-handler/ \
-  --wait \
-  --force \
-  --namespace kube-system \
-  --set instanceMetadataURL="http://$AEMM_URL:$IMDS_PORT" \
-  --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO" \
-  --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG" \
-  --set webhookURLSecretName=webhooksecret \
-  --set webhookTemplate="\{\"Content\":\"[NTH][Instance Interruption] InstanceId: \{\{ \.InstanceID \}\} - InstanceType: \{\{ \.InstanceType \}\} - Kind: \{\{ \.Kind \}\} - Start Time: \{\{ \.StartTime \}\}\"\}" \
-  --set enableSpotInterruptionDraining="true" \
-  --set enableScheduledEventDraining="true"
+common_helm_args=()
+[[ "${TEST_WINDOWS-}" == "true" ]] && common_helm_args+=(--set targetNodeOs="windows")
+[[ -n "${NTH_WORKER_LABEL-}" ]] && common_helm_args+=(--set nodeSelector."$NTH_WORKER_LABEL")
 
-helm upgrade --install $CLUSTER_NAME-aemm $AEMM_DL_URL \
-  --wait \
-  --namespace default \
+aemm_helm_args=(
+  upgrade
+  --install
+  $CLUSTER_NAME-aemm
+  $AEMM_DL_URL
+  --wait
+  --namespace default
   --set servicePort="$IMDS_PORT"
+)
+[[ ${#common_helm_args[@]} -gt 0 ]] &&
+    aemm_helm_args+=("${common_helm_args[@]}")
 
-helm upgrade --install $CLUSTER_NAME-emtp $SCRIPTPATH/../../config/helm/webhook-test-proxy/ \
-  --wait \
-  --force \
-  --namespace default \
+set -x
+helm "${aemm_helm_args[@]}"
+set +x
+
+emtp_helm_args=(
+  upgrade
+  --install
+  $CLUSTER_NAME-emtp
+  $SCRIPTPATH/../../config/helm/webhook-test-proxy/
+  --wait
+  --namespace default
   --set webhookTestProxy.port="$IMDS_PORT"
+  --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
+  --set webhookTestProxy.image.tag="$WEBHOOK_DOCKER_TAG"
+)
+[[ -n "${WEBHOOK_DOCKER_PULL_POLICY-}" ]] &&
+    emtp_helm_args+=(--set webhookTestProxy.image.pullPolicy="$WEBHOOK_DOCKER_PULL_POLICY")
+[[ ${#common_helm_args[@]} -gt 0 ]] &&
+    emtp_helm_args+=("${common_helm_args[@]}")
+
+set -x
+helm "${emtp_helm_args[@]}"
+set +x
+
+anth_helm_args=(
+  upgrade
+  --install
+  $CLUSTER_NAME-anth
+  $SCRIPTPATH/../../config/helm/aws-node-termination-handler/
+  --force
+  --namespace kube-system
+  --wait
+  --set instanceMetadataURL="http://$AEMM_URL:$IMDS_PORT"
+  --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
+  --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
+  --set enableSpotInterruptionDraining="true"
+  --set enableScheduledEventDraining="true"
+  --set webhookURLSecretName=webhooksecret \
+  --set webhookTemplate="\{\"Content\":\"[NTH][Instance Interruption] InstanceId: \{\{ \.InstanceID \}\} - InstanceType: \{\{ \.InstanceType \}\} - Kind: \{\{ \.Kind \}\} - Start Time: \{\{ \.StartTime \}\}\"\}"
+)
+[[ -n "${NODE_TERMINATION_HANDLER_DOCKER_PULL_POLICY-}" ]] &&
+    anth_helm_args+=(--set image.pullPolicy="$NODE_TERMINATION_HANDLER_DOCKER_PULL_POLICY")
+[[ ${#common_helm_args[@]} -gt 0 ]] &&
+    anth_helm_args+=("${common_helm_args[@]}")
+
+set -x
+helm "${anth_helm_args[@]}"
+set +x
 
 TAINT_CHECK_CYCLES=15
 TAINT_CHECK_SLEEP=15

--- a/test/e2e/webhook-test
+++ b/test/e2e/webhook-test
@@ -36,7 +36,7 @@ anth_helm_args=(
   --set instanceMetadataURL=${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
-  --set webhookURL="${WEBHOOK_URL:-"http://localhost:$IMDS_PORT"}"
+  --set webhookURL="${WEBHOOK_URL}"
   --set webhookTemplate="\{\"Content\":\"[NTH][Instance Interruption] InstanceId: \{\{ \.InstanceID \}\} - InstanceType: \{\{ \.InstanceType \}\} -  AvailabilityZone: \{\{ \.AvailabilityZone \}\} - Kind: \{\{ \.Kind \}\} - Start Time: \{\{ \.StartTime \}\}\"\}"
   --set enableSpotInterruptionDraining="true"
   --set enableScheduledEventDraining="true"
@@ -58,7 +58,7 @@ emtp_helm_args=(
   $SCRIPTPATH/../../config/helm/webhook-test-proxy/
   --wait
   --namespace default
-  --set webhookTestProxy.port="$IMDS_PORT"
+  --set webhookTestProxy.port="$(echo ${WEBHOOK_URL} | rev | cut -d':' -f1 | rev)"
   --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
   --set webhookTestProxy.image.tag="$WEBHOOK_DOCKER_TAG"
 )

--- a/test/k8s-local-cluster-test/run-test
+++ b/test/k8s-local-cluster-test/run-test
@@ -47,11 +47,11 @@ function reset_cluster {
     echo "Resetting cluster"
     charts=$(helm ls --all --short)
     if [[ ! -z "$charts" ]]; then
-        helm del $charts || :
+        helm del $charts --no-hooks || :
     fi
     system_charts=$(helm ls --all --short --namespace kube-system)
     if [[ ! -z "$system_charts" ]]; then
-        helm del $system_charts --namespace kube-system || :
+        helm del $system_charts --no-hooks --namespace kube-system || :
     fi
     for node in $(kubectl get nodes | tail -n+2 | cut -d' ' -f1); do
         kubectl uncordon $node
@@ -208,6 +208,7 @@ export NODE_TERMINATION_HANDLER_DOCKER_TAG=$(echo $NODE_TERMINATION_HANDLER_DOCK
 export WEBHOOK_DOCKER_IMG=$(cat $TMP_DIR/webhook-test-proxy-docker-img)
 export WEBHOOK_DOCKER_REPO=$(echo $WEBHOOK_DOCKER_IMG | cut -d':' -f1)
 export WEBHOOK_DOCKER_TAG=$(echo $WEBHOOK_DOCKER_IMG | cut -d':' -f2)
+export NTH_WORKER_LABEL="kubernetes\.io/hostname=$CLUSTER_NAME-worker"
 ###
 
 i=0

--- a/test/k8s-local-cluster-test/run-test
+++ b/test/k8s-local-cluster-test/run-test
@@ -18,7 +18,7 @@ K8S_VERSION="1.16"
 AEMM_URL="amazon-ec2-metadata-mock-service.default.svc.cluster.local"
 AEMM_VERSION="1.2.0"
 AEMM_DL_URL="https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v"$AEMM_VERSION"/amazon-ec2-metadata-mock-"$AEMM_VERSION".tgz"
-WEBHOOK_URL=${WEBHOOK_URL:="http://webhook-test-proxy.default.svc.cluster.local:2318"}
+WEBHOOK_URL=${WEBHOOK_URL:="http://webhook-test-proxy.default.svc.cluster.local:1338"}
 
 ASSERTION_SCRIPTS=$(find $SCRIPTPATH/../e2e -type f | sort)
 

--- a/test/k8s-local-cluster-test/run-test
+++ b/test/k8s-local-cluster-test/run-test
@@ -18,6 +18,8 @@ K8S_VERSION="1.16"
 AEMM_URL="amazon-ec2-metadata-mock-service.default.svc.cluster.local"
 AEMM_VERSION="1.2.0"
 AEMM_DL_URL="https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v"$AEMM_VERSION"/amazon-ec2-metadata-mock-"$AEMM_VERSION".tgz"
+WEBHOOK_URL=${WEBHOOK_URL:="http://webhook-test-proxy.default.svc.cluster.local:2318"}
+
 ASSERTION_SCRIPTS=$(find $SCRIPTPATH/../e2e -type f | sort)
 
 function timeout() { perl -e 'alarm shift; exec @ARGV' "$@"; }
@@ -199,6 +201,7 @@ export CLUSTER_NAME
 export AEMM_URL
 export AEMM_VERSION
 export AEMM_DL_URL
+export WEBHOOK_URL
 export -f timeout
 export -f relpath
 export -f get_nth_worker_pod


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Only deploy NTH pod to worker node in e2e tests.
    - This solves an issue with coredns being evicted and causing webhook failures. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
