### PR TITLE
add script to draft release notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,9 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*$$' $(MAKEFILE_LIST) | sort
 
 ## Targets intended to be run in preparation for a new release
+draft-release-notes:
+	${MAKEFILE_PATH}/scripts/draft-release-notes
+
 create-local-release-tag-major:
 	${MAKEFILE_PATH}/scripts/create-local-tag-for-release -m
 

--- a/scripts/draft-release-notes
+++ b/scripts/draft-release-notes
@@ -9,13 +9,12 @@ touch "${RELEASE_NOTES}"
 
 >&2 git fetch --all --tags
 
-if $(git describe HEAD --tags | grep -Eq "^v[0-9]+(\.[0-9]+)*(-[a-z0-9]+)?$"); then
+if git describe HEAD --tags | grep -Eq "^v[0-9]+(\.[0-9]+)*(-[a-z0-9]+)?$"; then
     LAST_RELEASE_HASH=$(git rev-list --tags --max-count=1 --skip=1 --no-walk)
 else 
     TAG=$(git describe HEAD --tags | grep -Eo "^v[0-9]+(\.[0-9]+)*")
     LAST_RELEASE_HASH=$(git rev-list -1 $TAG)
 fi
-LAST_RELEASE_TAG=$(git describe $LAST_RELEASE_HASH --tags)
 
 echo "## Changes"  | tee -a "${RELEASE_NOTES}"
 for change in $(git rev-list $LAST_RELEASE_HASH..HEAD); do

--- a/scripts/draft-release-notes
+++ b/scripts/draft-release-notes
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GIT_REPO_ROOT=$(git rev-parse --show-toplevel)
+BUILD_DIR="${GIT_REPO_ROOT}/build"
+
+RELEASE_NOTES="${BUILD_DIR}/release-notes.md"
+touch "${RELEASE_NOTES}"
+
+>&2 git fetch --all --tags
+
+if $(git describe HEAD --tags | grep -Eq "^v[0-9]+(\.[0-9]+)*(-[a-z0-9]+)?$"); then
+    LAST_RELEASE_HASH=$(git rev-list --tags --max-count=1 --skip=1 --no-walk)
+else 
+    TAG=$(git describe HEAD --tags | grep -Eo "^v[0-9]+(\.[0-9]+)*")
+    LAST_RELEASE_HASH=$(git rev-list -1 $TAG)
+fi
+LAST_RELEASE_TAG=$(git describe $LAST_RELEASE_HASH --tags)
+
+echo "## Changes"  | tee -a "${RELEASE_NOTES}"
+for change in $(git rev-list $LAST_RELEASE_HASH..HEAD); do
+    one_line_msg=$(git --no-pager log --pretty='%s (thanks to %an)'  "${change}" -n1 |  sed 's/^\[.*\]//' | xargs)
+    echo "  - ${one_line_msg}" | tee -a "${RELEASE_NOTES}"
+done
+
+>&2 echo -e "\n\nRelease notes file: ${RELEASE_NOTES}"


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Add a script to draft release notes by pulling all the commits since the last release.
The releaser still needs to copy/paste the release notes into the github UI to make a release, but we can automate that part away soon.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
