### PR TITLE
Fix goreportcard test and run make fmt

### DIFF
--- a/pkg/monitor/sqsevent/sqs-monitor_test.go
+++ b/pkg/monitor/sqsevent/sqs-monitor_test.go
@@ -184,7 +184,7 @@ func TestMonitor_DrainTasks(t *testing.T) {
 }
 
 func TestMonitor_DrainTasks_Errors(t *testing.T) {
-	testEvents := []sqsevent.EventBridgeEvent{spotItnEvent, asgLifecycleEvent, sqsevent.EventBridgeEvent{}, rebalanceRecommendationEvent}
+	testEvents := []sqsevent.EventBridgeEvent{spotItnEvent, asgLifecycleEvent, {}, rebalanceRecommendationEvent}
 	messages := make([]*sqs.Message, 0, len(testEvents))
 	for _, event := range testEvents {
 		msg, err := getSQSMessageFromEvent(event)

--- a/test/go-report-card-test/Dockerfile
+++ b/test/go-report-card-test/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1
 
 WORKDIR /app
 
+ARG GO111MODULE=auto
 RUN go get github.com/gojp/goreportcard
 RUN cd $GOPATH/src/github.com/gojp/goreportcard && (make install || cd / && curl -L https://git.io/vp6lP | sh)
 


### PR DESCRIPTION
Description of changes:
golang version 1.16 was released this week, and they changed the default behavior of `GO111MODULE`. So now if we want it to act like it used to, we have to set `GO111MODULE=auto`. More info on `GO111MODULE` [here](https://golang.org/ref/mod#mod-commands)

It was not downloading the source files for goreportcard, so when trying to `cd` into that directory the directory did not exist.

I also ran `make fmt`, which changed one line in `sqs-monitor_test.go` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
