### PR TITLE
Update automated release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
       script: test/license-test/run-license-test.sh
       name: License Test
     - stage: Test
-      if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(DOCKER_USERNAME) IS present
+      if: type = push AND env(GITHUB_TOKEN) IS present
       script: make helm-tests
       name: Helm Sync and Version Test
     - stage: Deploy
@@ -79,6 +79,10 @@ jobs:
       if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(GITHUB_TOKEN) IS present
       script: make ekscharts-sync-release
       name: Sync to EKS Charts
+    - stage: EKS Charts Sync Check
+      if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(DOCKER_USERNAME) IS present
+      script: make helm-sync-test
+      name: Validate Charts in sync
     - stage: ReadMe Version Sync
       if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(GITHUB_TOKEN) IS present
       script: make create-release-prep-pr-readme

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,9 @@ helm-version-sync-test:
 helm-lint:
 	${MAKEFILE_PATH}/test/helm/helm-lint
 
+helm-validate-eks-versions:
+	${MAKEFILE_PATH}/test/helm/validate-chart-versions
+
 build-binaries:
 	${MAKEFILE_PATH}/scripts/build-binaries -p ${SUPPORTED_PLATFORMS_LINUX} -v ${VERSION} -d
 
@@ -129,7 +132,7 @@ spellcheck:
 
 build: compile
 
-helm-tests: helm-sync-test helm-version-sync-test helm-lint
+helm-tests: helm-version-sync-test helm-lint helm-validate-eks-versions
 
 eks-cluster-test:
 	${MAKEFILE_PATH}/test/eks-cluster-test/run-test

--- a/scripts/sync-to-aws-eks-charts
+++ b/scripts/sync-to-aws-eks-charts
@@ -65,9 +65,9 @@ if [[ -z "${REPO}" ]]; then
 fi
 
 if [[ -z $(command -v gh) ]] || [[ ! $(gh --version) =~ $GH_CLI_VERSION ]]; then
-  mkdir -p ${BUILD_DIR}/gh
-  curl -Lo ${BUILD_DIR}/gh/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_${OS}_amd64.tar.gz"
-  tar -C ${BUILD_DIR}/gh -xvf "${BUILD_DIR}/gh/gh.tar.gz"
+  mkdir -p "${BUILD_DIR}"/gh
+  curl -Lo "${BUILD_DIR}"/gh/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_${OS}_amd64.tar.gz"
+  tar -C "${BUILD_DIR}"/gh -xvf "${BUILD_DIR}/gh/gh.tar.gz"
   export PATH="${BUILD_DIR}/gh/gh_${GH_CLI_VERSION}_${OS}_amd64/bin:$PATH"
   if [[ ! $(gh --version) =~ $GH_CLI_VERSION ]]; then
     echo "❌ Failed install of github cli"
@@ -104,7 +104,7 @@ mkdir -p "${SYNC_DIR}"
 cd "${SYNC_DIR}"
 gh repo fork $CHARTS_REPO --clone --remote
 cd "${FORK_DIR}"
-git remote set-url origin https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/${GITHUB_USERNAME}/${CHARTS_REPO_NAME}.git
+git remote set-url origin https://"${GITHUB_USERNAME}":"${GITHUB_TOKEN}"@github.com/"${GITHUB_USERNAME}"/"${CHARTS_REPO_NAME}".git
 DEFAULT_BRANCH=$(git rev-parse --abbrev-ref HEAD | tr -d '\n')
 
 
@@ -123,8 +123,9 @@ git pull upstream "${DEFAULT_BRANCH}"
 git push -u origin "${DEFAULT_BRANCH}"
 
 FORK_RELEASE_BRANCH="${BINARY_BASE}-${VERSION}-${PR_ID}"
-git checkout -b "${FORK_RELEASE_BRANCH}" upstream/${DEFAULT_BRANCH}
+git checkout -b "${FORK_RELEASE_BRANCH}" upstream/"${DEFAULT_BRANCH}"
 
+rm -rf "${FORK_DIR}"/stable/aws-node-termination-handler/
 cp -r "$NTH_HELM_CHART_DIR/" "${FORK_DIR}/stable/aws-node-termination-handler/"
 
 git add --all
@@ -137,11 +138,11 @@ EOM
 
 if [[ "${INCLUDE_NOTES}" -eq 1 ]]; then
   RELEASE_ID=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-    https://api.github.com/repos/${REPO}/releases | \
+    https://api.github.com/repos/"${REPO}"/releases | \
     jq --arg VERSION "$VERSION" '.[] | select(.tag_name==$VERSION) | .id')
 
   RELEASE_NOTES=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
-    https://api.github.com/repos/${REPO}/releases/${RELEASE_ID} | \
+    https://api.github.com/repos/"${REPO}"/releases/"${RELEASE_ID}" | \
     jq -r '.body')
 
   PR_BODY=$(cat << EOM

--- a/scripts/sync-to-aws-eks-charts
+++ b/scripts/sync-to-aws-eks-charts
@@ -125,7 +125,7 @@ git push -u origin "${DEFAULT_BRANCH}"
 FORK_RELEASE_BRANCH="${BINARY_BASE}-${VERSION}-${PR_ID}"
 git checkout -b "${FORK_RELEASE_BRANCH}" upstream/${DEFAULT_BRANCH}
 
-cp -r "$NTH_HELM_CHART_DIR/*" "${FORK_DIR}/stable/aws-node-termination-handler/"
+cp -r "$NTH_HELM_CHART_DIR/" "${FORK_DIR}/stable/aws-node-termination-handler/"
 
 git add --all
 git commit -m "${BINARY_BASE}: ${VERSION}"

--- a/test/helm/validate-chart-versions
+++ b/test/helm/validate-chart-versions
@@ -10,6 +10,7 @@ SYNC_DIR="${BUILD_DIR}/eks-charts-sync"
 FORK_DIR="${SYNC_DIR}/${CHARTS_REPO_NAME}"
 STABLE="${FORK_DIR}/stable"
 
+function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
 
 EXIT_CODE=0
 # Helm yaml changes should increment Chart version EXCEPT FOR test.yaml
@@ -36,6 +37,9 @@ cd "${STABLE}"
 LAST_RELEASE_CHART_VERSION=$(git --no-pager show "$LAST_RELEASE_HASH":stable/aws-node-termination-handler/Chart.yaml | grep 'version:' | xargs | cut -d' ' -f2 | tr -d '[:space:]')
 if [[ $LAST_RELEASE_CHART_VERSION == "$LATEST_COMMIT_CHART_VERSION" ]]; then
   echo "❌ This commit's NTH Chart has the same Chart version as the latest release $LATEST_COMMIT_CHART_VERSION -- please increment Chart version in NTH"
+  EXIT_CODE=1
+elif [[ $(version $LATEST_COMMIT_CHART_VERSION) -lt $(version $LAST_RELEASE_CHART_VERSION) ]]; then
+  echo "❌ This commit's NTH Chart version $LATEST_COMMIT_CHART_VERSION is BEHIND the latest release's chart version $LAST_RELEASE_CHART_VERSION -- please increment Chart version in NTH"
   EXIT_CODE=1
 else
   echo "✅ This commit's NTH Chart has a different version since the last eks-charts release ($LAST_RELEASE_CHART_VERSION -> $LATEST_COMMIT_CHART_VERSION)"

--- a/test/helm/validate-chart-versions
+++ b/test/helm/validate-chart-versions
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NTH_HELM_DIR=config/helm/aws-node-termination-handler
+CHARTS_REPO="aws/eks-charts"
+CHARTS_REPO_NAME=$(echo ${CHARTS_REPO} | cut -d'/' -f2)
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+BUILD_DIR="${SCRIPTPATH}/../build"
+SYNC_DIR="${BUILD_DIR}/eks-charts-sync"
+FORK_DIR="${SYNC_DIR}/${CHARTS_REPO_NAME}"
+STABLE="${FORK_DIR}/stable"
+
+
+EXIT_CODE=0
+# Helm yaml changes should increment Chart version EXCEPT FOR test.yaml
+HELM_FILES_CHANGED=$(git show --name-only | grep -E "$NTH_HELM_DIR" | grep .yaml | grep -v test.yaml || :)
+if [[ -z $HELM_FILES_CHANGED ]]; then
+  echo "✅ No Helm file changes detected"
+  exit $EXIT_CODE
+fi
+
+echo "📝 Helm chart changes detected! Checking for updated Chart versions since the last eks-charts release"
+LATEST_COMMIT_HASH=$(git rev-parse HEAD)
+LATEST_COMMIT_CHART_VERSION=$(git --no-pager show "$LATEST_COMMIT_HASH":"$NTH_HELM_DIR"/Chart.yaml | grep 'version:' | xargs | cut -d' ' -f2 | tr -d '[:space:]')
+
+rm -rf "${SYNC_DIR}"
+mkdir -p "${SYNC_DIR}"
+
+cd "${SYNC_DIR}"
+gh repo fork $CHARTS_REPO --clone --remote
+cd "${FORK_DIR}"
+
+TAG=$(git describe HEAD --tags | grep -Eo "^v[0-9]+(\.[0-9]+)*")
+LAST_RELEASE_HASH=$(git rev-list -1 "$TAG")
+cd "${STABLE}"
+LAST_RELEASE_CHART_VERSION=$(git --no-pager show "$LAST_RELEASE_HASH":stable/aws-node-termination-handler/Chart.yaml | grep 'version:' | xargs | cut -d' ' -f2 | tr -d '[:space:]')
+if [[ $LAST_RELEASE_CHART_VERSION == "$LATEST_COMMIT_CHART_VERSION" ]]; then
+  echo "❌ This commit's NTH Chart has the same Chart version as the latest release $LATEST_COMMIT_CHART_VERSION -- please increment Chart version in NTH"
+  EXIT_CODE=1
+else
+  echo "✅ This commit's NTH Chart has a different version since the last eks-charts release ($LAST_RELEASE_CHART_VERSION -> $LATEST_COMMIT_CHART_VERSION)"
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
Issue #, if available:
* copy to eks-charts command had a typo
* no automated checks to prompt user to increment chart version
* no automated checks following EC2-Bot's PR to eks-charts

Description of changes:
* fixed typo
* added `validate-chart-versions` which will check NTH's latest commit Helm Chart Version (what is currently running in Travis) against the latest released version in eks-charts
  * if the commit edited Helm files, but chart versions are the same then FAIL because chart version in NTH should be incremented
  * if the commit edited Helm files, but the chart versions are different then SUCCEED
    * note, there is still some manual checking from the review to ensure **correctness** of the chart version
  * if the commit did not edit Helm files, then SUCCEED
* added Makefile target
* updated Travis to run `validate-chart-versions` for all PRs
* updated Travis to run `helm-sync-test` only after the eks charts sync PR during release

Testing:
* tested locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
