### PR TITLE
Fix volume name of daemonsets to follow DNS-1123 label standard

### DIFF
--- a/config/helm/aws-node-termination-handler/Chart.yaml
+++ b/config/helm/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.13.0
+version: 0.13.1
 appVersion: 1.11.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -43,7 +43,7 @@ spec:
           hostPath:
             path: {{ .Values.procUptimeFile | default "/proc/uptime" | quote }}
         {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
-        - name: "webhookTemplate"
+        - name: "webhook-template"
           configMap:
             name: {{ .Values.webhookTemplateConfigMapName }}
         {{- end }}
@@ -91,7 +91,7 @@ spec:
               mountPath: {{ .Values.procUptimeFile | default "/proc/uptime" | quote }}
               readOnly: true
             {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
-            - name: "webhookTemplate"
+            - name: "webhook-template"
               mountPath: "/config/"
             {{- end }}
           env:

--- a/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -40,7 +40,7 @@ spec:
     spec:
       {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
       volumes:
-      - name: "webhookTemplate"
+      - name: "webhook-template"
         configMap:
           name: {{ .Values.webhookTemplateConfigMapName }}
       {{- end }}
@@ -72,7 +72,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
           volumeMounts:
-          - name: "webhookTemplate"
+          - name: "webhook-template"
             mountPath: "/config/"
           {{- end }}
           env:


### PR DESCRIPTION
Description of changes:

When trying to use aws-node-termination-handler with `webhookTemplateConfigMapName` and `webhookTemplateConfigMapKey` configured, following error occurs:

```text
Error: UPGRADE FAILED: cannot patch "aws-node-termination-handler" with kind DaemonSet: DaemonSet.apps "aws-node-termination-handler" is invalid: [spec.template.spec.volumes[1].name: Invalid value: "webhookTemplate": a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'), spec.template.spec.containers[0].volumeMounts[1].name: Not found: "webhookTemplate"]
```
This PR fixes those names.

see also: https://github.com/aws/eks-charts/pull/363

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
