### PR TITLE
clear up shellcheck warnings

### DIFF
--- a/scripts/push-docker-images
+++ b/scripts/push-docker-images
@@ -67,7 +67,7 @@ if [[ $MANIFEST == "true" ]]; then
     echo "manifest already exists"
     EXISTING_IMAGES=()
     while IFS='' read -r line; do 
-      shell_files+=("$line"); 
+      EXISTING_IMAGES+=("$line"); 
     done < <(docker manifest inspect $IMAGE_REPO:$VERSION | jq -r '.manifests[] | "\(.platform.os)-\(.platform.architecture)"')
     # treat separate from PLATFORMS because existing images don't need to be tagged and pushed
     for os_arch in "${EXISTING_IMAGES[@]}"; do

--- a/scripts/push-docker-images
+++ b/scripts/push-docker-images
@@ -60,18 +60,21 @@ if [[ $MANIFEST == "true" ]]; then
     echo '{"experimental":"enabled"}' > $DOCKER_CLI_CONFIG
     echo "Created docker config file"
   fi
-  cat <<< $(jq '.+{"experimental":"enabled"}' $DOCKER_CLI_CONFIG) > $DOCKER_CLI_CONFIG
+  cat <<< "$(jq '.+{"experimental":"enabled"}' $DOCKER_CLI_CONFIG)" > $DOCKER_CLI_CONFIG
   echo "Enabled experimental CLI features to execute docker manifest commands"
   manifest_exists=$(docker manifest inspect $IMAGE_REPO:$VERSION > /dev/null ; echo $?)
   if [[ manifest_exists -eq 0 ]]; then
     echo "manifest already exists"
-    EXISTING_IMAGES=($(docker manifest inspect $IMAGE_REPO:$VERSION | jq -r '.manifests[] | "\(.platform.os)-\(.platform.architecture)"'))
+    EXISTING_IMAGES=()
+    while IFS='' read -r line; do 
+      shell_files+=("$line"); 
+    done < <(docker manifest inspect $IMAGE_REPO:$VERSION | jq -r '.manifests[] | "\(.platform.os)-\(.platform.architecture)"')
     # treat separate from PLATFORMS because existing images don't need to be tagged and pushed
     for os_arch in "${EXISTING_IMAGES[@]}"; do
       img_tag="$IMAGE_REPO:$VERSION-$os_arch"
-      MANIFEST_IMAGES+=($img_tag)
+      MANIFEST_IMAGES+=("$img_tag")
     done
-    echo "images already in manifest: $MANIFEST_IMAGES"
+    echo "images already in manifest: ${MANIFEST_IMAGES[*]}"
   fi
 fi
 
@@ -88,7 +91,7 @@ for os_arch in "${PLATFORMS[@]}"; do
         docker tag $img_tag_w_platform $img_tag
     fi
     docker push $img_tag
-    MANIFEST_IMAGES+=($img_tag)
+    MANIFEST_IMAGES+=("$img_tag")
 done
 
 if [[ $MANIFEST == "true" ]]; then

--- a/scripts/upload-resources-to-github
+++ b/scripts/upload-resources-to-github
@@ -50,7 +50,7 @@ handle_errors_and_cleanup() {
 
     if [[ ${#ASSET_IDS_UPLOADED[@]} -ne 0 ]]; then
         echo -e "\nCleaning up assets uploaded in the current execution of the script"
-        for asset_id in $ASSET_IDS_UPLOADED; do
+        for asset_id in "${ASSET_IDS_UPLOADED[@]}"; do
             echo "Deleting asset $asset_id"
             curl -X DELETE \
               -H "Authorization: token $GITHUB_TOKEN" \
@@ -63,17 +63,17 @@ handle_errors_and_cleanup() {
 gather_assets_to_upload() {
     local resources=()
     for binary in $BINARY_DIR/*; do
-      resources+=($binary)
+      resources+=("$binary")
     done
     if [ $BINARIES_ONLY != "true" ]; then
-      resources+=($INDV_K8S_RESOURCES $AGG_RESOURCES_YAML)
+      resources+=("$INDV_K8S_RESOURCES" "$AGG_RESOURCES_YAML")
     fi
     echo "${resources[@]}"
 }
 
 # $1: absolute path to asset
 upload_asset() {
-    resp=$(curl --write-out %{http_code} --silent \
+    resp=$(curl --write-out '%{http_code}' --silent \
         -H "Authorization: token $GITHUB_TOKEN" \
         -H "Content-Type: $(file -b --mime-type $1)" \
         --data-binary @$1 \
@@ -85,7 +85,7 @@ upload_asset() {
     # HTTP success code expected - 201 Created
     if [[ $response_code -eq 201 ]]; then
         asset_id=$(echo $response_content | jq '.id')
-        ASSET_IDS_UPLOADED+=($asset_id)
+        ASSET_IDS_UPLOADED+=("$asset_id")
         echo "Created asset ID $asset_id successfully"
     else
         echo -e "❌ Upload failed with response code $response_code and message \n$response_content ❌"

--- a/test/e2e/cordon-only-test
+++ b/test/e2e/cordon-only-test
@@ -83,14 +83,14 @@ TAINT_CHECK_SLEEP=15
 
 DEPLOYED=0
 
-for i in `seq 1 10`; do
+for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
         echo "✅ Verified regular-pod-test pod was scheduled and started!"
         DEPLOYED=1
         break
     fi
-    echo "Setup Loop $i/10, sleeping for 5 seconds"
-    sleep 5
+    echo "Setup Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
+    sleep $TAINT_CHECK_SLEEP
 done
 
 if [[ $DEPLOYED -eq 0 ]]; then

--- a/test/e2e/cordon-only-test
+++ b/test/e2e/cordon-only-test
@@ -28,10 +28,10 @@ common_helm_args=()
 anth_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-anth
-  $SCRIPTPATH/../../config/helm/aws-node-termination-handler/
+  "$CLUSTER_NAME-anth"
+  "$SCRIPTPATH/../../config/helm/aws-node-termination-handler/"
   --namespace kube-system
-  --set instanceMetadataURL=${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}
+  --set instanceMetadataURL="${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}"
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
   --set cordonOnly="true"
@@ -48,8 +48,8 @@ set +x
 aemm_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-aemm
-  $AEMM_DL_URL
+  "$CLUSTER_NAME-aemm"
+  "$AEMM_DL_URL"
   --namespace default
   --set servicePort="$IMDS_PORT"
 )
@@ -63,8 +63,8 @@ set +x
 emtp_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-emtp
-  $SCRIPTPATH/../../config/helm/webhook-test-proxy/
+  "$CLUSTER_NAME-emtp"
+  "$SCRIPTPATH/../../config/helm/webhook-test-proxy/"
   --namespace default
   --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
   --set webhookTestProxy.image.tag="$WEBHOOK_DOCKER_TAG"
@@ -89,6 +89,7 @@ for i in `seq 1 10`; do
         DEPLOYED=1
         break
     fi
+    echo "Setup Loop $i/10, sleeping for 5 seconds"
     sleep 5
 done
 
@@ -98,18 +99,19 @@ if [[ $DEPLOYED -eq 0 ]]; then
 fi
 
 cordoned=0
-test_node=${TEST_NODE:-$CLUSTER_NAME-worker}
+test_node="${TEST_NODE:-$CLUSTER_NAME-worker}"
 for i in `seq 1 $TAINT_CHECK_CYCLES`; do
-      if [[ $cordoned -eq 0 ]] && kubectl get nodes $test_node | grep SchedulingDisabled > /dev/null; then
-          echo "✅ Verified the worker node was cordoned!"
-          cordoned=1
-      fi
+    if [[ $cordoned -eq 0 ]] && kubectl get nodes $test_node | grep SchedulingDisabled > /dev/null; then
+        echo "✅ Verified the worker node was cordoned!"
+        cordoned=1
+    fi
 
-      if [[ $cordoned -eq 1 && $(kubectl get deployments regular-pod-test -o=jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
-          echo "✅ Verified the regular-pod-test pod was NOT evicted!"
-          echo "✅ Cordon Only Test Passed $CLUSTER_NAME! ✅"
-          exit 0
-      fi
+    if [[ $cordoned -eq 1 && $(kubectl get deployments regular-pod-test -o=jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
+        echo "✅ Verified the regular-pod-test pod was NOT evicted!"
+        echo "✅ Cordon Only Test Passed $CLUSTER_NAME! ✅"
+        exit 0
+    fi
+    echo "Assertion Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
     sleep $TAINT_CHECK_SLEEP
 done
 

--- a/test/e2e/imds-v2-test
+++ b/test/e2e/imds-v2-test
@@ -88,14 +88,14 @@ TAINT_CHECK_SLEEP=15
 
 DEPLOYED=0
 
-for i in `seq 1 10`; do
+for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
         echo "✅ Verified regular-pod-test pod was scheduled and started!"
         DEPLOYED=1
         break
     fi
-    echo "Setup Loop $i/10, sleeping for 5 seconds"
-    sleep 5
+    echo "Setup Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
+    sleep $TAINT_CHECK_SLEEP
 done
 
 if [[ $DEPLOYED -eq 0 ]]; then

--- a/test/e2e/imds-v2-test
+++ b/test/e2e/imds-v2-test
@@ -28,11 +28,11 @@ common_helm_args=()
 anth_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-anth
-  $SCRIPTPATH/../../config/helm/aws-node-termination-handler/
+  "$CLUSTER_NAME-anth"
+  "$SCRIPTPATH/../../config/helm/aws-node-termination-handler/"
   --force
   --namespace kube-system
-  --set instanceMetadataURL=${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}
+  --set instanceMetadataURL="${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}"
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
   --set enableSpotInterruptionDraining="true"
@@ -50,8 +50,8 @@ set +x
 emtp_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-emtp
-  $SCRIPTPATH/../../config/helm/webhook-test-proxy/
+  "$CLUSTER_NAME-emtp"
+  "$SCRIPTPATH/../../config/helm/webhook-test-proxy/"
   --wait
   --namespace default
   --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
@@ -69,8 +69,8 @@ set +x
 aemm_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-aemm
-  $AEMM_DL_URL
+  "$CLUSTER_NAME-aemm"
+  "$AEMM_DL_URL"
   --wait
   --namespace default
   --set aemm.imdsv2="true"
@@ -94,6 +94,7 @@ for i in `seq 1 10`; do
         DEPLOYED=1
         break
     fi
+    echo "Setup Loop $i/10, sleeping for 5 seconds"
     sleep 5
 done
 
@@ -103,18 +104,19 @@ if [[ $DEPLOYED -eq 0 ]]; then
 fi
 
 cordoned=0
-test_node=${TEST_NODE:-$CLUSTER_NAME-worker}
+test_node="${TEST_NODE:-$CLUSTER_NAME-worker}"
 for i in `seq 1 $TAINT_CHECK_CYCLES`; do
-      if [[ $cordoned -eq 0 ]] && kubectl get nodes $test_node | grep SchedulingDisabled >/dev/null; then
-          echo "✅ Verified the worker node was cordoned!"
-          cordoned=1
-      fi
+    if [[ $cordoned -eq 0 ]] && kubectl get nodes $test_node | grep SchedulingDisabled >/dev/null; then
+        echo "✅ Verified the worker node was cordoned!"
+        cordoned=1
+    fi
 
-      if [[ $cordoned -eq 1 && $(kubectl get deployments regular-pod-test -o=jsonpath='{.status.unavailableReplicas}') -eq 1 ]]; then
-          echo "✅ Verified the regular-pod-test pod was evicted!"
-          echo "✅ IMDSv2 Test Passed $CLUSTER_NAME! ✅"
-          exit 0
-      fi
+    if [[ $cordoned -eq 1 && $(kubectl get deployments regular-pod-test -o=jsonpath='{.status.unavailableReplicas}') -eq 1 ]]; then
+        echo "✅ Verified the regular-pod-test pod was evicted!"
+        echo "✅ IMDSv2 Test Passed $CLUSTER_NAME! ✅"
+        exit 0
+    fi
+    echo "Assertion Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
     sleep $TAINT_CHECK_SLEEP
 done
 

--- a/test/e2e/maintenance-event-cancellation-test
+++ b/test/e2e/maintenance-event-cancellation-test
@@ -92,14 +92,14 @@ TAINT_CHECK_SLEEP=15
 
 DEPLOYED=0
 
-for i in `seq 1 10`; do
+for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
         echo "✅ Verified regular-pod-test pod was scheduled and started!"
         DEPLOYED=1
         break
     fi
-    echo "Setup Loop $i/10, sleeping for 5 seconds"
-    sleep 5
+    echo "Setup Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
+    sleep $TAINT_CHECK_SLEEP
 done
 
 if [[ $DEPLOYED -eq 0 ]]; then

--- a/test/e2e/maintenance-event-cancellation-test
+++ b/test/e2e/maintenance-event-cancellation-test
@@ -28,11 +28,11 @@ common_helm_args=()
 anth_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-anth
-  $SCRIPTPATH/../../config/helm/aws-node-termination-handler/
+  "$CLUSTER_NAME-anth"
+  "$SCRIPTPATH/../../config/helm/aws-node-termination-handler/"
   --wait
   --namespace kube-system
-  --set instanceMetadataURL=${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}
+  --set instanceMetadataURL="${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}"
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
   --set enableSpotInterruptionDraining="true"
@@ -52,8 +52,8 @@ set +x
 emtp_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-emtp
-  $SCRIPTPATH/../../config/helm/webhook-test-proxy/
+  "$CLUSTER_NAME-emtp"
+  "$SCRIPTPATH/../../config/helm/webhook-test-proxy/"
   --wait
   --namespace default
   --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
@@ -71,14 +71,14 @@ set +x
 aemm_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-aemm
-  $AEMM_DL_URL
+  "$CLUSTER_NAME-aemm"
+  "$AEMM_DL_URL"
   --wait
   --namespace default
   --set servicePort="$IMDS_PORT"
   --set 'tolerations[0].effect=NoSchedule'
   --set 'tolerations[0].operator=Exists'
-  --set arguments={events}
+  --set arguments='{events}'
 )
 [[ ${#common_helm_args[@]} -gt 0 ]] &&
     aemm_helm_args+=("${common_helm_args[@]}")
@@ -98,6 +98,7 @@ for i in `seq 1 10`; do
         DEPLOYED=1
         break
     fi
+    echo "Setup Loop $i/10, sleeping for 5 seconds"
     sleep 5
 done
 
@@ -109,7 +110,7 @@ fi
 cordoned=0
 tainted=0
 evicted=0
-test_node=${TEST_NODE:-$CLUSTER_NAME-worker}
+test_node="${TEST_NODE:-$CLUSTER_NAME-worker}"
 for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     if [[ $cordoned -eq 0 ]] && kubectl get nodes $test_node --no-headers | grep SchedulingDisabled >/dev/null; then
         echo "✅ Verified the worker node was cordoned!"
@@ -126,6 +127,7 @@ for i in `seq 1 $TAINT_CHECK_CYCLES`; do
         evicted=1
         break
     fi
+    echo "Assertion Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
     sleep $TAINT_CHECK_SLEEP
 done
 
@@ -143,15 +145,15 @@ fi
 aemm_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-aemm
-  $AEMM_DL_URL
+  "$CLUSTER_NAME-aemm"
+  "$AEMM_DL_URL"
   --wait
   --namespace default
   --set servicePort="$IMDS_PORT"
   --set aemm.events.state="canceled"
   --set 'tolerations[0].effect=NoSchedule'
   --set 'tolerations[0].operator=Exists'
-  --set arguments={events}
+  --set arguments='{events}'
 )
 [[ ${#common_helm_args[@]} -gt 0 ]] &&
     aemm_helm_args+=("${common_helm_args[@]}")
@@ -163,8 +165,8 @@ set +x
 emtp_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-emtp
-  $SCRIPTPATH/../../config/helm/webhook-test-proxy/
+  "$CLUSTER_NAME-emtp"
+  "$SCRIPTPATH/../../config/helm/webhook-test-proxy/"
   --wait
   --namespace default
   --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
@@ -189,6 +191,7 @@ for i in `seq 1 $TAINT_CHECK_CYCLES`; do
         echo "✅ Test Maintenance Event Cancellation passed! $CLUSTER_NAME ✅"
         exit 0
     fi
+    echo "Assertion Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
     sleep $TAINT_CHECK_SLEEP
 done
 

--- a/test/e2e/maintenance-event-dry-run-test
+++ b/test/e2e/maintenance-event-dry-run-test
@@ -87,10 +87,13 @@ set -x
 retry 5 helm "${aemm_helm_args[@]}"
 set +x
 
+TAINT_CHECK_CYCLES=15
+TAINT_CHECK_SLEEP=15
+
 logs=0
 pod_id="$(get_nth_worker_pod)"
 test_node="${TEST_NODE:-$CLUSTER_NAME-worker}"
-for i in $(seq 1 10); do
+for i in $(seq 1 $TAINT_CHECK_CYCLES); do
   if [[ $logs -eq 0 && ! -z $(kubectl logs $pod_id -n kube-system | grep -i -e 'would have been cordoned and drained') ]]; then
       echo "✅ Verified the dryrun logs were executed"
       logs=1
@@ -101,8 +104,8 @@ for i in $(seq 1 10); do
       echo "✅ Scheduled Maintenance Event Dry Run Test Passed $CLUSTER_NAME! ✅"
       exit 0
   fi
-    echo "Assertion Loop $i/10, sleeping for 10 seconds"
-  sleep 10
+    echo "Assertion Loop $i/$TAINT_CHECK_SLEEP, sleeping for $TAINT_CHECK_SLEEP seconds"
+  sleep $TAINT_CHECK_SLEEP
 done
 
 if [[ $logs -eq 0 ]]; then

--- a/test/e2e/maintenance-event-dry-run-test
+++ b/test/e2e/maintenance-event-dry-run-test
@@ -29,12 +29,12 @@ common_helm_args=()
 anth_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-anth
-  $SCRIPTPATH/../../config/helm/aws-node-termination-handler/
+  "$CLUSTER_NAME-anth"
+  "$SCRIPTPATH/../../config/helm/aws-node-termination-handler/"
   --wait
   --force
   --namespace kube-system
-  --set instanceMetadataURL=${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}
+  --set instanceMetadataURL="${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}"
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
   --set dryRun="true"
@@ -53,8 +53,8 @@ set +x
 emtp_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-emtp
-  $SCRIPTPATH/../../config/helm/webhook-test-proxy/
+  "$CLUSTER_NAME-emtp"
+  "$SCRIPTPATH/../../config/helm/webhook-test-proxy/"
   --wait
   --force
   --namespace default
@@ -73,12 +73,12 @@ set +x
 aemm_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-aemm
-  $AEMM_DL_URL
+  "$CLUSTER_NAME-aemm"
+  "$AEMM_DL_URL"
   --wait
   --namespace default
   --set servicePort="$IMDS_PORT"
-  --set arguments={events}
+  --set arguments='{events}'
 )
 [[ ${#common_helm_args[@]} -gt 0 ]] &&
     aemm_helm_args+=("${common_helm_args[@]}")
@@ -88,9 +88,9 @@ retry 5 helm "${aemm_helm_args[@]}"
 set +x
 
 logs=0
-pod_id=$(get_nth_worker_pod)
-test_node=${TEST_NODE:-$CLUSTER_NAME-worker}
-for i in $(seq 0 10); do
+pod_id="$(get_nth_worker_pod)"
+test_node="${TEST_NODE:-$CLUSTER_NAME-worker}"
+for i in $(seq 1 10); do
   if [[ $logs -eq 0 && ! -z $(kubectl logs $pod_id -n kube-system | grep -i -e 'would have been cordoned and drained') ]]; then
       echo "✅ Verified the dryrun logs were executed"
       logs=1
@@ -101,6 +101,7 @@ for i in $(seq 0 10); do
       echo "✅ Scheduled Maintenance Event Dry Run Test Passed $CLUSTER_NAME! ✅"
       exit 0
   fi
+    echo "Assertion Loop $i/10, sleeping for 10 seconds"
   sleep 10
 done
 

--- a/test/e2e/maintenance-event-reboot-test
+++ b/test/e2e/maintenance-event-reboot-test
@@ -24,12 +24,12 @@ common_helm_args=()
 anth_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-anth
-  $SCRIPTPATH/../../config/helm/aws-node-termination-handler/
+  "$CLUSTER_NAME-anth"
+  "$SCRIPTPATH/../../config/helm/aws-node-termination-handler/"
   --wait
   --force
   --namespace kube-system
-  --set instanceMetadataURL=${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}
+  --set instanceMetadataURL="${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}"
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
   --set enableSpotInterruptionDraining="true"
@@ -48,8 +48,8 @@ set +x
 emtp_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-emtp
-  $SCRIPTPATH/../../config/helm/webhook-test-proxy/
+  "$CLUSTER_NAME-emtp"
+  "$SCRIPTPATH/../../config/helm/webhook-test-proxy/"
   --wait
   --namespace default
   --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
@@ -67,12 +67,12 @@ set +x
 aemm_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-aemm
-  $AEMM_DL_URL
+  "$CLUSTER_NAME-aemm"
+  "$AEMM_DL_URL"
   --wait
   --namespace default
   --set servicePort="$IMDS_PORT"
-  --set arguments={events}
+  --set arguments='{events}'
 )
 [[ ${#common_helm_args[@]} -gt 0 ]] &&
     aemm_helm_args+=("${common_helm_args[@]}")
@@ -91,6 +91,7 @@ for i in `seq 1 10`; do
         deployed=1
         break
     fi
+    echo "Setup Loop $i/10, sleeping for 5 seconds"
     sleep 5
 done
 
@@ -101,8 +102,7 @@ fi
 
 cordoned=0
 tainted=0
-evicted=0
-test_node=${TEST_NODE:-$CLUSTER_NAME-worker}
+test_node="${TEST_NODE:-$CLUSTER_NAME-worker}"
 for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     if [[ $cordoned -eq 0 ]] && kubectl get nodes $test_node | grep SchedulingDisabled >/dev/null; then
         echo "✅ Verified the worker node was cordoned for maintenance event reboot!"
@@ -116,9 +116,9 @@ for i in `seq 1 $TAINT_CHECK_CYCLES`; do
 
     if [[ $tainted -eq 1 && $(kubectl get deployments regular-pod-test -o=jsonpath='{.status.unavailableReplicas}') -eq 1 ]]; then
         echo "✅ Verified the regular-pod-test pod was evicted!"
-        evicted=1
         break
     fi
+    echo "Assertion Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
     sleep $TAINT_CHECK_SLEEP
 done
 
@@ -136,32 +136,32 @@ mock_uptime_filepath="/uptime"
 if [[ "${TEST_WINDOWS:-"false"}" != "true" ]]; then
     echo "Copy uptime file to Kind k8s nodes"
     for node in $(kubectl get nodes -o json | jq -r '.items[].metadata.name'); do
-        docker exec $node sh -c "rm -rf $mock_uptime_filepath"
-        docker cp $SCRIPTPATH/../assets/uptime-reboot $node:$mock_uptime_filepath
-        docker exec $node sh -c "chmod 0444 $mock_uptime_filepath && chown root $mock_uptime_filepath && chgrp root $mock_uptime_filepath"
+        docker exec "$node" sh -c "rm -rf $mock_uptime_filepath"
+        docker cp "$SCRIPTPATH/../assets/uptime-reboot" "$node:$mock_uptime_filepath"
+        docker exec "$node" sh -c "chmod 0444 $mock_uptime_filepath && chown root $mock_uptime_filepath && chgrp root $mock_uptime_filepath"
     done
 else
     echo "Copy uptime file to $TEST_NODE"
-    kubectl cp $SCRIPTPATH/../assets/uptime-root kube-system/$(get_nth_worker_pod):$mock_uptime_filepath
+    kubectl cp "$SCRIPTPATH/../assets/uptime-root kube-system/$(get_nth_worker_pod):$mock_uptime_filepath"
 fi
 
 echo "Remove amazon-ec2-metadata-mock to prevent another drain event but keep regular-test-pod"
 daemonset=$(kubectl get daemonsets | grep 'amazon-ec2-metadata-mock' | cut -d' ' -f1)
-kubectl delete daemonsets $daemonset
+kubectl delete daemonsets "$daemonset"
 
 ## Restart NTH which will simulate a system reboot by mounting a new uptime file
 anth_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-anth
-  $SCRIPTPATH/../../config/helm/aws-node-termination-handler/
+  "$CLUSTER_NAME-anth"
+  "$SCRIPTPATH/../../config/helm/aws-node-termination-handler/"
   --wait
   --force
   --namespace kube-system
-  --set instanceMetadataURL=${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}
+  --set instanceMetadataURL="${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}"
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
-  --set procUptimeFile=$mock_uptime_filepath
+  --set procUptimeFile="$mock_uptime_filepath"
   --set enableSpotInterruptionDraining="true"
   --set enableScheduledEventDraining="true"
   --set taintNode="true"
@@ -192,6 +192,7 @@ for i in `seq 1 $TAINT_CHECK_CYCLES`; do
         echo "✅ Scheduled Maintenance Event System Reboot Test Passed $CLUSTER_NAME! ✅"
         exit 0
     fi
+    echo "Assertion Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
     sleep $TAINT_CHECK_SLEEP
 done
 

--- a/test/e2e/maintenance-event-reboot-test
+++ b/test/e2e/maintenance-event-reboot-test
@@ -85,14 +85,14 @@ TAINT_CHECK_CYCLES=15
 TAINT_CHECK_SLEEP=15
 
 deployed=0
-for i in `seq 1 10`; do
+for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
         echo "✅ Verified regular-pod-test pod was scheduled and started!"
         deployed=1
         break
     fi
-    echo "Setup Loop $i/10, sleeping for 5 seconds"
-    sleep 5
+    echo "Setup Loop $i/$TAINT_CHECK_SLEEP, sleeping for $TAINT_CHECK_SLEEP seconds"
+    sleep $TAINT_CHECK_SLEEP
 done
 
 if [[ $deployed -eq 0 ]]; then

--- a/test/e2e/maintenance-event-test
+++ b/test/e2e/maintenance-event-test
@@ -28,12 +28,12 @@ common_helm_args=()
 anth_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-anth
-  $SCRIPTPATH/../../config/helm/aws-node-termination-handler/
+  "$CLUSTER_NAME-anth"
+  "$SCRIPTPATH/../../config/helm/aws-node-termination-handler/"
   --wait
   --force
   --namespace kube-system
-  --set instanceMetadataURL=${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}
+  --set instanceMetadataURL="${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}"
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
   --set enableSpotInterruptionDraining="true"
@@ -53,8 +53,8 @@ set +x
 emtp_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-emtp
-  $SCRIPTPATH/../../config/helm/webhook-test-proxy/
+  "$CLUSTER_NAME-emtp"
+  "$SCRIPTPATH/../../config/helm/webhook-test-proxy/"
   --wait
   --namespace default
   --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
@@ -72,14 +72,14 @@ set +x
 aemm_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-aemm
-  $AEMM_DL_URL
+  "$CLUSTER_NAME-aemm"
+  "$AEMM_DL_URL"
   --wait
   --namespace default
   --set servicePort="$IMDS_PORT"
   --set 'tolerations[0].effect=NoSchedule'
   --set 'tolerations[0].operator=Exists'
-  --set arguments={events}
+  --set arguments='{events}'
 )
 
 [[ ${#common_helm_args[@]} -gt 0 ]] &&
@@ -100,6 +100,7 @@ for i in `seq 1 10`; do
         deployed=1
         break
     fi
+    echo "Setup Loop $i/10, sleeping for 5 seconds"
     sleep 5
 done
 
@@ -110,7 +111,7 @@ fi
 
 cordoned=0
 tainted=0
-test_node=${TEST_NODE:-$CLUSTER_NAME-worker}
+test_node="${TEST_NODE:-$CLUSTER_NAME-worker}"
 for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     if [[ $cordoned -eq 0 ]] && kubectl get nodes $test_node | grep SchedulingDisabled >/dev/null; then
         echo "✅ Verified the worker node was cordoned!"
@@ -127,6 +128,7 @@ for i in `seq 1 $TAINT_CHECK_CYCLES`; do
         echo "✅ Maintenance Event Test Passed $CLUSTER_NAME! ✅"
         exit 0
     fi
+    echo "Assertion Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
     sleep $TAINT_CHECK_SLEEP
 done
 

--- a/test/e2e/maintenance-event-test
+++ b/test/e2e/maintenance-event-test
@@ -94,14 +94,14 @@ TAINT_CHECK_SLEEP=15
 
 deployed=0
 
-for i in `seq 1 10`; do
+for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
         echo "✅ Verified regular-pod-test pod was scheduled and started!"
         deployed=1
         break
     fi
-    echo "Setup Loop $i/10, sleeping for 5 seconds"
-    sleep 5
+    echo "Setup Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
+    sleep $TAINT_CHECK_SLEEP
 done
 
 if [[ $deployed -eq 0 ]]; then

--- a/test/e2e/prometheus-metrics-test
+++ b/test/e2e/prometheus-metrics-test
@@ -27,12 +27,12 @@ retry 5 helm install prometheus-operator stable/prometheus-operator --set promet
 anth_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-anth
-  $SCRIPTPATH/../../config/helm/aws-node-termination-handler/
+  "$CLUSTER_NAME-anth"
+  "$SCRIPTPATH/../../config/helm/aws-node-termination-handler/"
   --wait
   --force
   --namespace kube-system
-  --set instanceMetadataURL=${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}
+  --set instanceMetadataURL="${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}"
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
   --set enableScheduledEventDraining="false"
@@ -54,8 +54,8 @@ set +x
 emtp_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-emtp
-  $SCRIPTPATH/../../config/helm/webhook-test-proxy/
+  "$CLUSTER_NAME-emtp"
+  "$SCRIPTPATH/../../config/helm/webhook-test-proxy/"
   --wait
   --namespace default
   --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
@@ -73,8 +73,8 @@ set +x
 aemm_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-aemm
-  $AEMM_DL_URL
+  "$CLUSTER_NAME-aemm"
+  "$AEMM_DL_URL"
   --wait
   --namespace default
   --set servicePort="$IMDS_PORT"
@@ -127,6 +127,7 @@ for i in `seq 1 $TAINT_CHECK_CYCLES`; do
               break
           fi
       fi
+    echo "Assertion Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
     sleep $TAINT_CHECK_SLEEP
 done
 
@@ -139,9 +140,9 @@ fi
 POD_NAME=$(get_nth_worker_pod)
 echo "✅ Fetched the pod $POD_NAME "
 
-kubectl -n kube-system port-forward $POD_NAME 7000:9092 &
+kubectl -n kube-system port-forward "$POD_NAME" 7000:9092 &
 PORT_FORWARD_PID=$!
-trap "kill ${PORT_FORWARD_PID}" EXIT SIGINT SIGTERM ERR
+trap 'kill ${PORT_FORWARD_PID}' EXIT SIGINT SIGTERM ERR
 echo "✅ Port-forwarded pod $POD_NAME"
 
 sleep 1

--- a/test/e2e/spot-interruption-dry-run-test
+++ b/test/e2e/spot-interruption-dry-run-test
@@ -86,10 +86,13 @@ set -x
 retry 5 helm "${aemm_helm_args[@]}"
 set +x
 
+TAINT_CHECK_CYCLES=15
+TAINT_CHECK_SLEEP=15
+
 logs=0
 pod_id=$(get_nth_worker_pod)
 test_node="${TEST_NODE:-$CLUSTER_NAME-worker}"
-for i in $(seq 1 10); do
+for i in $(seq 1 $TAINT_CHECK_CYCLES); do
   if [[ $logs -eq 0 && ! -z $(kubectl logs $pod_id -n kube-system | grep -i -e 'would have been cordoned and drained') ]]; then
       echo "✅ Verified the dryrun logs were executed"
       logs=1
@@ -100,8 +103,8 @@ for i in $(seq 1 10); do
       echo "✅ Spot Interruption Dry Run Test Passed $CLUSTER_NAME! ✅"
       exit 0
   fi
-  echo "Assertion Loop $i/10, sleeping for 10 seconds"
-  sleep 10
+  echo "Assertion Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
+  sleep $TAINT_CHECK_SLEEP
 done
 
 if [[ $logs -eq 0 ]]; then

--- a/test/e2e/spot-interruption-dry-run-test
+++ b/test/e2e/spot-interruption-dry-run-test
@@ -28,12 +28,12 @@ common_helm_args=()
 anth_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-anth
-  $SCRIPTPATH/../../config/helm/aws-node-termination-handler/
+  "$CLUSTER_NAME-anth"
+  "$SCRIPTPATH/../../config/helm/aws-node-termination-handler/"
   --wait
   --force
   --namespace kube-system
-  --set instanceMetadataURL=${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}
+  --set instanceMetadataURL="${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}"
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
   --set dryRun="true"
@@ -52,8 +52,9 @@ set +x
 emtp_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-emtp
-  $SCRIPTPATH/../../config/helm/webhook-test-proxy/
+  
+  "$CLUSTER_NAME-emtp"
+  "$SCRIPTPATH/../../config/helm/webhook-test-proxy/"
   --wait
   --namespace default
   --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
@@ -71,12 +72,12 @@ set +x
 aemm_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-aemm
-  $AEMM_DL_URL
+  "$CLUSTER_NAME-aemm"
+  "$AEMM_DL_URL"
   --wait
   --namespace default
   --set servicePort="$IMDS_PORT"
-  --set arguments={spot}
+  --set arguments='{spot}'
 )
 [[ ${#common_helm_args[@]} -gt 0 ]] &&
     aemm_helm_args+=("${common_helm_args[@]}")
@@ -87,8 +88,8 @@ set +x
 
 logs=0
 pod_id=$(get_nth_worker_pod)
-test_node=${TEST_NODE:-$CLUSTER_NAME-worker}
-for i in $(seq 0 10); do
+test_node="${TEST_NODE:-$CLUSTER_NAME-worker}"
+for i in $(seq 1 10); do
   if [[ $logs -eq 0 && ! -z $(kubectl logs $pod_id -n kube-system | grep -i -e 'would have been cordoned and drained') ]]; then
       echo "✅ Verified the dryrun logs were executed"
       logs=1
@@ -99,6 +100,7 @@ for i in $(seq 0 10); do
       echo "✅ Spot Interruption Dry Run Test Passed $CLUSTER_NAME! ✅"
       exit 0
   fi
+  echo "Assertion Loop $i/10, sleeping for 10 seconds"
   sleep 10
 done
 

--- a/test/e2e/spot-interruption-test
+++ b/test/e2e/spot-interruption-test
@@ -93,14 +93,14 @@ TAINT_CHECK_CYCLES=15
 TAINT_CHECK_SLEEP=15
 
 deployed=0
-for i in `seq 1 10`; do
+for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
         echo "✅ Verified regular-pod-test pod was scheduled and started!"
         deployed=1
         break
     fi
-    echo "Setup Loop $i/10, sleeping for 5 seconds"
-    sleep 5
+    echo "Setup Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
+    sleep $TAINT_CHECK_SLEEP
 done
 
 if [[ $deployed -eq 0 ]]; then

--- a/test/e2e/spot-interruption-test
+++ b/test/e2e/spot-interruption-test
@@ -28,12 +28,12 @@ common_helm_args=()
 anth_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-anth
-  $SCRIPTPATH/../../config/helm/aws-node-termination-handler/
+  "$CLUSTER_NAME-anth"
+  "$SCRIPTPATH/../../config/helm/aws-node-termination-handler/"
   --wait
   --force
   --namespace kube-system
-  --set instanceMetadataURL=${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}
+  --set instanceMetadataURL="${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}"
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
   --set enableScheduledEventDraining="false"
@@ -53,8 +53,8 @@ set +x
 emtp_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-emtp
-  $SCRIPTPATH/../../config/helm/webhook-test-proxy/
+  "$CLUSTER_NAME-emtp"
+  "$SCRIPTPATH/../../config/helm/webhook-test-proxy/"
   --wait
   --force
   --namespace default
@@ -73,14 +73,14 @@ set +x
 aemm_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-aemm
-  $AEMM_DL_URL
+  "$CLUSTER_NAME-aemm"
+  "$AEMM_DL_URL"
   --wait
   --namespace default
   --set servicePort="$IMDS_PORT"
   --set 'tolerations[0].effect=NoSchedule'
   --set 'tolerations[0].operator=Exists'
-  --set arguments={spot}
+  --set arguments='{spot}'
 )
 [[ ${#common_helm_args[@]} -gt 0 ]] &&
     aemm_helm_args+=("${common_helm_args[@]}")
@@ -99,6 +99,7 @@ for i in `seq 1 10`; do
         deployed=1
         break
     fi
+    echo "Setup Loop $i/10, sleeping for 5 seconds"
     sleep 5
 done
 
@@ -111,21 +112,22 @@ cordoned=0
 tainted=0
 test_node=${TEST_NODE:-$CLUSTER_NAME-worker}
 for i in `seq 1 $TAINT_CHECK_CYCLES`; do
-      if [[ $cordoned -eq 0 ]] && kubectl get nodes $test_node | grep SchedulingDisabled >/dev/null; then
-          echo "✅ Verified the worker node was cordoned!"
-          cordoned=1
-      fi
+    if [[ $cordoned -eq 0 ]] && kubectl get nodes $test_node | grep SchedulingDisabled >/dev/null; then
+        echo "✅ Verified the worker node was cordoned!"
+        cordoned=1
+    fi
 
-      if [[ $cordoned -eq 1 && $tainted -eq 0 ]] && kubectl get nodes $test_node -o json | grep -q "aws-node-termination-handler/spot-itn" >/dev/null; then
-        echo "✅ Verified the worked node was tainted!"
-        tainted=1
-      fi
+    if [[ $cordoned -eq 1 && $tainted -eq 0 ]] && kubectl get nodes $test_node -o json | grep -q "aws-node-termination-handler/spot-itn" >/dev/null; then
+    echo "✅ Verified the worked node was tainted!"
+    tainted=1
+    fi
 
-      if [[ $tainted -eq 1 && $(kubectl get deployments regular-pod-test -o=jsonpath='{.status.unavailableReplicas}') -eq 1 ]]; then
-          echo "✅ Verified the regular-pod-test pod was evicted!"
-          echo "✅ Spot Interruption Test Passed $CLUSTER_NAME! ✅"
-          exit 0
-      fi
+    if [[ $tainted -eq 1 && $(kubectl get deployments regular-pod-test -o=jsonpath='{.status.unavailableReplicas}') -eq 1 ]]; then
+        echo "✅ Verified the regular-pod-test pod was evicted!"
+        echo "✅ Spot Interruption Test Passed $CLUSTER_NAME! ✅"
+        exit 0
+    fi
+    echo "Assertion Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
     sleep $TAINT_CHECK_SLEEP
 done
 

--- a/test/e2e/webhook-http-proxy-test
+++ b/test/e2e/webhook-http-proxy-test
@@ -30,14 +30,14 @@ function get_squid_worker_pod() {
 
 function start_squid() {
   kubectl delete configmap squid-config || :
-  kubectl create configmap squid-config --from-file=$SCRIPTPATH/../assets/squid.conf
+  kubectl create configmap squid-config --from-file="$SCRIPTPATH/../assets/squid.conf"
 
   old_squid_pods=""
   for i in `seq 1 10`; do
     echo "Checking if squid http-proxy has been terminated from previous run..."
     old_squid_pods="$(get_squid_worker_pod)"
     if [[ -n "${old_squid_pods}" ]]; then 
-      echo "Still waiting on squid to terminate from last run..."
+      echo "Still waiting on squid to terminate from last run... Check $i/10"
       sleep 10
     else
       break
@@ -58,7 +58,7 @@ function start_squid() {
     echo "Checking if squid http-proxy has started..."
     squid_worker_pods="$(get_squid_worker_pod)"
     if [[ -z "${squid_worker_pods}" ]]; then 
-      echo "Still waiting on squid..."
+      echo "Still waiting on squid... Check $i/10"
       sleep 10
     else
       break
@@ -68,9 +68,9 @@ function start_squid() {
 
 echo "Starting Webhook HTTP Proxy Test for Node Termination Handler"
 
-docker pull $SQUID_DOCKERHUB_IMG
-docker tag $SQUID_DOCKERHUB_IMG $SQUID_DOCKER_IMG
-kind load docker-image --name $CLUSTER_NAME --nodes=$CLUSTER_NAME-worker,$CLUSTER_NAME-control-plane $SQUID_DOCKER_IMG
+docker pull "$SQUID_DOCKERHUB_IMG"
+docker tag "$SQUID_DOCKERHUB_IMG" "$SQUID_DOCKER_IMG"
+kind load docker-image --name "$CLUSTER_NAME" --nodes="$CLUSTER_NAME-worker,$CLUSTER_NAME-control-plane" "$SQUID_DOCKER_IMG"
 
 ## Starts squid and waits for pods to be ready
 start_squid
@@ -83,8 +83,8 @@ common_helm_args=()
 aemm_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-aemm
-  $AEMM_DL_URL
+  "$CLUSTER_NAME-aemm"
+  "$AEMM_DL_URL"
   --wait
   --namespace default
   --set servicePort="$IMDS_PORT"
@@ -99,8 +99,8 @@ set +x
 emtp_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-emtp
-  $SCRIPTPATH/../../config/helm/webhook-test-proxy/
+  "$CLUSTER_NAME-emtp"
+  "$SCRIPTPATH/../../config/helm/webhook-test-proxy/"
   --wait
   --namespace default
   --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
@@ -118,8 +118,8 @@ set +x
 anth_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-anth
-  $SCRIPTPATH/../../config/helm/aws-node-termination-handler/
+  "$CLUSTER_NAME-anth"
+  "$SCRIPTPATH/../../config/helm/aws-node-termination-handler/"
   --force
   --namespace kube-system
   --wait
@@ -151,6 +151,7 @@ for i in `seq 1 10`; do
         deployed=1
         break
     fi
+      echo "Setup Loop $i/10, sleeping for 5 seconds"
     sleep 5
 done
 
@@ -180,10 +181,11 @@ for i in `seq 1 $TAINT_CHECK_CYCLES`; do
   fi
 
   webhook_hostname=$(echo "${WEBHOOK_URL}" | sed -e 's@^[^/]*//@@' -e 's@/.*$@@')
-  if [[ $sent -eq 1 ]] && kubectl exec -it $(echo $squid_worker_pods | cut -d' ' -f1) -- cat /var/log/squid/access.log | grep "${webhook_hostname}" >/dev/null; then
+  if [[ $sent -eq 1 ]] && kubectl exec -it "$(echo $squid_worker_pods | cut -d' ' -f1)" -- cat /var/log/squid/access.log | grep "${webhook_hostname}" >/dev/null; then
      echo "✅ Verified the webhook POST used the http proxy"
         exit 0
   fi
+  echo "Assertion Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
   sleep $TAINT_CHECK_SLEEP
 done
 
@@ -198,7 +200,7 @@ else
 fi
 
 echo "=====================================   SQUID LOGS   ===================================================="
-kubectl exec -it $(echo $squid_worker_pods | cut -d' ' -f1) -- cat /var/log/squid/access.log
+kubectl exec -it "$(echo $squid_worker_pods | cut -d' ' -f1)" -- cat /var/log/squid/access.log
 echo "===================================== END SQUID LOGS ===================================================="
 
 fail_and_exit 1

--- a/test/e2e/webhook-http-proxy-test
+++ b/test/e2e/webhook-http-proxy-test
@@ -145,14 +145,14 @@ TAINT_CHECK_CYCLES=15
 TAINT_CHECK_SLEEP=15
 
 deployed=0
-for i in `seq 1 10`; do
+for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
         echo "✅ Verified regular-pod-test pod was scheduled and started!"
         deployed=1
         break
     fi
-      echo "Setup Loop $i/10, sleeping for 5 seconds"
-    sleep 5
+      echo "Setup Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
+    sleep $TAINT_CHECK_SLEEP
 done
 
 if [[ $deployed -eq 0 ]]; then

--- a/test/e2e/webhook-secret-test
+++ b/test/e2e/webhook-secret-test
@@ -32,8 +32,8 @@ common_helm_args=()
 aemm_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-aemm
-  $AEMM_DL_URL
+  "$CLUSTER_NAME-aemm"
+  "$AEMM_DL_URL"
   --wait
   --namespace default
   --set servicePort="$IMDS_PORT"
@@ -48,8 +48,8 @@ set +x
 emtp_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-emtp
-  $SCRIPTPATH/../../config/helm/webhook-test-proxy/
+  "$CLUSTER_NAME-emtp"
+  "$SCRIPTPATH/../../config/helm/webhook-test-proxy/"
   --wait
   --namespace default
   --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
@@ -67,8 +67,8 @@ set +x
 anth_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-anth
-  $SCRIPTPATH/../../config/helm/aws-node-termination-handler/
+  "$CLUSTER_NAME-anth"
+  "$SCRIPTPATH/../../config/helm/aws-node-termination-handler/"
   --force
   --namespace kube-system
   --wait
@@ -99,6 +99,7 @@ for i in `seq 1 10`; do
         DEPLOYED=1
         break
     fi
+    echo "Setup Loop $i/10, sleeping for 5 seconds"
     sleep 5
 done
 
@@ -107,15 +108,16 @@ if [[ $DEPLOYED -eq 0 ]]; then
 fi
 
 for i in `seq 1 $TAINT_CHECK_CYCLES`; do
-      if kubectl get nodes $CLUSTER_NAME-worker | grep SchedulingDisabled; then
-          echo "✅ Verified the worker node was cordoned!"
-          NTH_POD_NAME=$(get_nth_worker_pod)
-          if kubectl logs $NTH_POD_NAME -n kube-system | grep 'Webhook Success'; then
-              echo "✅ Verified the webhook message was sent!"
-              echo "✅ Webhook URL as a Secret Test Passed $CLUSTER_NAME! ✅"
-              exit 0
-          fi
-      fi
+    if kubectl get nodes "$CLUSTER_NAME-worker" | grep SchedulingDisabled; then
+        echo "✅ Verified the worker node was cordoned!"
+        NTH_POD_NAME=$(get_nth_worker_pod)
+        if kubectl logs $NTH_POD_NAME -n kube-system | grep 'Webhook Success'; then
+            echo "✅ Verified the webhook message was sent!"
+            echo "✅ Webhook URL as a Secret Test Passed $CLUSTER_NAME! ✅"
+            exit 0
+        fi
+    fi
+    echo "Assertion Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
     sleep $TAINT_CHECK_SLEEP
 done
 

--- a/test/e2e/webhook-secret-test
+++ b/test/e2e/webhook-secret-test
@@ -93,14 +93,14 @@ TAINT_CHECK_CYCLES=15
 TAINT_CHECK_SLEEP=15
 
 DEPLOYED=0
-for i in `seq 1 10`; do
+for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
         echo "✅ Verified regular-pod-test pod was scheduled and started!"
         DEPLOYED=1
         break
     fi
-    echo "Setup Loop $i/10, sleeping for 5 seconds"
-    sleep 5
+    echo "Setup Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
+    sleep $TAINT_CHECK_SLEEP
 done
 
 if [[ $DEPLOYED -eq 0 ]]; then

--- a/test/e2e/webhook-test
+++ b/test/e2e/webhook-test
@@ -28,12 +28,12 @@ common_helm_args=()
 anth_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-anth
-  $SCRIPTPATH/../../config/helm/aws-node-termination-handler/
+  "$CLUSTER_NAME-anth"
+  "$SCRIPTPATH/../../config/helm/aws-node-termination-handler/"
   --wait
   --force
   --namespace kube-system
-  --set instanceMetadataURL=${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}
+  --set instanceMetadataURL="${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}"
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
   --set webhookURL="${WEBHOOK_URL}"
@@ -54,8 +54,8 @@ set +x
 emtp_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-emtp
-  $SCRIPTPATH/../../config/helm/webhook-test-proxy/
+  "$CLUSTER_NAME-emtp"
+  "$SCRIPTPATH/../../config/helm/webhook-test-proxy/"
   --wait
   --namespace default
   --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
@@ -73,8 +73,8 @@ set +x
 aemm_helm_args=(
   upgrade
   --install
-  $CLUSTER_NAME-aemm
-  $AEMM_DL_URL
+  "$CLUSTER_NAME-aemm"
+  "$AEMM_DL_URL"
   --wait
   --namespace default
   --set servicePort="$IMDS_PORT"
@@ -96,6 +96,7 @@ for i in `seq 1 10`; do
         deployed=1
         break
     fi
+    echo "Setup Loop $i/10, sleeping for 5 seconds"
     sleep 5
 done
 
@@ -106,18 +107,19 @@ fi
 
 cordoned=0
 nth_pod_name=$(get_nth_worker_pod)
-test_node=${TEST_NODE:-$CLUSTER_NAME-worker}
+test_node="${TEST_NODE:-$CLUSTER_NAME-worker}"
 for i in `seq 1 $TAINT_CHECK_CYCLES`; do
-      if [[ $cordoned -eq 0 ]] && kubectl get nodes $test_node | grep SchedulingDisabled >/dev/null; then
-          echo "✅ Verified the worker node was cordoned!"
-          cordoned=1
-      fi
+    if [[ $cordoned -eq 0 ]] && kubectl get nodes $test_node | grep SchedulingDisabled >/dev/null; then
+        echo "✅ Verified the worker node was cordoned!"
+        cordoned=1
+    fi
 
-      if [[ $cordoned -eq 1 ]] && kubectl logs $nth_pod_name -n kube-system | grep 'Webhook Success' >/dev/null; then
-          echo "✅ Verified the webhook message was sent!"
-          echo "✅ Webhook Test Passed $CLUSTER_NAME! ✅"
-          exit 0
-      fi
+    if [[ $cordoned -eq 1 ]] && kubectl logs $nth_pod_name -n kube-system | grep 'Webhook Success' >/dev/null; then
+        echo "✅ Verified the webhook message was sent!"
+        echo "✅ Webhook Test Passed $CLUSTER_NAME! ✅"
+        exit 0
+    fi
+    echo "Assertion Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
     sleep $TAINT_CHECK_SLEEP
 done
 

--- a/test/e2e/webhook-test
+++ b/test/e2e/webhook-test
@@ -90,14 +90,14 @@ TAINT_CHECK_CYCLES=15
 TAINT_CHECK_SLEEP=15
 
 deployed=0
-for i in `seq 1 10`; do
+for i in `seq 1 $TAINT_CHECK_CYCLES`; do
     if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
         echo "✅ Verified regular-pod-test pod was scheduled and started!"
         deployed=1
         break
     fi
-    echo "Setup Loop $i/10, sleeping for 5 seconds"
-    sleep 5
+    echo "Setup Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
+    sleep $TAINT_CHECK_SLEEP
 done
 
 if [[ $deployed -eq 0 ]]; then

--- a/test/eks-cluster-test/reset-cluster
+++ b/test/eks-cluster-test/reset-cluster
@@ -21,7 +21,12 @@ function reset_cluster {
 
 function remove_labels {
     echo "Removing labels from NTH cluster nodes"
-    labels_to_remove=($(kubectl get nodes -o json | jq '.items[].metadata.labels' | grep 'aws-node-termination-handler' | tr -d '[:blank:]' | tr -d '\"' | cut -d':' -f1))
+    
+    labels_to_remove=()
+    while IFS='' read -r line; do 
+      labels_to_remove+=("$line"); 
+    done < <(kubectl get nodes -o json | jq '.items[].metadata.labels' | grep 'aws-node-termination-handler' | tr -d '[:blank:]' | tr -d '\"' | cut -d':' -f1)
+
     if [[ "${#labels_to_remove[@]}" -ne 0 ]]; then
       for l in "${labels_to_remove[@]}"; do
         for n in $(kubectl get nodes -o json | jq -r '.items[].metadata.name'); do

--- a/test/eks-cluster-test/run-test
+++ b/test/eks-cluster-test/run-test
@@ -7,7 +7,7 @@ PRESERVE=true
 
 export TEST_WINDOWS="false"
 export AEMM_VERSION="1.2.0"
-export AEMM_DL_URL="https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v"$AEMM_VERSION"/amazon-ec2-metadata-mock-"$AEMM_VERSION".tgz"
+export AEMM_DL_URL="https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v$AEMM_VERSION/amazon-ec2-metadata-mock-$AEMM_VERSION.tgz"
 export CLUSTER_CONFIG_FILE=$SCRIPTPATH/cluster-spec.yaml
 
 
@@ -54,7 +54,8 @@ while getopts "a:dw" opt; do
 done
 
 function exit_and_fail {
-    local pod_id=$(get_nth_worker_pod || :)
+    local pod_id
+    pod_id=$(get_nth_worker_pod || :)
     kubectl logs $pod_id --namespace kube-system || :
     assertion_end=$(date +%s)
     echo "⏰ Took $(expr $assertion_end - $assertion_start)sec"
@@ -118,13 +119,15 @@ fi
 export TEST_WINDOWS \
   TEST_OS
 
-config=${@:$OPTIND:1}
+config=${*:$OPTIND:1}
 if [[ -z ${config} ]]; then
   echo "no CONFIG provided; creating EKS cluster using $CLUSTER_CONFIG_FILE"
+  # shellcheck source=../eks-cluster-test/provision-cluster
   source $SCRIPTPATH/../eks-cluster-test/provision-cluster
 else
   echo "Reading configuration from ${config}"
   set -a  # Export variables by default.
+  # shellcheck disable=SC1090
   source $config
   set +a  # Disable exporting variables by default.
   PRESERVE=true # cluster user-provided so don't try to delete
@@ -168,10 +171,11 @@ if ! kubectl get svc >/dev/null 2>&1; then
     exit 1
 fi
 
-export TEST_NODE=$(kubectl get nodes -l kubernetes.io/os=$TEST_OS |
+TEST_NODE=$(kubectl get nodes -l kubernetes.io/os=$TEST_OS |
     tail -n +2 |
     tr -s "\t" " " |
     cut -d" " -f1)
+export TEST_NODE
 echo "TEST_NODE=${TEST_NODE:?"not found"}"
 
 function get_nth_worker_pod {
@@ -182,6 +186,7 @@ function get_nth_worker_pod {
 }
 export -f get_nth_worker_pod
 
+# shellcheck disable=SC2120
 function reset_cluster {
     echo "-------------------------------------------------------------------------------------------------"
     echo "🧹 Resetting cluster $CLUSTER_NAME"
@@ -192,17 +197,17 @@ function reset_cluster {
 
 if [[ -z ${assertion_scripts+x} ]]; then
     assertion_scripts=(
-        $SCRIPTPATH/../e2e/cordon-only-test
-        $SCRIPTPATH/../e2e/imds-v2-test
-        $SCRIPTPATH/../e2e/maintenance-event-cancellation-test
-        $SCRIPTPATH/../e2e/maintenance-event-dry-run-test
-        #$SCRIPTPATH/../e2e/maintenance-event-reboot-test
-        $SCRIPTPATH/../e2e/maintenance-event-test
-        $SCRIPTPATH/../e2e/spot-interruption-dry-run-test
-        $SCRIPTPATH/../e2e/spot-interruption-test
-        #$SCRIPTPATH/../e2e/webhook-http-proxy-test
-        #$SCRIPTPATH/../e2e/webhook-secret-test
-        $SCRIPTPATH/../e2e/webhook-test
+        "$SCRIPTPATH/../e2e/cordon-only-test"
+        "$SCRIPTPATH/../e2e/imds-v2-test"
+        "$SCRIPTPATH/../e2e/maintenance-event-cancellation-test"
+        "$SCRIPTPATH/../e2e/maintenance-event-dry-run-test"
+        #"$SCRIPTPATH/../e2e/maintenance-event-reboot-test"
+        "$SCRIPTPATH/../e2e/maintenance-event-test"
+        "$SCRIPTPATH/../e2e/spot-interruption-dry-run-test"
+        "$SCRIPTPATH/../e2e/spot-interruption-test"
+        #"$SCRIPTPATH/../e2e/webhook-http-proxy-test"
+        #"$SCRIPTPATH/../e2e/webhook-secret-test"
+        "$SCRIPTPATH/../e2e/webhook-test"
     )
 fi
 

--- a/test/go-report-card-test/run-report-card-test.sh
+++ b/test/go-report-card-test/run-report-card-test.sh
@@ -19,7 +19,7 @@ else
     echo "✅ goimports found no formatting errors in go source files"
 fi
 
-if grep -r -i -e 'cancelled' --exclude-dir={build,$(basename $SCRIPTPATH)} $SCRIPTPATH/../../* ; then
+if grep -r -i -e 'cancelled' --exclude-dir={build,"$(basename $SCRIPTPATH)"} $SCRIPTPATH/../../* ; then
     echo "❌ Found a misspelling of 'canceled'!"
     EXIT_CODE=3
 fi

--- a/test/helm-sync-test/run-helm-sync-test
+++ b/test/helm-sync-test/run-helm-sync-test
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 TEST_ID=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
@@ -12,8 +13,16 @@ mkdir -p $TMP_DIR
 cd $TMP_DIR
 
 prs=$(curl -s $GITHUB_CURL_AUTH https://api.github.com/repos/aws/eks-charts/pulls)
-branches=($(echo $prs | jq -r '.[].head.ref'))
-clone_urls=($(echo $prs | jq -r '.[].head.repo.clone_url'))
+
+branches=()
+while IFS='' read -r line; do 
+   branches+=("$line"); 
+done < <(echo $prs | jq -r '.[].head.ref')
+
+clone_urls=()
+while IFS='' read -r line; do 
+   clone_urls+=("$line"); 
+done < <(echo $prs | jq -r '.[].head.repo.clone_url')
 
 branches=("master" "${branches[@]}")
 clone_urls=("https://github.com/aws/eks-charts.git" "${clone_urls[@]}")

--- a/test/helm-sync-test/run-helm-version-sync-test
+++ b/test/helm-sync-test/run-helm-version-sync-test
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-TAG=$(git describe --tags `git rev-list --tags --max-count=1` | cut -d'v' -f2)
+TAG=$(git describe --tags "`git rev-list --tags --max-count=1`" | cut -d'v' -f2)
 CHART_VERSION=$(cat $SCRIPTPATH/../../config/helm/aws-node-termination-handler/Chart.yaml | grep 'appVersion:' | xargs | cut -d' ' -f2 | tr -d '[:space:]')
 DEFAULT_VALUE=$(cat $SCRIPTPATH/../../config/helm/aws-node-termination-handler/values.yaml | grep 'tag:' | xargs | cut -d' ' -f2 | tr -d '[:space:]')
 

--- a/test/k8s-compatibility-test/run-k8s-compatibility-test.sh
+++ b/test/k8s-compatibility-test/run-k8s-compatibility-test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail 
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 versions=("1.18" "1.17" "1.16" "1.15" "1.14" "1.13" "1.12")

--- a/test/k8s-local-cluster-test/delete-cluster
+++ b/test/k8s-local-cluster-test/delete-cluster
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-
 USAGE=$(cat << 'EOM'
   Usage: delete-cluster  [-c <CLUSTER_CONTEXT>] [-o]
   Deletes a kind cluster and context dir
@@ -25,7 +23,6 @@ while getopts "c:o" opt; do
         CLUSTER_NAME=$(cat $TMP_DIR/clustername)
       ;;
     o ) # Override path with your own kubectl and kind binaries
-	      OVERRIDE_PATH=1
         export PATH=$PATH:$TMP_DIR
       ;;
     \? )

--- a/test/k8s-local-cluster-test/provision-cluster
+++ b/test/k8s-local-cluster-test/provision-cluster
@@ -3,18 +3,24 @@ set -euo pipefail
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
-CLUSTER_CREATION_TIMEOUT_IN_SEC=300
 TEST_ID=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
 CLUSTER_NAME_BASE=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
 OVERRIDE_PATH=0
 KIND_CONFIG_FILE=$SCRIPTPATH/kind-two-node-cluster.yaml
 
+# shellcheck disable=SC2034
 K8_1_18="kindest/node:v1.18.4@sha256:9ddbe5ba7dad96e83aec914feae9105ac1cffeb6ebd0d5aa42e820defe840fd4"
+# shellcheck disable=SC2034
 K8_1_17="kindest/node:v1.17.5@sha256:ab3f9e6ec5ad8840eeb1f76c89bb7948c77bbf76bcebe1a8b59790b8ae9a283a"
+# shellcheck disable=SC2034
 K8_1_16="kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765"
+# shellcheck disable=SC2034
 K8_1_15="kindest/node:v1.15.11@sha256:6cc31f3533deb138792db2c7d1ffc36f7456a06f1db5556ad3b6927641016f50"
+# shellcheck disable=SC2034
 K8_1_14="kindest/node:v1.14.10@sha256:6cd43ff41ae9f02bb46c8f455d5323819aec858b99534a290517ebc181b443c6"
+# shellcheck disable=SC2034
 K8_1_13="kindest/node:v1.13.12@sha256:214476f1514e47fe3f6f54d0f9e24cfb1e4cda449529791286c7161b7f9c08e7"
+# shellcheck disable=SC2034
 K8_1_12="kindest/node:v1.12.10@sha256:faeb82453af2f9373447bb63f50bae02b8020968e0889c7fa308e19b348916cb"
 
 K8_VERSION="$K8_1_16"
@@ -118,18 +124,12 @@ else
 fi
 
 echoerr "🥑 Creating k8s cluster using \"kind\""
-for i in $(seq 0 5); do
-  if [[ -z $(kind get clusters | grep $CLUSTER_NAME) ]]; then
-      kind create cluster -q --name "$CLUSTER_NAME" --image $K8_VERSION --config "$SCRIPTPATH/kind-two-node-cluster.yaml" --kubeconfig $TMP_DIR/kubeconfig 1>&2 || :
-  else
-      break
-  fi
-done
+retry 3 kind create cluster -q --name "$CLUSTER_NAME" --image $K8_VERSION --config "$KIND_CONFIG_FILE" --kubeconfig $TMP_DIR/kubeconfig 1>&2
 
-echo "$CLUSTER_NAME" > $TMP_DIR/clustername
+echo "$CLUSTER_NAME" > "$TMP_DIR/clustername"
 echoerr "👍 Created k8s cluster using \"kind\""
 
-kubectl apply -f "$SCRIPTPATH/psp-default.yaml" --context kind-$CLUSTER_NAME --kubeconfig $TMP_DIR/kubeconfig 1>&2
-kubectl apply -f "$SCRIPTPATH/psp-privileged.yaml" --context kind-$CLUSTER_NAME --kubeconfig $TMP_DIR/kubeconfig 1>&2
+kubectl apply -f "$SCRIPTPATH/psp-default.yaml" --context "kind-$CLUSTER_NAME" --kubeconfig "$TMP_DIR/kubeconfig" 1>&2
+kubectl apply -f "$SCRIPTPATH/psp-privileged.yaml" --context "kind-$CLUSTER_NAME" --kubeconfig "$TMP_DIR/kubeconfig" 1>&2
 
-echo $TMP_DIR
+echo "$TMP_DIR"

--- a/test/k8s-local-cluster-test/run-test
+++ b/test/k8s-local-cluster-test/run-test
@@ -17,7 +17,7 @@ OVERRIDE_PATH=0
 K8S_VERSION="1.16"
 AEMM_URL="amazon-ec2-metadata-mock-service.default.svc.cluster.local"
 AEMM_VERSION="1.2.0"
-AEMM_DL_URL="https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v"$AEMM_VERSION"/amazon-ec2-metadata-mock-"$AEMM_VERSION".tgz"
+AEMM_DL_URL="https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v$AEMM_VERSION/amazon-ec2-metadata-mock-$AEMM_VERSION.tgz"
 WEBHOOK_URL=${WEBHOOK_URL:="http://webhook-test-proxy.default.svc.cluster.local"}
 
 ASSERTION_SCRIPTS=$(find $SCRIPTPATH/../e2e -type f | sort)
@@ -62,7 +62,8 @@ function clean_up {
 }
 
 function exit_and_fail {
-    local pod_id=$(get_nth_worker_pod || :)
+    local pod_id
+    pod_id=$(get_nth_worker_pod || :)
     kubectl logs $pod_id --namespace kube-system || :
     END=$(date +%s)
     echo "⏰ Took $(expr $END - $START)sec"
@@ -91,7 +92,12 @@ function reset_cluster {
 
 function remove_labels {
     echo "Removing labels from NTH cluster nodes"
-    labels_to_remove=($(kubectl get nodes -o json | jq '.items[].metadata.labels' | grep 'aws-node-termination-handler' | tr -d '[:blank:]' | tr -d '\"' | cut -d':' -f1))
+
+    labels_to_remove=()
+    while IFS='' read -r line; do 
+      labels_to_remove+=("$line"); 
+    done < <(kubectl get nodes -o json | jq '.items[].metadata.labels' | grep 'aws-node-termination-handler' | tr -d '[:blank:]' | tr -d '\"' | cut -d':' -f1)
+
     if [[ "${#labels_to_remove[@]}" -ne 0 ]]; then
       for l in "${labels_to_remove[@]}"; do
         for n in $(kubectl get nodes -o json | jq -r '.items[].metadata.name'); do
@@ -191,6 +197,8 @@ else
     echo "🥑 Skipping building the node-termination-handler docker image, since one was specified ($NODE_TERMINATION_HANDLER_DOCKER_IMG)"
 fi
 echo "$NODE_TERMINATION_HANDLER_DOCKER_IMG" > $TMP_DIR/nth-docker-img
+NODE_TERMINATION_HANDLER_DOCKER_REPO=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f1)
+NODE_TERMINATION_HANDLER_DOCKER_TAG=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f2)
 
 if [ -z "$WEBHOOK_DOCKER_IMG" ]; then
     echo "🥑 Building the webhook-test-proxy docker image"
@@ -201,6 +209,8 @@ else
     echo "🥑 Skipping building the webhook-test-proxy docker image, since one was specified ($WEBHOOK_DOCKER_IMG)"
 fi
 echo "$WEBHOOK_DOCKER_IMG" > $TMP_DIR/webhook-test-proxy-docker-img
+WEBHOOK_DOCKER_REPO=$(echo $WEBHOOK_DOCKER_IMG | cut -d':' -f1)
+WEBHOOK_DOCKER_TAG=$(echo $WEBHOOK_DOCKER_IMG | cut -d':' -f2)
 
 echo "🥑 Loading both images into the cluster"
 kind load docker-image --name $CLUSTER_NAME --nodes=$CLUSTER_NAME-worker,$CLUSTER_NAME-control-plane $NODE_TERMINATION_HANDLER_DOCKER_IMG
@@ -230,19 +240,20 @@ export WEBHOOK_URL
 export -f timeout
 export -f relpath
 export -f get_nth_worker_pod
-export NODE_TERMINATION_HANDLER_DOCKER_IMG=$(cat $TMP_DIR/nth-docker-img)
-export NODE_TERMINATION_HANDLER_DOCKER_REPO=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f1)
-export NODE_TERMINATION_HANDLER_DOCKER_TAG=$(echo $NODE_TERMINATION_HANDLER_DOCKER_IMG | cut -d':' -f2)
-export WEBHOOK_DOCKER_IMG=$(cat $TMP_DIR/webhook-test-proxy-docker-img)
-export WEBHOOK_DOCKER_REPO=$(echo $WEBHOOK_DOCKER_IMG | cut -d':' -f1)
-export WEBHOOK_DOCKER_TAG=$(echo $WEBHOOK_DOCKER_IMG | cut -d':' -f2)
+export NODE_TERMINATION_HANDLER_DOCKER_IMG
+export NODE_TERMINATION_HANDLER_DOCKER_REPO
+export NODE_TERMINATION_HANDLER_DOCKER_TAG
+export WEBHOOK_DOCKER_IMG
+export WEBHOOK_DOCKER_REPO
+export WEBHOOK_DOCKER_TAG
 export NTH_WORKER_LABEL="kubernetes\.io/hostname=$CLUSTER_NAME-worker"
 ###
 
 i=0
 for assert_script in $ASSERTION_SCRIPTS; do
   reset_cluster
-  export IMDS_PORT=$(expr $i + 1338)
+  IMDS_PORT=$(expr $i + 1338)
+  export IMDS_PORT
   i=$(expr $i + 1)
   echo "======================================================================================================"
   echo "🥑 Running assertion script $(basename $assert_script)"

--- a/test/license-test/gen-license-report.sh
+++ b/test/license-test/gen-license-report.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 BUILD_DIR="$SCRIPTPATH/../../build"
 mkdir -p $BUILD_DIR
-export PATH="$PATH:$(go env GOPATH | sed 's+:+/bin+g')/bin"
+GOBIN=$(go env GOPATH | sed 's+:+/bin+g')/bin
+export PATH="$PATH:$GOBIN"
 
 go get github.com/mitchellh/golicense
 go build -o $BUILD_DIR/nth $SCRIPTPATH/../../.

--- a/test/shellcheck/run-shellcheck
+++ b/test/shellcheck/run-shellcheck
@@ -14,10 +14,14 @@ function exit_and_fail() {
 }
 trap exit_and_fail INT ERR TERM
 
-curl -Lo ${BUILD_DIR}/shellcheck.tar.xz https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.${KERNEL}.x86_64.tar.xz
+curl -Lo ${BUILD_DIR}/shellcheck.tar.xz "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.${KERNEL}.x86_64.tar.xz"
 tar -C ${BUILD_DIR} -xvf "${BUILD_DIR}/shellcheck.tar.xz"
 export PATH="${BUILD_DIR}/shellcheck-v${SHELLCHECK_VERSION}:$PATH"
 
-shellcheck -S error $(grep -Rn -e '#!.*/bin/bash' -e '#!.*/usr/bin/env bash' ${SCRIPTPATH}/../../ | grep ":[1-5]:" | cut -d':' -f1)
+shell_files=()
+while IFS='' read -r line; do 
+   shell_files+=("$line"); 
+done < <(grep -Rnl -e '#!.*/bin/bash' -e '#!.*/usr/bin/env bash' ${SCRIPTPATH}/../../)
+shellcheck -S warning "${shell_files[@]}"
 
 echo "✅ All shell scripts look good! 😎"


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:

There have been a lot of build/test/deployment script changes lately and have caused some problems since these scripts are difficult to test locally. As an enhanced safety measure, which would've caught some of these errors, this PR clears up shellcheck warnings and now only passes if shell scripts do not contain warnings. Before, shellcheck was only set to fail on errors. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
