### PR TITLE
Reduce event logging to only new events

### DIFF
--- a/pkg/interruptioneventstore/interruption-event-store.go
+++ b/pkg/interruptioneventstore/interruption-event-store.go
@@ -17,6 +17,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/aws/aws-node-termination-handler/pkg/config"
 	"github.com/aws/aws-node-termination-handler/pkg/monitor"
 )
@@ -54,8 +56,10 @@ func (s *Store) AddInterruptionEvent(interruptionEvent *monitor.InterruptionEven
 	if ok {
 		return
 	}
+
 	s.Lock()
 	defer s.Unlock()
+	log.Log().Interface("event", interruptionEvent).Msg("Adding new event to the event store")
 	s.interruptionEventStore[interruptionEvent.EventID] = interruptionEvent
 	if _, ignored := s.ignoredEvents[interruptionEvent.EventID]; !ignored {
 		s.atLeastOneEvent = true

--- a/pkg/interruptioneventstore/interruption-event-store_test.go
+++ b/pkg/interruptioneventstore/interruption-event-store_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
+
 	"github.com/aws/aws-node-termination-handler/pkg/config"
 	"github.com/aws/aws-node-termination-handler/pkg/interruptioneventstore"
 	"github.com/aws/aws-node-termination-handler/pkg/monitor"
@@ -160,6 +162,9 @@ func TestIgnoreEvent(t *testing.T) {
 
 // BenchmarkDrainEventStore tests concurrent read/write patterns. We don't really care about the timings as long as deadlock doesn't occur
 func BenchmarkDrainEventStore(b *testing.B) {
+	// too many logs can break the Travis build, so we'll disable logging for this test
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+
 	idBound := 10
 	store := interruptioneventstore.New(config.Config{})
 	b.RunParallel(func(pb *testing.PB) {

--- a/pkg/monitor/scheduledevent/scheduled-event-monitor.go
+++ b/pkg/monitor/scheduledevent/scheduled-event-monitor.go
@@ -35,7 +35,7 @@ const (
 	instanceRetirementCode       = "instance-retirement"
 )
 
-// ScheduledEventMonitor is a struct definiiton that knows how to process scheduled events from IMDS
+// ScheduledEventMonitor is a struct definition that knows how to process scheduled events from IMDS
 type ScheduledEventMonitor struct {
 	IMDS             *ec2metadata.Service
 	InterruptionChan chan<- monitor.InterruptionEvent
@@ -61,10 +61,8 @@ func (m ScheduledEventMonitor) Monitor() error {
 	}
 	for _, interruptionEvent := range interruptionEvents {
 		if isStateCanceledOrCompleted(interruptionEvent.State) {
-			log.Log().Msg("Sending cancel events to the cancel channel")
 			m.CancelChan <- interruptionEvent
 		} else {
-			log.Log().Msg("Sending interruption events to the interruption channel")
 			m.InterruptionChan <- interruptionEvent
 		}
 	}

--- a/pkg/monitor/spotitn/spot-itn-monitor.go
+++ b/pkg/monitor/spotitn/spot-itn-monitor.go
@@ -21,7 +21,6 @@ import (
 	"github.com/aws/aws-node-termination-handler/pkg/ec2metadata"
 	"github.com/aws/aws-node-termination-handler/pkg/monitor"
 	"github.com/aws/aws-node-termination-handler/pkg/node"
-	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -54,7 +53,6 @@ func (m SpotInterruptionMonitor) Monitor() error {
 		return err
 	}
 	if interruptionEvent != nil && interruptionEvent.Kind == SpotITNKind {
-		log.Log().Msg("Sending interruption event to the interruption channel")
 		m.InterruptionChan <- *interruptionEvent
 	}
 	return nil

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -89,11 +89,13 @@ func (n Node) CordonAndDrain(nodeName string) error {
 		log.Log().Msgf("Node %s would have been cordoned and drained, but dry-run flag was set", nodeName)
 		return nil
 	}
+	log.Log().Msg("Cordoning the node")
 	err := n.Cordon(nodeName)
 	if err != nil {
 		return err
 	}
 	// Delete all pods on the node
+	log.Log().Msg("Draining the node")
 	err = drain.RunNodeDrain(n.drainHelper, nodeName)
 	if err != nil {
 		return err


### PR DESCRIPTION
Issue #, if available:
#250 

Description of changes:
Reduce the congestion of event logging by only logging for new events. No behavioral changes.

---

**Upside:** Better looking logs

Human readable example
```
2020/09/09 16:06:44 Kubernetes AWS Node Termination Handler has started successfully!
2020/09/09 16:06:44 Started monitoring for SPOT_ITN events
2020/09/09 16:06:44 Started watching for event cancellations
2020/09/09 16:06:46 Adding new event to the event store event={"Description":"Spot ITN received. Instance will be interrupted at 2020-09-09T16:10:47Z \n","Drained":false,"EndTime":"0001-01-01T00:00:00Z","EventID":"spot-itn-a47ba0ecd3e0bf3a0023591eaf85caf67eb18a13a7c4a5e3d0c2a9885d19c791","Kind":"SPOT_ITN","NodeName":"ip-123-456-789-123.us-east-2.compute.internal","StartTime":"2020-09-09T16:10:47Z","State":""}
2020/09/09 16:08:47 Cordoning the node
2020/09/09 16:08:47 Draining the node
WARNING: ignoring DaemonSet-managed Pods: default/amazon-ec2-metadata-mock-98gtp, kube-system/aws-node-6wzns, kube-system/aws-node-termination-handler-8wkt2, kube-system/kube-proxy-k9kzp
evicting pod "coredns-67bfd975c5-c5xjh"
2020/09/09 16:08:47 Node "ip-123-456-789-123.us-east-2.compute.internal" successfully cordoned and drained.
```
json logging example
```json
{"time":"2020-09-09T17:12:23Z","message":"Kubernetes AWS Node Termination Handler has started successfully!"}
{"time":"2020-09-09T17:12:23Z","message":"Started watching for event cancellations"}
{"time":"2020-09-09T17:12:23Z","message":"Started monitoring for SPOT_ITN events"}
{"event":{"EventID":"spot-itn-a47ba0ecd3e0bf3a0023591eaf85caf67eb18a13a7c4a5e3d0c2a9885d19c791","Kind":"SPOT_ITN","Description":"Spot ITN received. Instance will be interrupted at 2020-09-09T17:15:47Z \n","State":"","NodeName":"ip-123-456-789-123.us-east-2.compute.internal","StartTime":"2020-09-09T17:15:47Z","EndTime":"0001-01-01T00:00:00Z","Drained":false},"time":"2020-09-09T17:12:25Z","message":"Adding new event to the event store"}
{"time":"2020-09-09T17:13:47Z","message":"Cordoning the node"}
{"time":"2020-09-09T17:13:47Z","message":"Draining the node"}
WARNING: ignoring DaemonSet-managed Pods: default/amazon-ec2-metadata-mock-pbqgx, kube-system/aws-node-bl2bj, kube-system/aws-node-termination-handler-j8ktr, kube-system/kube-proxy-fct9f
evicting pod "coredns-67bfd975c5-qbnjd"
{"time":"2020-09-09T17:13:47Z","message":"Node \"ip-123-456-789-123.us-east-2.compute.internal\" successfully cordoned and drained."}
```

**Downside:** Removed node metadata from event logs. As a k8s application I don't think it's necessary to put that information in there. No "heartbeat" logging anymore (event logs used to come in every 2 seconds)

old logging example:
```
2020/09/09 16:13:02 Kubernetes AWS Node Termination Handler has started successfully!
2020/09/09 16:13:02 Started watching for event cancellations
2020/09/09 16:13:02 Started monitoring for SPOT_ITN events
2020/09/09 16:13:04 Sending interruption event to the interruption channel
2020/09/09 16:13:04 Got interruption event from channel {InstanceID:i-1234567890abcdef0 InstanceType:m4.xlarge PublicHostname:ec2-123-456-789-123.compute-1.amazonaws.com PublicIP:123.456.789.123 LocalHostname:ip-123-456-789-123.ec2.internal LocalIP:123.456.789.123 AvailabilityZone:us-east-1a} {EventID:spot-itn-793d64d900d62573e95ef93881f5290b46df70d62b994613f296ca1152672b7c Kind:SPOT_ITN Description:Spot ITN received. Instance will be interrupted at 2020-09-09T16:17:47Z
 State: NodeName:ip-123-456-789-123.us-east-2.compute.internal StartTime:2020-09-09 16:17:47 +0000 UTC EndTime:0001-01-01 00:00:00 +0000 UTC Drained:false PreDrainTask:0x113c8a0 PostDrainTask:<nil>}
2020/09/09 16:13:06 Sending interruption event to the interruption channel
2020/09/09 16:13:06 Got interruption event from channel {InstanceID:i-1234567890abcdef0 InstanceType:m4.xlarge PublicHostname:ec2-123-456-789-123.compute-1.amazonaws.com PublicIP:123.456.789.123 LocalHostname:ip-123-456-789-123.ec2.internal LocalIP:123.456.789.123 AvailabilityZone:us-east-1a} {EventID:spot-itn-793d64d900d62573e95ef93881f5290b46df70d62b994613f296ca1152672b7c Kind:SPOT_ITN Description:Spot ITN received. Instance will be interrupted at 2020-09-09T16:17:47Z
 State: NodeName:ip-123-456-789-123.us-east-2.compute.internal StartTime:2020-09-09 16:17:47 +0000 UTC EndTime:0001-01-01 00:00:00 +0000 UTC Drained:false PreDrainTask:0x113c8a0 PostDrainTask:<nil>}
.
. (this repeats every 2 seconds)
.
2020/09/09 16:15:46 Sending interruption event to the interruption channel
2020/09/09 16:15:46 Got interruption event from channel {InstanceID:i-1234567890abcdef0 InstanceType:m4.xlarge PublicHostname:ec2-123-456-789-123.compute-1.amazonaws.com PublicIP:123.456.789.123 LocalHostname:ip-123-456-789-123.ec2.internal LocalIP:123.456.789.123 AvailabilityZone:us-east-1a} {EventID:spot-itn-793d64d900d62573e95ef93881f5290b46df70d62b994613f296ca1152672b7c Kind:SPOT_ITN Description:Spot ITN received. Instance will be interrupted at 2020-09-09T16:17:47Z
 State: NodeName:ip-123-456-789-123.us-east-2.compute.internal StartTime:2020-09-09 16:17:47 +0000 UTC EndTime:0001-01-01 00:00:00 +0000 UTC Drained:false PreDrainTask:0x113c8a0 PostDrainTask:<nil>}
WARNING: ignoring DaemonSet-managed Pods: default/amazon-ec2-metadata-mock-f4jrv, kube-system/aws-node-bl2bj, kube-system/aws-node-termination-handler-6zdv4, kube-system/kube-proxy-fct9f
evicting pod "coredns-67bfd975c5-hn8tz"
2020/09/09 16:15:47 Node "ip-123-456-789-123.us-east-2.compute.internal" successfully cordoned and drained.
2020/09/09 16:15:48 Sending interruption event to the interruption channel
2020/09/09 16:15:48 Got interruption event from channel {InstanceID:i-1234567890abcdef0 InstanceType:m4.xlarge PublicHostname:ec2-123-456-789-123.compute-1.amazonaws.com PublicIP:123.456.789.123 LocalHostname:ip-123-456-789-123.ec2.internal LocalIP:123.456.789.123 AvailabilityZone:us-east-1a} {EventID:spot-itn-793d64d900d62573e95ef93881f5290b46df70d62b994613f296ca1152672b7c Kind:SPOT_ITN Description:Spot ITN received. Instance will be interrupted at 2020-09-09T16:17:47Z
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
