### PR TITLE
Allow users to configure webhook message content with a template file

### DIFF
--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -64,6 +64,8 @@ Parameter | Description | Default
 `webhookProxy` | Uses the specified HTTP(S) proxy for sending webhooks | ``
 `webhookHeaders` | Replaces the default webhook headers. | `{"Content-type":"application/json"}`
 `webhookTemplate` | Replaces the default webhook message template. | `{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} - State: {{ .State }} - Start Time: {{ .StartTime }}"}`
+`webhookTemplateConfigMapName` | Pass Webhook template file as configmap | None
+`webhookTemplateConfigMapKey` | Name of the template file stored in the configmap| None
 `dryRun` | If true, only log if a node would be drained | `false`
 `enableScheduledEventDraining` | [EXPERIMENTAL] If true, drain nodes before the maintenance window starts for an EC2 instance scheduled event | `false`
 `enableSpotInterruptionDraining` | If false, do not drain nodes when the spot interruption termination notice is received | `true`

--- a/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -42,6 +42,11 @@ spec:
         - name: "uptime"
           hostPath:
             path: {{ .Values.procUptimeFile | default "/proc/uptime" | quote }}
+        {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
+        - name: "webhookTemplate"
+          configMap:
+            name: {{ .Values.webhookTemplateConfigMapName }}
+        {{- end }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       affinity:
         nodeAffinity:
@@ -85,6 +90,10 @@ spec:
             - name: "uptime"
               mountPath: {{ .Values.procUptimeFile | default "/proc/uptime" | quote }}
               readOnly: true
+            {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
+            - name: "webhookTemplate"
+              mountPath: "/config/"
+            {{- end }}
           env:
           - name: NODE_NAME
             valueFrom:
@@ -125,8 +134,10 @@ spec:
           {{- end }}
           - name: WEBHOOK_HEADERS
             value: {{ .Values.webhookHeaders | quote }}
+          {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
           - name: WEBHOOK_TEMPLATE_FILE
-            value: {{ .Values.webhookTemplateFile | quote }}
+            value: {{ print "/config/" .Values.webhookTemplateConfigMapKey | quote }}
+          {{- end }}
           - name: WEBHOOK_TEMPLATE
             value: {{ .Values.webhookTemplate | quote }}
           - name: DRY_RUN

--- a/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -125,6 +125,8 @@ spec:
           {{- end }}
           - name: WEBHOOK_HEADERS
             value: {{ .Values.webhookHeaders | quote }}
+          - name: WEBHOOK_TEMPLATE_FILE
+            value: {{ .Values.webhookTemplateFile | quote }}
           - name: WEBHOOK_TEMPLATE
             value: {{ .Values.webhookTemplate | quote }}
           - name: DRY_RUN

--- a/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -97,6 +97,8 @@ spec:
             value: {{ .Values.webhookURL | quote }}
           - name: WEBHOOK_HEADERS
             value: {{ .Values.webhookHeaders | quote }}
+          - name: WEBHOOK_TEMPLATE_FILE
+            value: {{ .Values.webhookTemplateFile | quote }}
           - name: WEBHOOK_TEMPLATE
             value: {{ .Values.webhookTemplate | quote }}
           - name: DRY_RUN

--- a/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -38,6 +38,12 @@ spec:
         {{ $key }}: {{ $value | quote }}
       {{- end }}
     spec:
+      {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
+      volumes:
+      - name: "webhookTemplate"
+        configMap:
+          name: {{ .Values.webhookTemplateConfigMapName }}
+      {{- end }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       affinity:
         nodeAffinity:
@@ -64,6 +70,11 @@ spec:
         - name: {{ include "aws-node-termination-handler.name" . }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
+          volumeMounts:
+          - name: "webhookTemplate"
+            mountPath: "/config/"
+          {{- end }}
           env:
           - name: NODE_NAME
             valueFrom:
@@ -97,8 +108,10 @@ spec:
             value: {{ .Values.webhookURL | quote }}
           - name: WEBHOOK_HEADERS
             value: {{ .Values.webhookHeaders | quote }}
+          {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
           - name: WEBHOOK_TEMPLATE_FILE
-            value: {{ .Values.webhookTemplateFile | quote }}
+            value: {{ print "/config/" .Values.webhookTemplateConfigMapKey | quote }}
+          {{- end }}
           - name: WEBHOOK_TEMPLATE
             value: {{ .Values.webhookTemplate | quote }}
           - name: DRY_RUN

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -81,9 +81,12 @@ webhookProxy: ""
 # webhookHeaders if specified, replaces the default webhook headers.
 webhookHeaders: ""
 
-# webhookTemplateFile if specified, replaces the default webhook message template.
-# Template file must be manually mounted into container
-webhookTemplateFile: ""
+# webhook template file will be fetched from given config map name
+# if specified, replaces the default webhook message with the content of the template file
+webhookTemplateConfigMapName: ""
+
+# template file name stored in configmap
+webhookTemplateConfigMapKey: ""
 
 # webhookTemplate if specified, replaces the default webhook message template.
 webhookTemplate: ""

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -81,6 +81,10 @@ webhookProxy: ""
 # webhookHeaders if specified, replaces the default webhook headers.
 webhookHeaders: ""
 
+# webhookTemplateFile if specified, replaces the default webhook message template.
+# Template file must be manually mounted into container
+webhookTemplateFile: ""
+
 # webhookTemplate if specified, replaces the default webhook message template.
 webhookTemplate: ""
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,6 +44,7 @@ const (
 	webhookHeadersConfigKey                 = "WEBHOOK_HEADERS"
 	webhookHeadersDefault                   = `{"Content-type":"application/json"}`
 	webhookTemplateConfigKey                = "WEBHOOK_TEMPLATE"
+	webhookTemplateFileConfigKey            = "WEBHOOK_TEMPLATE_FILE"
 	webhookTemplateDefault                  = `{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Description: {{ .Description }} - Start Time: {{ .StartTime }}"}`
 	enableScheduledEventDrainingConfigKey   = "ENABLE_SCHEDULED_EVENT_DRAINING"
 	enableScheduledEventDrainingDefault     = false
@@ -79,6 +80,7 @@ type Config struct {
 	WebhookURL                     string
 	WebhookHeaders                 string
 	WebhookTemplate                string
+	WebhookTemplateFile            string
 	WebhookProxy                   string
 	EnableScheduledEventDraining   bool
 	EnableSpotInterruptionDraining bool
@@ -116,6 +118,7 @@ func ParseCliArgs() (config Config, err error) {
 	flag.StringVar(&config.WebhookProxy, "webhook-proxy", getEnv(webhookProxyConfigKey, webhookProxyDefault), "If specified, uses the HTTP(S) proxy to send webhooks. Example: --webhook-url='tcp://<ip-or-dns-to-proxy>:<port>'")
 	flag.StringVar(&config.WebhookHeaders, "webhook-headers", getEnv(webhookHeadersConfigKey, webhookHeadersDefault), "If specified, replaces the default webhook headers.")
 	flag.StringVar(&config.WebhookTemplate, "webhook-template", getEnv(webhookTemplateConfigKey, webhookTemplateDefault), "If specified, replaces the default webhook message template.")
+	flag.StringVar(&config.WebhookTemplateFile, "webhook-template-file", getEnv(webhookTemplateFileConfigKey, ""), "If specified, replaces the default webhook message template with content from template file.")
 	flag.BoolVar(&config.EnableScheduledEventDraining, "enable-scheduled-event-draining", getBoolEnv(enableScheduledEventDrainingConfigKey, enableScheduledEventDrainingDefault), "[EXPERIMENTAL] If true, drain nodes before the maintenance window starts for an EC2 instance scheduled event")
 	flag.BoolVar(&config.EnableSpotInterruptionDraining, "enable-spot-interruption-draining", getBoolEnv(enableSpotInterruptionDrainingConfigKey, enableSpotInterruptionDrainingDefault), "If false, do not drain nodes when the spot interruption termination notice is received")
 	flag.IntVar(&config.MetadataTries, "metadata-tries", getIntEnv(metadataTriesConfigKey, metadataTriesDefault), "The number of times to try requesting metadata. If you would like 2 retries, set metadata-tries to 3.")

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -41,7 +41,7 @@ func Post(additionalInfo ec2metadata.NodeMetadata, event *monitor.InterruptionEv
 	if nthconfig.WebhookTemplateFile != "" {
 		content,err := ioutil.ReadFile(nthconfig.WebhookTemplateFile)
 		if err != nil {
-			log.Log().Msgf("Webhook Error: Template parsing failed - %s", err)
+			log.Log().Msgf("Webhook Error: Could not read template file %s - %s", nthconfig.WebhookTemplateFile, err)
 			return
 		}
 		webhookTemplateContent = string(content)

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -36,10 +36,10 @@ type combinedDrainData struct {
 
 // Post makes a http post to send drain event data to webhook url
 func Post(additionalInfo ec2metadata.NodeMetadata, event *monitor.InterruptionEvent, nthconfig config.Config) {
-	var webhookTemplateContent = ""
+	var webhookTemplateContent string
 
 	if nthconfig.WebhookTemplateFile != "" {
-		content,err := ioutil.ReadFile(nthconfig.WebhookTemplateFile)
+		content, err := ioutil.ReadFile(nthconfig.WebhookTemplateFile)
 		if err != nil {
 			log.Log().Msgf("Webhook Error: Could not read template file %s - %s", nthconfig.WebhookTemplateFile, err)
 			return


### PR DESCRIPTION
Description of changes:

When the destination of the webhook requires a more complex message content, it can be easier to provide a json template file which will be mounted into the pod, rather than having the webhook message content set in an inline variable.

This will allow users to set a WEBHOOK_TEMPLATE_FILE environment variable (--webhook-template-file argument) to set the template file path which will be used to send the webhook message. This takes precedence over the --webhook-template argument.

Template file will have to exist (be mounted into the pod as volume by users) otherwise it will throw an error.

Example: 
```
---
apiVersion: v1
data:
  webhook-alert-template.json: |-
    {
      "status": "firing",
      "alerts": [
          {
            "status": "firing",
            "labels": {
              "alertname": "myalert",
              "region": "eu-west-1",
              "severity": "high"
            }
          }
       ]
    }
kind: ConfigMap
metadata:
  name: webhook-template
  namespace: monitoring
---
apiVersion: apps/v1
kind: DaemonSet
metadata:
  labels:
    app: aws-node-termination-handler
  name: aws-node-termination-handler
  namespace: monitoring
spec:
  selector:
    matchLabels:
      app: aws-node-termination-handler
  template:
    metadata:
      labels:
        app: aws-node-termination-handler
    spec:
      containers:
      - env:
        ...
        - name: WEBHOOK_TEMPLATE_FILE
          value: /config/webhook-alert-template.json
        ...
        volumeMounts:
        - mountPath: /config/
          name: template
      volumes:
      - configMap:
          name: webhook-template
        name: template
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
