### PR TITLE
add log-level helm param

### DIFF
--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -71,6 +71,7 @@ Parameter | Description | Default
 `cordonOnly` | If true, nodes will be cordoned but not drained when an interruption event occurs. | `false`
 `taintNode` | If true, nodes will be tainted when an interruption event occurs. Currently used taint keys are `aws-node-termination-handler/scheduled-maintenance`, `aws-node-termination-handler/spot-itn`, and `aws-node-termination-handler/asg-lifecycle-termination` | `false`
 `jsonLogging` | If true, use JSON-formatted logs instead of human readable logs. | `false`
+`logLevel` | Sets the log level (INFO, DEBUG, or ERROR) | `INFO`
 `enablePrometheusServer` | If true, start an http server exposing `/metrics` endpoint for prometheus. | `false`
 `prometheusServerPort` | Replaces the default HTTP port for exposing prometheus metrics. | `9092`
 `podMonitor.create` | if `true`, create a PodMonitor | `false`

--- a/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -156,6 +156,8 @@ spec:
             value: {{ .Values.taintNode | quote }}
           - name: JSON_LOGGING
             value: {{ .Values.jsonLogging | quote }}
+          - name: LOG_LEVEL
+            value: {{ .Values.logLevel | quote }}
           - name: WEBHOOK_PROXY
             value: {{ .Values.webhookProxy | quote }}
           - name: UPTIME_FROM_FILE

--- a/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -130,6 +130,8 @@ spec:
             value: {{ .Values.taintNode | quote }}
           - name: JSON_LOGGING
             value: {{ .Values.jsonLogging | quote }}
+          - name: LOG_LEVEL
+            value: {{ .Values.logLevel | quote }}
           - name: WEBHOOK_PROXY
             value: {{ .Values.webhookProxy | quote }}
           - name: UPTIME_FROM_FILE

--- a/config/helm/aws-node-termination-handler/templates/deployment.yaml
+++ b/config/helm/aws-node-termination-handler/templates/deployment.yaml
@@ -112,6 +112,8 @@ spec:
             value: {{ .Values.taintNode | quote }}
           - name: JSON_LOGGING
             value: {{ .Values.jsonLogging | quote }}
+          - name: LOG_LEVEL
+            value: {{ .Values.logLevel | quote }}
           - name: WEBHOOK_PROXY
             value: {{ .Values.webhookProxy | quote }}
           - name: ENABLE_PROMETHEUS_SERVER

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -76,6 +76,9 @@ taintNode: false
 # Log messages in JSON format.
 jsonLogging: false
 
+# Sets the log level
+logLevel: "info"
+
 # dryRun tells node-termination-handler to only log calls to kubernetes control plane
 dryRun: false
 


### PR DESCRIPTION
Issue #, if available:
* N/A: helm param for log level was missing

Description of changes:
* added param

Testing:
* added various log levels (debug, info, error) to e2e tests, executed locally, and saw pod logs reflected the configuration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
