### PR TITLE
Add retries when reponse from IMDSv2 retruns a 401

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -114,7 +114,7 @@ func main() {
 						duplicateErrCount = 0
 						previousErr = err
 					}
-					if duplicateErrCount > duplicateErrThreshold {
+					if duplicateErrCount >= duplicateErrThreshold {
 						log.Log().Msg("Stopping NITH - Duplicate Error Threshold hit.")
 						panic(fmt.Sprintf("%v",err))
 					}

--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -115,7 +115,7 @@ func main() {
 						previousErr = err
 					}
 					if duplicateErrCount >= duplicateErrThreshold {
-						log.Log().Msg("Stopping NITH - Duplicate Error Threshold hit.")
+						log.Log().Msg("Stopping NTH - Duplicate Error Threshold hit.")
 						panic(fmt.Sprintf("%v",err))
 					}
 				}

--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -116,7 +116,7 @@ func main() {
 					}
 					if duplicateErrCount >= duplicateErrThreshold {
 						log.Log().Msg("Stopping NTH - Duplicate Error Threshold hit.")
-						panic(fmt.Sprintf("%v",err))
+						panic(fmt.Sprintf("%v", err))
 					}
 				}
 			}

--- a/pkg/ec2metadata/ec2metadata.go
+++ b/pkg/ec2metadata/ec2metadata.go
@@ -52,7 +52,6 @@ const (
 	tokenRequestHeader      = "X-aws-ec2-metadata-token"
 	tokenTTL                = 3600 // 1 hour
 	secondsBeforeTTLRefresh = 15
-	tokenRetryAttempts      = 2
 )
 
 // Service is used to query the EC2 instance metadata service v1 and v2
@@ -120,57 +119,41 @@ func New(metadataURL string, tries int) *Service {
 
 // GetScheduledMaintenanceEvents retrieves EC2 scheduled maintenance events from imds
 func (e *Service) GetScheduledMaintenanceEvents() ([]ScheduledEventDetail, error) {
-	for i := 0; i < tokenRetryAttempts; i++ {
-		resp, err := e.Request(ScheduledEventPath)
-		if resp != nil && resp.StatusCode == 401 {
-			e.v2Token = ""
-			continue
-		}
-		if resp != nil && (resp.StatusCode < 200 || resp.StatusCode >= 300) {
-			return nil, fmt.Errorf("Metadata request received http status code: %d", resp.StatusCode)
-		}
-		if err != nil {
-			return nil, fmt.Errorf("Unable to parse metadata response: %w", err)
-		}
-		defer resp.Body.Close()
-		var scheduledEvents []ScheduledEventDetail
-		err = json.NewDecoder(resp.Body).Decode(&scheduledEvents)
-		if err != nil {
-			return nil, fmt.Errorf("Could not decode json retrieved from imds: %w", err)
-		}
-		return scheduledEvents, nil
+	resp, err := e.Request(ScheduledEventPath)
+	if resp != nil && (resp.StatusCode < 200 || resp.StatusCode >= 300) {
+		return nil, fmt.Errorf("Metadata request received http status code: %d", resp.StatusCode)
 	}
-	log.Log().Msg("Stopping NITH")
-	panic(fmt.Sprintf("Not able to get a non 401 response"))
+	if err != nil {
+		return nil, fmt.Errorf("Unable to parse metadata response: %w", err)
+	}
+	defer resp.Body.Close()
+	var scheduledEvents []ScheduledEventDetail
+	err = json.NewDecoder(resp.Body).Decode(&scheduledEvents)
+	if err != nil {
+		return nil, fmt.Errorf("Could not decode json retrieved from imds: %w", err)
+	}
+	return scheduledEvents, nil
 }
 
 // GetSpotITNEvent retrieves EC2 spot interruption events from imds
 func (e *Service) GetSpotITNEvent() (instanceAction *InstanceAction, err error) {
-	for i := 0; i < tokenRetryAttempts; i++ {
-		resp, err := e.Request(SpotInstanceActionPath)
-		if resp != nil && resp.StatusCode == 401 {
-			e.v2Token = ""
-			continue
-		}
-		// 404s are normal when querying for the 'latest/meta-data/spot' path
-		if resp != nil && resp.StatusCode == 404 {
-			return nil, nil
-		} else if resp != nil && (resp.StatusCode < 200 || resp.StatusCode >= 300) {
-			return nil, fmt.Errorf("Metadata request received http status code: %d", resp.StatusCode)
-		}
-		if err != nil {
-			return nil, fmt.Errorf("Unable to parse metadata response: %w", err)
-		}
-		defer resp.Body.Close()
-
-		err = json.NewDecoder(resp.Body).Decode(&instanceAction)
-		if err != nil {
-			return nil, fmt.Errorf("Could not decode instance action response: %w", err)
-		}
-		return instanceAction, nil
+	resp, err := e.Request(SpotInstanceActionPath)
+	// 404s are normal when querying for the 'latest/meta-data/spot' path
+	if resp != nil && resp.StatusCode == 404 {
+		return nil, nil
+	} else if resp != nil && (resp.StatusCode < 200 || resp.StatusCode >= 300) {
+		return nil, fmt.Errorf("Metadata request received http status code: %d", resp.StatusCode)
 	}
-	log.Log().Msg("Stopping NITH")
-	panic(fmt.Sprintf("Not able to get a non 401 response"))
+	if err != nil {
+		return nil, fmt.Errorf("Unable to parse metadata response: %w", err)
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&instanceAction)
+	if err != nil {
+		return nil, fmt.Errorf("Could not decode instance action response: %w", err)
+	}
+	return instanceAction, nil
 }
 
 // GetMetadataInfo generic function for retrieving ec2 metadata


### PR DESCRIPTION
Issue #, if available:
#229 
Description of changes:
Added a for loop for getting scheduled maintenance events and spot instance events. Set the retry limit to 1. 


Not sure of the best way to add this to the test suite. Also curious if throwing a panic to sovle the second item in the issue is what's best to do here or not. 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
