### PR TITLE
fix identation on PodMonitor

### DIFF
--- a/config/helm/aws-node-termination-handler/templates/podmonitor.yaml
+++ b/config/helm/aws-node-termination-handler/templates/podmonitor.yaml
@@ -9,7 +9,7 @@ metadata:
 {{- with .Values.podMonitor.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
- spec:
+spec:
   jobLabel: {{ include "aws-node-termination-handler.name" . }}
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
# Description of changes:

I am trying to use the new PodMonitor but I am getting a parsing error when deploying.

I am using the following version of helm:

```bash
# helm version
Client: &version.Version{SemVer:"v2.16.3", GitCommit:"1ee0254c86d4ed6887327dabed7aa7da29d7eb0d", GitTreeState:"clean"}
Server: &version.Version{SemVer:"v2.16.3", GitCommit:"1ee0254c86d4ed6887327dabed7aa7da29d7eb0d", GitTreeState:"clean"}
```

This is the command I ran to get the error:

```bash
$ helm template aws-node-termination-handler eks/aws-node-termination-handler --version 0.9.4 --namespace=kube-system --set enablePrometheusServer=true --set podMonitor.create=true

UPGRADE FAILED
Error: YAML parse error on aws-node-termination-handler/templates/podmonitor.yaml: error converting YAML to JSON: yaml: line 12: did not find expected key
Error: UPGRADE FAILED: YAML parse error on aws-node-termination-handler/templates/podmonitor.yaml: error converting YAML to JSON: yaml: line 12: did not find expected key
make: *** [Makefile:210: deploy_instance_interrupt_handler] Error 1
```

I did an `helm fetch`, fixed the `spec` indentation and I can install it now. According to the [specification](https://docs.openshift.com/container-platform/4.5/rest_api/monitoring_apis/podmonitor-monitoring-coreos-com-v1.html), the `spec` should be on root level.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
