### PR TITLE
Add debug log messages to `isInstanceManaged`

### DIFF
--- a/pkg/monitor/sqsevent/sqs-monitor.go
+++ b/pkg/monitor/sqsevent/sqs-monitor.go
@@ -194,6 +194,7 @@ func (m SQSMonitor) isInstanceManaged(instanceID string) (bool, error) {
 		return false, err
 	}
 	if len(asgs.AutoScalingInstances) == 0 {
+		log.Debug().Str("instance_id", instanceID).Msg("Did not find an Auto Scaling Instance for the given instance id")
 		return false, nil
 	}
 	asgName := asgs.AutoScalingInstances[0].AutoScalingGroupName
@@ -214,5 +215,10 @@ func (m SQSMonitor) isInstanceManaged(instanceID string) (bool, error) {
 		return true
 	})
 
+	if !isManaged {
+		log.Debug().
+			Str("instance_id", instanceID).
+			Msgf("The instance's Auto Scaling Group is not tagged as managed with tag key: %s", NTHManagedASG)
+	}
 	return isManaged, err
 }

--- a/pkg/monitor/sqsevent/sqs-monitor.go
+++ b/pkg/monitor/sqsevent/sqs-monitor.go
@@ -194,7 +194,7 @@ func (m SQSMonitor) isInstanceManaged(instanceID string) (bool, error) {
 		return false, err
 	}
 	if len(asgs.AutoScalingInstances) == 0 {
-		log.Debug().Str("instance_id", instanceID).Msg("Did not find an Auto Scaling Instance for the given instance id")
+		log.Debug().Str("instance_id", instanceID).Msg("Did not find an Auto Scaling Group for the given instance id")
 		return false, nil
 	}
 	asgName := asgs.AutoScalingInstances[0].AutoScalingGroupName


### PR DESCRIPTION
This change adds debug log messages to give hints when an Auto Scaling
Group is not tagged as managed. Without this change there's no other
indication that the instance & ASG is unmanaged and makes diagnosing
this condition quite difficult without reading through the source code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
