### PR TITLE
Avoid noisy error on scheduled events without NotAfter

### DIFF
--- a/pkg/monitor/scheduledevent/scheduled-event-monitor.go
+++ b/pkg/monitor/scheduledevent/scheduled-event-monitor.go
@@ -91,10 +91,13 @@ func (m ScheduledEventMonitor) checkForScheduledEvents() ([]monitor.Interruption
 		if err != nil {
 			return nil, fmt.Errorf("Unable to parse scheduled event start time: %w", err)
 		}
-		notAfter, err := time.Parse(scheduledEventDateFormat, scheduledEvent.NotAfter)
-		if err != nil {
-			notAfter = notBefore
-			log.Log().Err(err).Msg("Unable to parse scheduled event end time, continuing")
+		notAfter := notBefore
+		if len(scheduledEvent.NotAfter) > 0 {
+			notAfter, err = time.Parse(scheduledEventDateFormat, scheduledEvent.NotAfter)
+			if err != nil {
+				notAfter = notBefore
+				log.Log().Err(err).Msg("Unable to parse scheduled event end time, continuing")
+			}
 		}
 		events = append(events, monitor.InterruptionEvent{
 			EventID:      scheduledEvent.EventID,


### PR DESCRIPTION
See Issue #361 and related #315

Description of changes:
Hide the continual error from attempting to parse an empty string (when there isn't a `NotAfter` in the scheduled event, as in the example from #361 ).

Note this only fixes the minor point of the issue - that the node isn't immediately drained & eventually terminated remains.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
