### PR TITLE
fix update version check

### DIFF
--- a/scripts/prepare-for-release
+++ b/scripts/prepare-for-release
@@ -125,7 +125,8 @@ update_versions() {
     echo -e "🥑 Attempting to update NTH release version in preparation for a new release."
 
     for f in "${FILES[@]}"; do
-        has_incorrect_version=$(cat $f | grep $PREVIOUS_VERSION)
+        # do not exit if grep doesn't find $PREVIOUS_VERSION; continue to exit on all other exit codes
+        has_incorrect_version=$(cat $f | grep $PREVIOUS_VERSION || [[ $? == 1 ]])
         if [[ ! -z  $has_incorrect_version ]]; then
             sed -i '' "s/$PREVIOUS_VERSION/$LATEST_VERSION/g" $f
             FILES_CHANGED+=("$f")


### PR DESCRIPTION
Issue #, if available:
* Last release failed because script prematurely exited when grep failed
  * https://github.com/aws/aws-node-termination-handler/runs/1602759774?check_suite_focus=true

Description of changes:
* Do not exit when grep is unable to find the previous version in documents, instead script should keep going and eventually have a file list of 0 requiring updates (and therefore no action)
* all other errors (exit code > 1) from grep will lead to script terminating

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
