### PR TITLE
helm: added necessary hostPorts in the PodSecurityPolicy

### DIFF
--- a/config/helm/aws-node-termination-handler/templates/psp.yaml
+++ b/config/helm/aws-node-termination-handler/templates/psp.yaml
@@ -12,6 +12,11 @@ spec:
   hostIPC: false
   hostNetwork: {{ .Values.useHostNetwork }} 
   hostPID: false
+{{- if and .Values.rbac.pspEnabled .Values.enablePrometheusServer }}
+  hostPorts:
+  - min: {{ .Values.prometheusServerPort }}
+    max: {{ .Values.prometheusServerPort }}
+{{- end }}
   readOnlyRootFilesystem: false
   allowPrivilegeEscalation: false
   allowedCapabilities:

--- a/config/helm/aws-node-termination-handler/test.yaml
+++ b/config/helm/aws-node-termination-handler/test.yaml
@@ -122,7 +122,7 @@ windowsNodeSelector: {
 }
 
 enablePrometheusServer: true
-prometheusServerPort: "9092"
+prometheusServerPort: 9092
 
 tolerations:
 - operator: "Exists"

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -142,7 +142,7 @@ nodeSelectorTermsOs: ""
 nodeSelectorTermsArch: ""
 
 enablePrometheusServer: false
-prometheusServerPort: "9092"
+prometheusServerPort: 9092
 
 tolerations:
   - operator: "Exists"


### PR DESCRIPTION
When metric/prometheus endpoint is enabled, we currently have an issue as the
PodSecurityPolicy does not allow the pod to bind the ports. This change sorts
this issue out (#365).

cc @haugenj