### PR TITLE
clarify queue processor install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,18 +320,9 @@ IAM Policy for aws-node-termination-handler Deployment:
 
 ### Installation
 
-#### Kubectl Apply
-
-You can use kubectl to directly add all of the above resources with the default configuration into your cluster.
-```
-kubectl apply -f https://github.com/aws/aws-node-termination-handler/releases/download/v1.12.0/all-resources-queue-processor.yaml
-```
-
-For a full list of releases and associated artifacts see our [releases page](https://github.com/aws/aws-node-termination-handler/releases).
-
 #### Helm
 
-The easiest way to configure the various options of the termination handler is via [helm](https://helm.sh/).  The chart for this project is hosted in the [eks-charts](https://github.com/aws/eks-charts) repository.
+The easiest and most commonly used method to configure the termination handler is via [helm](https://helm.sh/).  The chart for this project is hosted in the [eks-charts](https://github.com/aws/eks-charts) repository.
 
 To get started you need to add the eks-charts repo to helm
 
@@ -376,6 +367,20 @@ helm upgrade --install aws-node-termination-handler \
 ```
 
 For a full list of configuration options see our [Helm readme](https://github.com/aws/eks-charts/tree/master/stable/aws-node-termination-handler).
+
+#### Kubectl Apply
+
+Queue Processor needs an **sqs queue url** to function; therefore, manifest changes are **REQUIRED** before using kubectl to directly add all of the above resources into your cluster.
+
+Minimal Config:
+
+```
+curl -L https://github.com/aws/aws-node-termination-handler/releases/download/v1.12.0/all-resources-queue-processor.yaml -o all-resources-queue-processor.yaml
+<open all-resources-queue-processor.yaml and update QUEUE_URL value>
+kubectl apply -f ./all-resources-queue-processor.yaml
+```
+
+For a full list of releases and associated artifacts see our [releases page](https://github.com/aws/aws-node-termination-handler/releases).
 
 </details>
 


### PR DESCRIPTION
Issue #, if available: #346

Description of changes:
* Moving Helm install instructions above kubectl since it is the most popular installation method and clearest in terms of configuring NTH
* Added instructions for the minimal config necessary when using kubectl. Noted that the default configs alone will not work because sqs queue will be ""

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
