### PR TITLE
helm: Add support to override pod monitor namespace

### DIFF
--- a/config/helm/aws-node-termination-handler/Chart.yaml
+++ b/config/helm/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.13.3
+version: 0.14.0
 appVersion: 1.12.0
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -78,6 +78,7 @@ Parameter | Description | Default
 `podMonitor.interval` | Prometheus scrape interval | `30s`
 `podMonitor.sampleLimit` | Number of scraped samples accepted | `5000`
 `podMonitor.labels` | Additional PodMonitor metadata labels | `{}`
+`podMonitor.namespace` | override podMonitor Helm release namespace | `{{.Release.Namespace}}`
 
 ### AWS Node Termination Handler - Queue-Processor Mode Configuration
 

--- a/config/helm/aws-node-termination-handler/templates/podmonitor.yaml
+++ b/config/helm/aws-node-termination-handler/templates/podmonitor.yaml
@@ -3,7 +3,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ template "aws-node-termination-handler.fullname" . }}
+  {{- if .Values.podMonitor.namespace }}
+  namespace: {{ .Values.podMonitor.namespace }}
+  {{- else }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
 {{ include "aws-node-termination-handler.labels" . | indent 4 }}
 {{- with .Values.podMonitor.labels }}

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -175,6 +175,9 @@ podMonitor:
   sampleLimit: 5000
    # Additional labels to add to the metadata
   labels: {}
+  # Specifies whether a pod monitor should be created in a different namespace than
+  # the Helm release
+  # namespace: monitoring
 
 # K8s DaemonSet update strategy.
 updateStrategy:


### PR DESCRIPTION
# Description of changes

The pod monitor is only created in the Helm release namespace. The Prometheus operator by default watches pod monitors resources only in its own namespace. To watch resources in another namespace, it can be configured to use label selectors. However, in some cases, we do not want to add labels to an already existing namespace like kube-system.

This PR allows overriding the release namespace for the pod monitor. Some other Helm charts already support this feature like the pushgateway.

# Testing
Forked the Helm chart and deployed it. Working as intended.
helm template output is working as well: previous release namespace and overridden namespace when the added namespace is uncommented.
