### PR TITLE
default enableSpotInterruptionDraining to true

### DIFF
--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -66,7 +66,7 @@ Parameter | Description | Default
 `webhookTemplate` | Replaces the default webhook message template. | `{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} - State: {{ .State }} - Start Time: {{ .StartTime }}"}`
 `dryRun` | If true, only log if a node would be drained | `false`
 `enableScheduledEventDraining` | [EXPERIMENTAL] If true, drain nodes before the maintenance window starts for an EC2 instance scheduled event | `false`
-`enableSpotInterruptionDraining` | If true, drain nodes when the spot interruption termination notice is received | `true`
+`enableSpotInterruptionDraining` | If false, do not drain nodes when the spot interruption termination notice is received | `true`
 `metadataTries` | The number of times to try requesting metadata. If you would like 2 retries, set metadata-tries to 3. | `3`
 `cordonOnly` | If true, nodes will be cordoned but not drained when an interruption event occurs. | `false`
 `taintNode` | If true, nodes will be tainted when an interruption event occurs. Currently used taint keys are `aws-node-termination-handler/scheduled-maintenance` and `aws-node-termination-handler/spot-itn` | `false`

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -34,7 +34,7 @@ resources:
     cpu: "100m"
 
 ## enableSpotInterruptionDraining If true, drain nodes when the spot interruption termination notice is received
-enableSpotInterruptionDraining: true
+enableSpotInterruptionDraining: "true"
 
 ## enableScheduledEventDraining [EXPERIMENTAL] If true, drain nodes before the maintenance window starts for an EC2 instance scheduled event
 enableScheduledEventDraining: ""

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -34,7 +34,7 @@ resources:
     cpu: "100m"
 
 ## enableSpotInterruptionDraining If true, drain nodes when the spot interruption termination notice is received
-enableSpotInterruptionDraining: ""
+enableSpotInterruptionDraining: true
 
 ## enableScheduledEventDraining [EXPERIMENTAL] If true, drain nodes before the maintenance window starts for an EC2 instance scheduled event
 enableScheduledEventDraining: ""

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -34,7 +34,7 @@ resources:
     cpu: "100m"
 
 ## enableSpotInterruptionDraining If true, drain nodes when the spot interruption termination notice is received
-enableSpotInterruptionDraining: "true"
+enableSpotInterruptionDraining: ""
 
 ## enableScheduledEventDraining [EXPERIMENTAL] If true, drain nodes before the maintenance window starts for an EC2 instance scheduled event
 enableScheduledEventDraining: ""


### PR DESCRIPTION
Description of changes:
According to the README, the default value for enableSpotInterruptionDraining is true, but the value in values.yaml had it set to empty string (""). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
