### PR TITLE
Update prometheus helm install

### DIFF
--- a/test/e2e/prometheus-metrics-test
+++ b/test/e2e/prometheus-metrics-test
@@ -20,9 +20,10 @@ common_helm_args=()
 [[ "${TEST_WINDOWS-}" == "true" ]] && common_helm_args+=(--set targetNodeOs="windows")
 [[ -n "${NTH_WORKER_LABEL-}" ]] && common_helm_args+=(--set nodeSelector."$NTH_WORKER_LABEL")
 
-helm repo add stable https://kubernetes-charts.storage.googleapis.com
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add stable https://charts.helm.sh/stable
 helm repo update
-retry 5 helm install prometheus-operator stable/prometheus-operator --set prometheusOperator.admissionWebhooks.enabled="false"
+retry 5 helm install prometheus-operator prometheus-community/kube-prometheus-stack --set prometheusOperator.admissionWebhooks.enabled="false"
 
 anth_helm_args=(
   upgrade


### PR DESCRIPTION
New repo: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack

Old repo: https://github.com/helm/charts/tree/master/stable/prometheus-operator

Issue #, if available:
- e2e tests breaking because helm repo changed

Description of changes:
- updated repo names

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
