### PR TITLE
retry second AEMM install in maintenance-event-cancellation-test

### DIFF
--- a/test/e2e/maintenance-event-cancellation-test
+++ b/test/e2e/maintenance-event-cancellation-test
@@ -159,7 +159,7 @@ aemm_helm_args=(
     aemm_helm_args+=("${common_helm_args[@]}")
 
 set -x
-helm "${aemm_helm_args[@]}"
+retry 5 helm "${aemm_helm_args[@]}"
 set +x
 
 emtp_helm_args=(


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Missed a retry on the second install of AEMM in the maintenance-event-cancellation e2e test. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
