### PR TITLE
only build one binary to check licenses

### DIFF
--- a/test/license-test/run-license-test.sh
+++ b/test/license-test/run-license-test.sh
@@ -7,6 +7,6 @@ BUILD_BIN="$SCRIPTPATH/../../build/bin"
 BINARY_NAME="node-termination-handler-linux-amd64"
 LICENSE_TEST_TAG="nth-license-test"
 
-NTH_OS_ARCH="linux-amd64" make -s -f $SCRIPTPATH/../../Makefile build-binaries
+SUPPORTED_PLATFORMS_LINUX="linux/amd64" make -s -f $SCRIPTPATH/../../Makefile build-binaries
 docker build --build-arg=GOPROXY=direct -t $LICENSE_TEST_TAG $SCRIPTPATH/
 docker run -it -e GITHUB_TOKEN --rm -v $SCRIPTPATH/:/test -v $BUILD_BIN/:/nth-bin $LICENSE_TEST_TAG golicense /test/license-config.hcl /nth-bin/$BINARY_NAME


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Only generate linux/amd64 binary for license analysis to speed up travis

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
