### PR TITLE
Log all pods on a node when cordoning the node

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -221,6 +221,10 @@ func drainOrCordonIfNecessary(interruptionEventStore *interruptioneventstore.Sto
 				os.Exit(1)
 			}
 			log.Log().Str("node_name", nodeName).Msg("Node successfully cordoned")
+			err = node.LogPods(nodeName)
+			if err != nil {
+				log.Log().Err(err).Msg("There was a problem while trying to log all pod names on the node")
+			}
 			metrics.NodeActionsInc("cordon", nodeName, err)
 		} else {
 			err := node.CordonAndDrain(nodeName)

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -240,6 +240,30 @@ func TestMarkForUncordonAfterRebootAddActionLabelFailure(t *testing.T) {
 	h.Assert(t, err != nil, "Failed to return error on MarkForUncordonAfterReboot failing to add action Label")
 }
 
+func TestLogPods(t *testing.T) {
+	resetFlagsForTest()
+
+	client := fake.NewSimpleClientset(
+		&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "myPod",
+				Labels: map[string]string{
+					"spec.nodeName": nodeName,
+				},
+			},
+		},
+		&v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+			},
+		},
+	)
+
+	tNode := getNode(t, getDrainHelper(client))
+	err := tNode.LogPods(nodeName)
+	h.Ok(t, err)
+}
+
 func TestIsLableledWithActionFailure(t *testing.T) {
 	resetFlagsForTest()
 


### PR DESCRIPTION
### Issue #, if available

N.A.

### Description of changes:

To log all pods that are potentially affected by a spot interruption.

### Decisions

1. Logging the pod names can be another `PreDrainTask`, but that would require the PreDrainTask of `monitor.InterruptionEvent` to be changed to a slice and much more code changes. On the other hand, for a scheduled maintenance, there is no need to log all pod names.
1. Make `LogPods ` and `fetchAllPods` a member function of Node such that they can potentially be reused.
1. Change a bit in the test cases to see if the logging works properly.

✅  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
