### PR TITLE
Drop sqs messages for absent nodes

### DIFF
--- a/pkg/monitor/sqsevent/asg-lifecycle-event.go
+++ b/pkg/monitor/sqsevent/asg-lifecycle-event.go
@@ -109,13 +109,5 @@ func (m SQSMonitor) asgTerminationToInterruptionEvent(event EventBridgeEvent, me
 		return nil
 	}
 
-	if nodeName == "" {
-		log.Info().Msg("Node name is empty, assuming instance was already terminated, deleting queue message")
-		errs := m.deleteMessages([]*sqs.Message{message})
-		if errs != nil {
-			log.Warn().Errs("errors", errs).Msg("There was an error deleting the messages")
-		}
-	}
-
 	return interruptionEvent, nil
 }

--- a/pkg/monitor/sqsevent/sqs-monitor.go
+++ b/pkg/monitor/sqsevent/sqs-monitor.go
@@ -192,14 +192,15 @@ func (m SQSMonitor) retrieveNodeName(instanceID string) (string, error) {
 		return "", err
 	}
 	if len(result.Reservations) == 0 || len(result.Reservations[0].Instances) == 0 {
-		return "", fmt.Errorf("No instance found with instance-id %s", instanceID)
+		log.Info().Msgf("No instance found with instance-id %s", instanceID)
+		return "", ErrNodeStateNotRunning
 	}
 
 	instance := result.Reservations[0].Instances[0]
 	nodeName := *instance.PrivateDnsName
 	log.Debug().Msgf("Got nodename from private ip %s", nodeName)
 	instanceJSON, _ := json.MarshalIndent(*instance, " ", "    ")
-	log.Debug().Msgf("Got nodename from ec2 describe call: %s", instanceJSON)
+	log.Debug().Msgf("Got instance data from ec2 describe call: %s", instanceJSON)
 
 	if nodeName == "" {
 		state := "unknown"

--- a/pkg/monitor/sqsevent/sqs-monitor_test.go
+++ b/pkg/monitor/sqsevent/sqs-monitor_test.go
@@ -474,7 +474,7 @@ func TestMonitor_EC2NoInstances(t *testing.T) {
 		}
 
 		err = sqsMonitor.Monitor()
-		h.Nok(t, err)
+		h.Ok(t, err)
 
 		select {
 		case <-drainChan:


### PR DESCRIPTION
Issue #367, if available:

Description of changes:
If no instances are returned from the describe instances call then there's no work to do, so we'll return a `ErrNodeStateNotRunning` error. This gets handled in the `Monitor` function - it'll delete the message and avoid the panic. 

With this we can also remove the `if nodeName == "" {` check in asg-lifecycle-event because we never actually run that. There's always a nodename by that point or we'll have already returned an error. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
