### PR TITLE
Fix duplicate error equality check

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -171,7 +171,7 @@ func main() {
 				if err != nil {
 					log.Log().Str("event_type", monitor.Kind()).Err(err).Msg("There was a problem monitoring for events")
 					metrics.ErrorEventsInc(monitor.Kind())
-					if err == previousErr {
+					if previousErr != nil && err.Error() == previousErr.Error() {
 						duplicateErrCount++
 					} else {
 						duplicateErrCount = 0


### PR DESCRIPTION
Issue #, if available:
no issue

Description of changes:
We're comparing the error objects instead of their contained errors. `err` is new on each loop so it'll never be equal to `previousErr`

Proof is in the playground: https://play.golang.org/p/o5ezN5xvaSy

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
