### PR TITLE
fix webhook tests

### DIFF
--- a/config/helm/webhook-test-proxy/templates/daemonset.yaml
+++ b/config/helm/webhook-test-proxy/templates/daemonset.yaml
@@ -18,6 +18,12 @@ spec:
         app: {{ .Values.webhookTestProxy.label }}
     spec:
       serviceAccountName: {{ template "webhook-test-proxy.serviceAccountName" . }}
+      {{- if (not $isWindows) }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
+      {{- end }}
       nodeSelector:
         {{ $osSelector }}: {{ $isWindows | ternary "windows" "linux" }}
       containers:
@@ -25,11 +31,10 @@ spec:
           image: {{ .Values.webhookTestProxy.image.repository }}:{{ .Values.webhookTestProxy.image.tag }}
           imagePullPolicy: {{ .Values.webhookTestProxy.image.pullPolicy }}
           ports:
-            - containerPort: {{ .Values.webhookTestProxy.port }}
-              hostPort: {{ .Values.webhookTestProxy.port }}
+            - containerPort: {{ .Values.webhookTestProxy.containerPort }}
           env:
             - name: PORT
-              value: {{ .Values.webhookTestProxy.port | quote }}
+              value: {{ .Values.webhookTestProxy.containerPort | quote }}
           {{- if .Values.webhookTestProxy.tolerations }}
           tolerations:
           {{ toYaml .Values.webhookTestProxy.tolerations | indent 8 }}

--- a/config/helm/webhook-test-proxy/templates/service.yaml
+++ b/config/helm/webhook-test-proxy/templates/service.yaml
@@ -7,5 +7,6 @@ spec:
     app: {{ .Values.webhookTestProxy.label }}
   ports:
   - port: {{ .Values.webhookTestProxy.port }}
+    targetPort: {{ .Values.webhookTestProxy.containerPort }}
     protocol: TCP
 

--- a/config/helm/webhook-test-proxy/values.yaml
+++ b/config/helm/webhook-test-proxy/values.yaml
@@ -13,7 +13,8 @@ serviceAccount:
 webhookTestProxy:
   create: true
   label: webhook-test-proxy
-  port: 1340
+  port: 80
+  containerPort: 1441
   image:
     repository: webhook-test-proxy
     tag: customtest

--- a/test/e2e/webhook-http-proxy-test
+++ b/test/e2e/webhook-http-proxy-test
@@ -103,7 +103,6 @@ emtp_helm_args=(
   $SCRIPTPATH/../../config/helm/webhook-test-proxy/
   --wait
   --namespace default
-  --set webhookTestProxy.port="$(echo ${WEBHOOK_URL} | rev | cut -d':' -f1 | rev)"
   --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
   --set webhookTestProxy.image.tag="$WEBHOOK_DOCKER_TAG"
 )

--- a/test/e2e/webhook-secret-test
+++ b/test/e2e/webhook-secret-test
@@ -52,7 +52,6 @@ emtp_helm_args=(
   $SCRIPTPATH/../../config/helm/webhook-test-proxy/
   --wait
   --namespace default
-  --set webhookTestProxy.port="$(echo ${WEBHOOK_URL} | rev | cut -d':' -f1 | rev)"
   --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
   --set webhookTestProxy.image.tag="$WEBHOOK_DOCKER_TAG"
 )

--- a/test/e2e/webhook-test
+++ b/test/e2e/webhook-test
@@ -58,7 +58,6 @@ emtp_helm_args=(
   $SCRIPTPATH/../../config/helm/webhook-test-proxy/
   --wait
   --namespace default
-  --set webhookTestProxy.port="$(echo ${WEBHOOK_URL} | rev | cut -d':' -f1 | rev)"
   --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
   --set webhookTestProxy.image.tag="$WEBHOOK_DOCKER_TAG"
 )

--- a/test/eks-cluster-test/run-test
+++ b/test/eks-cluster-test/run-test
@@ -31,7 +31,7 @@ USAGE=$(cat << 'EOM'
                  WEBHOOK_DOCKER_PULL_POLICY                   Webhook Proxy Docker image pull policy (defaults to DOCKER_PULL_POLICY)
                  EC2_METADATA_PORT                            EC2 Metadata Test Proxy port (defaults to 18999)
                  EC2_METADATA_URL                             EC2 Metadata Test Proxy URL (defaults to "http://amazon-ec2-metadata-mock-service.default.svc.cluster.local:$EC2_METADATA_PORT")
-                 WEBHOOK_URL                                  Webhook URL (defaults to "http://webhook-test-proxy.default.svc.cluster.local:$EC2_METADATA_PORT")
+                 WEBHOOK_URL                                  Webhook URL (defaults to "http://webhook-test-proxy.default.svc.cluster.local")
 EOM
 )
 
@@ -115,7 +115,7 @@ echo "WEBHOOK_DOCKER_TAG=${WEBHOOK_DOCKER_TAG:?"not found"}"
 echo "WEBHOOK_DOCKER_PULL_POLICY=${WEBHOOK_DOCKER_PULL_POLICY:=$DOCKER_PULL_POLICY}"
 echo "EC2_METADATA_PORT=${EC2_METADATA_PORT:=18999}"
 echo "EC2_METADATA_URL=${EC2_METADATA_URL:="http://amazon-ec2-metadata-mock-service.default.svc.cluster.local:$EC2_METADATA_PORT"}"
-echo "WEBHOOK_URL=${WEBHOOK_URL:="http://webhook-test-proxy.default.svc.cluster.local:$EC2_METADATA_PORT"}"
+echo "WEBHOOK_URL=${WEBHOOK_URL:="http://webhook-test-proxy.default.svc.cluster.local"}"
 
 # The e2e test scripts use other variable names.
 echo "IMDS_PORT=${IMDS_PORT:=$EC2_METADATA_PORT}"

--- a/test/k8s-local-cluster-test/run-test
+++ b/test/k8s-local-cluster-test/run-test
@@ -18,7 +18,7 @@ K8S_VERSION="1.16"
 AEMM_URL="amazon-ec2-metadata-mock-service.default.svc.cluster.local"
 AEMM_VERSION="1.2.0"
 AEMM_DL_URL="https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v"$AEMM_VERSION"/amazon-ec2-metadata-mock-"$AEMM_VERSION".tgz"
-WEBHOOK_URL=${WEBHOOK_URL:="http://webhook-test-proxy.default.svc.cluster.local:1338"}
+WEBHOOK_URL=${WEBHOOK_URL:="http://webhook-test-proxy.default.svc.cluster.local"}
 
 ASSERTION_SCRIPTS=$(find $SCRIPTPATH/../e2e -type f | sort)
 


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
  - Webhook test proxy now runs as a k8s service w/ a static port number (80)
  - Added the security context config for linux on the webhook daemonset 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
