### PR TITLE
update readme versions post-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,3 +79,7 @@ jobs:
       if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(GITHUB_TOKEN) IS present
       script: make ekscharts-sync-release
       name: Sync to EKS Charts
+    - stage: ReadMe Version Sync
+      if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(GITHUB_TOKEN) IS present
+      script: make create-release-prep-pr-readme
+      name: Sync ReadMe versions

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,9 @@ create-local-release-tag-patch:
 create-release-prep-pr:
 	${MAKEFILE_PATH}/scripts/prepare-for-release
 
+create-release-prep-pr-readme:
+	${MAKEFILE_PATH}/scripts/prepare-for-release -m
+
 create-release-prep-pr-draft:
 	${MAKEFILE_PATH}/scripts/prepare-for-release -d
 

--- a/scripts/prepare-for-release
+++ b/scripts/prepare-for-release
@@ -17,13 +17,14 @@ PREVIOUS_VERSION=$(make -s -f $MAKEFILE_PATH previous-release-tag | cut -b 2- )
 REPO_README=$REPO_ROOT_PATH/README.md
 CHART=$REPO_ROOT_PATH/config/helm/aws-node-termination-handler/Chart.yaml
 CHART_VALUES=$REPO_ROOT_PATH/config/helm/aws-node-termination-handler/values.yaml
-FILES=("$REPO_README"  "$CHART" "$CHART_VALUES")
+# ReadMe will be updated post-release due to long NTH release time
+FILES=("$CHART" "$CHART_VALUES")
 FILES_CHANGED=()
 
 # release prep
 LATEST_TAG="v$LATEST_VERSION"
 NEW_BRANCH="pr/$LATEST_TAG-release"
-COMMIT_MESSAGE="🥑🤖 $LATEST_TAG release prep [Skip Helm E2E Tests] 🤖🥑"
+COMMIT_MESSAGE="🥑🤖 $LATEST_TAG release prep 🤖🥑"
 
 # PR details
 DEFAULT_REPO_FULL_NAME=$(make -s -f $MAKEFILE_PATH repo-full-name)
@@ -43,6 +44,7 @@ HELP=$(cat << 'EOM'
 
   Options:
     -d      create a draft pr
+    -m      update versions in ReadMe only
     -r      target repo full name for the pr (default: aws/aws-node-termination-handler)
     -h      help
 
@@ -57,7 +59,7 @@ REPO_FULL_NAME=""
 NEED_ROLLBACK=true
 
 process_args() {
-    while getopts "hdr:" opt; do
+    while getopts "hdmr:" opt; do
         case ${opt} in
             h )
             echo -e "$HELP" 1>&2
@@ -65,6 +67,12 @@ process_args() {
             ;;
             d )
             DRAFT=true
+            ;;
+            m )
+            FILES=("$REPO_README")
+            # release should be completed, so no longer prep
+            COMMIT_MESSAGE="🥑🤖 $LATEST_TAG release 🤖🥑"
+            PR_TITLE="🥑🤖 $LATEST_TAG release"
             ;;
             r )
             # todo: validate $REPO_FULL_NAME


### PR DESCRIPTION
Issue #, if available:
* update ReadMe versions post-release so we don't create the opportunity for users to try and pull a release version that is currently in progress

Description of changes:
- add travis target to submit PR to update ReadMe versions
- corrected automated commit msg when updating ReadMes only (intended for post-release only)

Testing:
- tested `make create-release-prep-pr-readme` and `make create-release-prep-pr` locally and saw expected file changes and PR/Commit messaging 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
