### PR TITLE
fix manifest updating in push-docker-images

### DIFF
--- a/scripts/push-docker-images
+++ b/scripts/push-docker-images
@@ -8,14 +8,13 @@ MAKE_FILE_PATH=$REPO_ROOT_PATH/Makefile
 
 VERSION=$(make -s -f $MAKE_FILE_PATH version)
 PLATFORMS=("linux/amd64")
-MANIFEST_IMAGES=""
+MANIFEST_IMAGES=()
 MANIFEST=""
 DOCKER_CLI_CONFIG="$HOME/.docker/config.json"
 
 USAGE=$(cat << 'EOM'
   Usage: push-docker-images  [-p <platform pairs>]
   Pushes docker images for the platform pairs passed in w/ a dockerhub manifest
-
   Example: push-docker-images -p "linux/amd64,linux/arm"
           Optional:
             -p          Platform pair list (os/architecture) [DEFAULT: linux/amd64]
@@ -57,9 +56,22 @@ fi
 # if manifest exists already, fetch existing platforms so "updated" manifest includes images
 # that were there previously
 if [[ $MANIFEST == "true" ]]; then
+  if [[ ! -f $DOCKER_CLI_CONFIG ]]; then
+    echo '{"experimental":"enabled"}' > $DOCKER_CLI_CONFIG
+    echo "Created docker config file"
+  fi
+  cat <<< $(jq '.+{"experimental":"enabled"}' $DOCKER_CLI_CONFIG) > $DOCKER_CLI_CONFIG
+  echo "Enabled experimental CLI features to execute docker manifest commands"
   manifest_exists=$(docker manifest inspect $IMAGE_REPO:$VERSION > /dev/null ; echo $?)
-  if [[ $manifest_exists -eq 0 ]]; then
-    PLATFORMS+=($(docker manifest inspect $IMAGE_REPO:$VERSION | jq -r '.manifests[] | "\(.platform.os)/\(.platform.architecture)"'))
+  if [[ manifest_exists -eq 0 ]]; then
+    echo "manifest already exists"
+    EXISTING_IMAGES=($(docker manifest inspect $IMAGE_REPO:$VERSION | jq -r '.manifests[] | "\(.platform.os)-\(.platform.architecture)"'))
+    # treat separate from PLATFORMS because existing images don't need to be tagged and pushed
+    for os_arch in "${EXISTING_IMAGES[@]}"; do
+      img_tag="$IMAGE_REPO:$VERSION-$os_arch"
+      MANIFEST_IMAGES+=($img_tag)
+    done
+    echo "images already in manifest: $MANIFEST_IMAGES"
   fi
 fi
 
@@ -75,28 +87,33 @@ for os_arch in "${PLATFORMS[@]}"; do
         img_tag="$IMAGE_REPO:$VERSION"
         docker tag $img_tag_w_platform $img_tag
     fi
-
     docker push $img_tag
-    MANIFEST_IMAGES="$MANIFEST_IMAGES $img_tag"
+    MANIFEST_IMAGES+=($img_tag)
 done
 
 if [[ $MANIFEST == "true" ]]; then
-    if [[ ! -f $DOCKER_CLI_CONFIG ]]; then
-      echo '{"experimental":"enabled"}' > $DOCKER_CLI_CONFIG
-      echo "Created docker config file"
-    fi
-    cat <<< $(jq '.+{"experimental":"enabled"}' $DOCKER_CLI_CONFIG) > $DOCKER_CLI_CONFIG
-    echo "Enabled experimental CLI features to create the docker manifest"
-    docker manifest create $IMAGE_REPO:$VERSION $MANIFEST_IMAGES
+    current_os=$(uname)
+    # Windows will append '\r' to the end of $img which
+    # results in docker failing to create the manifest due to invalid reference format.
+    # However, MacOS does not recognize '\r' as carriage return
+    # and attempts to remove literal 'r' chars; therefore, made this so portable
+    for img in "${MANIFEST_IMAGES[@]}"; do
+      if [[ $current_os == "Darwin" ]]; then
+        updated_img=$img
+      else
+        updated_img=$(echo $img | sed -e 's/\r$//')
+      fi
+      echo "creating manifest for $updated_img"
+      docker manifest create $IMAGE_REPO:$VERSION $updated_img --amend
 
-    for os_arch in "${PLATFORMS[@]}"; do
-        os=$(echo $os_arch | cut -d'/' -f1)
-        arch=$(echo $os_arch | cut -d'/' -f2)
+      os_arch=$(echo ${updated_img//$IMAGE_REPO:$VERSION-/})
+      os=$(echo $os_arch | cut -d'-' -f1)
+      arch=$(echo $os_arch | cut -d'-' -f2)
 
-        img_tag="$IMAGE_REPO:$VERSION-$os-$arch"
-
-        docker manifest annotate $IMAGE_REPO:$VERSION $img_tag --arch $arch --os $os
+      echo "annotating manifest"
+      docker manifest annotate $IMAGE_REPO:$VERSION $updated_img --arch $arch --os $os
     done
 
+    echo "pushing manifest"
     docker manifest push --purge $IMAGE_REPO:$VERSION
 fi


### PR DESCRIPTION
Issue #, if available: 
* N/A

Description of changes:
* `MANIFEST_IMAGES` is an array; existing images in the manifest will be added directly here
* using `manifest create --amend` because for-loop is the only way I can get Windows to register multiple manifest images at once
* fixed spacing
* added more `echo` for easier debugging in Travis

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
