### PR TITLE
publish images to ecr public repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,14 +50,14 @@ push-docker-images:
 	@docker login -u ${DOCKER_USERNAME} -p="${DOCKERHUB_TOKEN}"
 	${MAKEFILE_PATH}/scripts/push-docker-images -p ${SUPPORTED_PLATFORMS_LINUX} -r ${IMG} -v ${VERSION} -m
 	${MAKEFILE_PATH}/scripts/retag-docker-images -p ${SUPPORTED_PLATFORMS_LINUX} -v ${VERSION} -o ${IMG} -n ${ECR_REPO}
-	@docker login --username AWS -p="$(shell aws ecr-public get-login-password --region us-east-1)" ${ECR_REGISTRY}
+	@ECR_REGISTRY=${ECR_REGISTRY} ${MAKEFILE_PATH}/scripts/ecr-public-login
 	${MAKEFILE_PATH}/scripts/push-docker-images -p ${SUPPORTED_PLATFORMS_LINUX} -r ${ECR_REPO} -v ${VERSION} -m
 
 push-docker-images-windows:
 	@docker login -u ${DOCKER_USERNAME} -p="${DOCKERHUB_TOKEN}"
 	${MAKEFILE_PATH}/scripts/push-docker-images -p ${SUPPORTED_PLATFORMS_WINDOWS} -r ${IMG} -v ${VERSION} -m
 	${MAKEFILE_PATH}/scripts/retag-docker-images -p ${SUPPORTED_PLATFORMS_LINUX} -v ${VERSION} -o ${IMG} -n ${ECR_REPO}
-	@docker login --username AWS -p="$(shell aws ecr-public get-login-password --region us-east-1)" ${ECR_REGISTRY}
+	@ECR_REGISTRY=${ECR_REGISTRY} ${MAKEFILE_PATH}/scripts/ecr-public-login
 	${MAKEFILE_PATH}/scripts/push-docker-images -p ${SUPPORTED_PLATFORMS_WINDOWS} -r ${ECR_REPO} -v ${VERSION} -m
 
 version:

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: amazon/aws-node-termination-handler
+  repository: public.ecr.aws/r6b0f9a1/aws-node-termination-handler
   tag: v1.11.1
   pullPolicy: IfNotPresent
   pullSecrets: []

--- a/scripts/ecr-public-login
+++ b/scripts/ecr-public-login
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ -z "${ECR_REGISTRY}" ]]; then
+    echo "The env var ECR_REGISTRY must be set"
+    exit 1
+fi
+
+docker login --username AWS -p="$(docker run --rm --env-file <(env | grep AWS) -i amazon/aws-cli ecr-public get-login-password --region us-east-1)" ${ECR_REGISTRY}

--- a/scripts/retag-docker-images
+++ b/scripts/retag-docker-images
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+REPO_ROOT_PATH=$SCRIPTPATH/../
+MAKE_FILE_PATH=$REPO_ROOT_PATH/Makefile
+
+VERSION=$(make -s -f $MAKE_FILE_PATH version)
+PLATFORMS=("linux/amd64")
+
+
+USAGE=$(cat << 'EOM'
+  Usage: retag-docker-images  [-p <platform pairs>]
+  Tags created docker images with a new prefix
+
+  Example: retag-docker-images -p "linux/amd64,linux/arm" -o <OLD_REPO_PREFIX> -n <NEW_REPO_PREFIX>
+          Optional:
+            -p          Platform pair list (os/architecture) [DEFAULT: linux/amd64]
+            -o          OLD IMAGE REPO to retag
+            -n          NEW IMAGE REPO to tag with
+            -v          VERSION: The application version of the docker image [DEFAULT: output of `make version`]
+EOM
+)
+
+# Process our input arguments
+while getopts "p:o:n:v:" opt; do
+  case ${opt} in
+    p ) # Platform Pairs
+        IFS=',' read -ra PLATFORMS <<< "$OPTARG"
+      ;;
+    o ) # Old Image Repo
+        OLD_IMAGE_REPO="$OPTARG"
+      ;;
+    n ) # New Image Repo
+        NEW_IMAGE_REPO="$OPTARG"
+      ;;
+    v ) # Image Version
+        VERSION="$OPTARG"
+      ;;
+    \? )
+        echo "$USAGE" 1>&2
+        exit
+      ;;
+  esac
+done
+
+for os_arch in "${PLATFORMS[@]}"; do
+    os=$(echo $os_arch | cut -d'/' -f1)
+    arch=$(echo $os_arch | cut -d'/' -f2)
+
+    old_img_tag="$OLD_IMAGE_REPO:$VERSION-$os-$arch"
+    new_img_tag="$NEW_IMAGE_REPO:$VERSION-$os-$arch"
+    docker tag ${old_img_tag} ${new_img_tag}
+done


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/eks-charts/issues/356
https://github.com/aws/aws-node-termination-handler/issues/295

Description of changes:
 - Publish docker images to ECR in addition to Dockerhub
 - Change helm to use ECR Public by default

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
