### PR TITLE
Add Amazon EC2 Spot Instances Integration Roadmap to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ For build instructions please consult [BUILD.md](./BUILD.md).
 ## Communication
 * If you've run into a bug or have a new feature request, please open an [issue](https://github.com/aws/aws-node-termination-handler/issues/new).
 * You can also chat with us in the [Kubernetes Slack](https://kubernetes.slack.com) in the `#provider-aws` channel
+* Check out the open source [Amazon EC2 Spot Instances Integrations Roadmap](https://github.com/aws/ec2-spot-instances-integrations-roadmap) to see what we're working on and give us feedback! 
 
 ##  Contributing
 Contributions are welcome! Please read our [guidelines](https://github.com/aws/aws-node-termination-handler/blob/master/CONTRIBUTING.md) and our [Code of Conduct](https://github.com/aws/aws-node-termination-handler/blob/master/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Add Amazon EC2 Spot Instances Integration Roadmap to readme

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
