### PR TITLE
Fix ECR login and add install-awscli script

### DIFF
--- a/scripts/ecr-public-login
+++ b/scripts/ecr-public-login
@@ -1,9 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+BUILD_DIR=$SCRIPTPATH/../build/
+export PATH="${BUILD_DIR}:${PATH}"
+
 if [[ -z "${ECR_REGISTRY}" ]]; then
     echo "The env var ECR_REGISTRY must be set"
     exit 1
 fi
 
-docker login --username AWS -p="$(docker run --rm --env-file <(env | grep AWS) -i amazon/aws-cli ecr-public get-login-password --region us-east-1)" ${ECR_REGISTRY}
+function exit_and_fail() {
+    echo "❌ Failed to login to ECR Public Repo!"
+}
+
+trap exit_and_fail INT TERM ERR
+
+"${SCRIPTPATH}/install-awscli"
+
+docker login --username AWS --password="$(aws ecr-public get-login-password --region us-east-1)" "${ECR_REGISTRY}"

--- a/scripts/install-awscli
+++ b/scripts/install-awscli
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+BUILD_DIR=$SCRIPTPATH/../build/
+
+VERSION="2.1.13"
+os=$(uname)
+arch=$(uname -m)
+
+function exit_and_fail() {
+    echo "❌ Unable to install awscli v${VERSION} for OS ${os} and arch ${arch}"
+}
+trap exit_and_fail INT TERM ERR
+
+if [[ "${os}" = "Linux" ]]; then
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-${arch}-${VERSION}.zip" -o "${BUILD_DIR}/awscliv2.zip"
+    unzip "${BUILD_DIR}/awscliv2.zip" -d "${BUILD_DIR}/awscliv2"
+    ${BUILD_DIR}/awscliv2/aws/install -i ${BUILD_DIR}/awscliv2 -b "${BUILD_DIR}"
+elif [[ "${os}" = "Darwin" ]]; then
+    curl "https://awscli.amazonaws.com/AWSCLIV2-${VERSION}.pkg" -o "${BUILD_DIR}/awscliv2.pkg"
+    CHOICES_XML="${BUILD_DIR}/aws-cli-mac.plist"
+    cat << EOF > "${CHOICES_XML}"
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <dict>
+      <key>choiceAttribute</key>
+      <string>customLocation</string>
+      <key>attributeSetting</key>
+      <string>${BUILD_DIR}</string>
+      <key>choiceIdentifier</key>
+      <string>default</string>
+    </dict>
+  </array>
+</plist>
+EOF
+    installer -pkg ${BUILD_DIR}/awscliv2.pkg \
+        -target CurrentUserHomeDirectory \
+        -applyChoiceChangesXML "${CHOICES_XML}"
+    ln -s "${BUILD_DIR}/aws-cli/aws" "${BUILD_DIR}/aws"
+else # windows
+    choco install awscli --version ${VERSION} --force -y || :
+fi
+
+echo "✅ Install AWS CLI v${VERSION} for OS ${os} and arch ${arch}"

--- a/scripts/retag-docker-images
+++ b/scripts/retag-docker-images
@@ -45,11 +45,31 @@ while getopts "p:o:n:v:" opt; do
   esac
 done
 
+function exit_and_fail() {
+  echo "❌ Failed retagging docker images"
+}
+
+trap "exit_and_fail" INT TERM ERR
+
 for os_arch in "${PLATFORMS[@]}"; do
     os=$(echo $os_arch | cut -d'/' -f1)
     arch=$(echo $os_arch | cut -d'/' -f2)
 
     old_img_tag="$OLD_IMAGE_REPO:$VERSION-$os-$arch"
     new_img_tag="$NEW_IMAGE_REPO:$VERSION-$os-$arch"
+
+    current_os=$(uname)
+    # Windows will append '\r' to the end of $img which
+    # results in docker failing to create the manifest due to invalid reference format.
+    # However, MacOS does not recognize '\r' as carriage return
+    # and attempts to remove literal 'r' chars; therefore, made this so portable
+    if [[ $current_os != "Darwin" ]]; then
+      old_img_tag=$(echo $old_img_tag | sed -e 's/\r//')
+      new_img_tag=$(echo $new_img_tag | sed -e 's/\r//')
+    fi
+    
     docker tag ${old_img_tag} ${new_img_tag}
+    echo "✅ Successfully retagged docker image $old_img_tag to $new_img_tag"
 done
+
+echo "✅ Done Retagging!"

--- a/test/shellcheck/run-shellcheck
+++ b/test/shellcheck/run-shellcheck
@@ -21,7 +21,7 @@ export PATH="${BUILD_DIR}/shellcheck-v${SHELLCHECK_VERSION}:$PATH"
 shell_files=()
 while IFS='' read -r line; do 
    shell_files+=("$line"); 
-done < <(grep -Rnl -e '#!.*/bin/bash' -e '#!.*/usr/bin/env bash' ${SCRIPTPATH}/../../)
+done < <(grep -Rnl --exclude-dir=build -e '#!.*/bin/bash' -e '#!.*/usr/bin/env bash' ${SCRIPTPATH}/../../)
 shellcheck -S warning "${shell_files[@]}"
 
 echo "✅ All shell scripts look good! 😎"


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
v1.11.2's release has been stuck because of issues with the ECR login for Windows and an old version of the aws-cli installed on github actions runners.  

This PR adds:
 - scripts/install-awscli which installs the specified AWS CLI version on mac, windows, or linux
 - Fixes ecr-login script to work across linux, windows, and mac
 - Fixes retag script to work on windows
 - Fix shellcheck test to exclude the build dir

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
