### PR TITLE
Allow to check agains the value of the managed tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ The value of the key does not matter.
 This functionality is helpful in accounts where there are ASGs that do not run kubernetes nodes or you do not want aws-node-termination-handler to manage their termination lifecycle. 
 However, if your account is dedicated to ASGs for your kubernetes cluster, then you can turn off the ASG tag check by setting the flag `--check-asg-tag-before-draining=false` or environment variable `CHECK_ASG_TAG_BEFORE_DRAINING=false`.
 
+In the case of multiple EKS clusters with they own set of ASGs. To ensure that the ASGs belong to that EKS cluster the aws-node-termination-handler can also check against the value of the tagged key, setting the value `--managed-asg-tag-value=my-cluster` or environment variable `MANAGED_ASG_TAG_VALUE=my-cluster`.
+
 You can also control what resources NTH manages by adding the resource ARNs to your Amazon EventBridge rules. 
 
 Take a look at the docs on how to create rules that only manage certain ASGs here: https://docs.aws.amazon.com/autoscaling/ec2/userguide/cloud-watch-events.html 

--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -151,14 +151,15 @@ func main() {
 		log.Debug().Msgf("AWS Credentials retrieved from provider: %s", creds.ProviderName)
 
 		sqsMonitor := sqsevent.SQSMonitor{
-			CheckIfManaged:   nthConfig.CheckASGTagBeforeDraining,
-			ManagedAsgTag:    nthConfig.ManagedAsgTag,
-			QueueURL:         nthConfig.QueueURL,
-			InterruptionChan: interruptionChan,
-			CancelChan:       cancelChan,
-			SQS:              sqs.New(nthConfig.AWSSession),
-			ASG:              autoscaling.New(nthConfig.AWSSession),
-			EC2:              ec2.New(nthConfig.AWSSession),
+			CheckIfManaged:     nthConfig.CheckASGTagBeforeDraining,
+			ManagedAsgTag:      nthConfig.ManagedAsgTag,
+			ManagedAsgTagValue: nthConfig.ManagedAsgTagValue,
+			QueueURL:           nthConfig.QueueURL,
+			InterruptionChan:   interruptionChan,
+			CancelChan:         cancelChan,
+			SQS:                sqs.New(nthConfig.AWSSession),
+			ASG:                autoscaling.New(nthConfig.AWSSession),
+			EC2:                ec2.New(nthConfig.AWSSession),
 		}
 		monitoringFns[sqsEvents] = sqsMonitor
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,6 +60,7 @@ const (
 	checkASGTagBeforeDrainingDefault        = true
 	managedAsgTagConfigKey                  = "MANAGED_ASG_TAG"
 	managedAsgTagDefault                    = "aws-node-termination-handler/managed"
+	managedAsgTagConfigValue                = "MANAGED_ASG_TAG_VALUE"
 	metadataTriesConfigKey                  = "METADATA_TRIES"
 	metadataTriesDefault                    = 3
 	cordonOnly                              = "CORDON_ONLY"
@@ -107,6 +108,7 @@ type Config struct {
 	EnableRebalanceMonitoring      bool
 	CheckASGTagBeforeDraining      bool
 	ManagedAsgTag                  string
+	ManagedAsgTagValue             string
 	MetadataTries                  int
 	CordonOnly                     bool
 	TaintNode                      bool
@@ -154,6 +156,7 @@ func ParseCliArgs() (config Config, err error) {
 	flag.BoolVar(&config.EnableRebalanceMonitoring, "enable-rebalance-monitoring", getBoolEnv(enableRebalanceMonitoringConfigKey, enableRebalanceMonitoringDefault), "If true, cordon nodes when the rebalance recommendation notice is received")
 	flag.BoolVar(&config.CheckASGTagBeforeDraining, "check-asg-tag-before-draining", getBoolEnv(checkASGTagBeforeDrainingConfigKey, checkASGTagBeforeDrainingDefault), "If true, check that the instance is tagged with \"aws-node-termination-handler/managed\" as the key before draining the node")
 	flag.StringVar(&config.ManagedAsgTag, "managed-asg-tag", getEnv(managedAsgTagConfigKey, managedAsgTagDefault), "Sets the tag to check for on instances that is propogated from the ASG before taking action, default to aws-node-termination-handler/managed")
+	flag.StringVar(&config.ManagedAsgTagValue, "managed-asg-tag-value", getEnv(managedAsgTagConfigValue, ""), "Sets the tag value to check that the ASG is related to this EKS before taking action.")
 	flag.IntVar(&config.MetadataTries, "metadata-tries", getIntEnv(metadataTriesConfigKey, metadataTriesDefault), "The number of times to try requesting metadata. If you would like 2 retries, set metadata-tries to 3.")
 	flag.BoolVar(&config.CordonOnly, "cordon-only", getBoolEnv(cordonOnly, false), "If true, nodes will be cordoned but not drained when an interruption event occurs.")
 	flag.BoolVar(&config.TaintNode, "taint-node", getBoolEnv(taintNode, false), "If true, nodes will be tainted when an interruption event occurs.")
@@ -254,6 +257,7 @@ func (c Config) PrintJsonConfigArgs() {
 		Str("queue_url", c.QueueURL).
 		Bool("check_asg_tag_before_draining", c.CheckASGTagBeforeDraining).
 		Str("ManagedAsgTag", c.ManagedAsgTag).
+		Str("ManagedAsgTagValue", c.ManagedAsgTagValue).
 		Msg("aws-node-termination-handler arguments")
 }
 
@@ -295,6 +299,7 @@ func (c Config) PrintHumanConfigArgs() {
 			"\tqueue-url: %s,\n"+
 			"\tcheck-asg-tag-before-draining: %t,\n"+
 			"\tmanaged-asg-tag: %s,\n"+
+			"\tmanaged-asg-tag-value: %s,\n"+
 			"\taws-endpoint: %s,\n",
 		c.DryRun,
 		c.NodeName,
@@ -325,6 +330,7 @@ func (c Config) PrintHumanConfigArgs() {
 		c.QueueURL,
 		c.CheckASGTagBeforeDraining,
 		c.ManagedAsgTag,
+		c.ManagedAsgTagValue,
 		c.AWSEndpoint,
 	)
 }


### PR DESCRIPTION
Allow to check agains the value of the managed tag, if set, to allow the scenario for multiple EKS clusters

Issue #380 

Description of changes:
This changes adds an extra optional validation to validate that the ASGs is managed by that cluster, by looking to the value of the tag and compare it to the value set by argument or env variable. If the tag value don't match will understand that the ASG is not managed by that NTH.

Any feedback is welcomed :)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.