### PR TITLE
Provide AutoScalingGroupName for webhook notifications

### DIFF
--- a/pkg/monitor/sqsevent/asg-lifecycle-event.go
+++ b/pkg/monitor/sqsevent/asg-lifecycle-event.go
@@ -70,12 +70,13 @@ func (m SQSMonitor) asgTerminationToInterruptionEvent(event EventBridgeEvent, me
 	}
 
 	interruptionEvent := monitor.InterruptionEvent{
-		EventID:     fmt.Sprintf("asg-lifecycle-term-%x", event.ID),
-		Kind:        SQSTerminateKind,
-		StartTime:   event.getTime(),
-		NodeName:    nodeName,
-		InstanceID:  lifecycleDetail.EC2InstanceID,
-		Description: fmt.Sprintf("ASG Lifecycle Termination event received. Instance will be interrupted at %s \n", event.getTime()),
+		EventID:              fmt.Sprintf("asg-lifecycle-term-%x", event.ID),
+		Kind:                 SQSTerminateKind,
+		AutoScalingGroupName: lifecycleDetail.AutoScalingGroupName,
+		StartTime:            event.getTime(),
+		NodeName:             nodeName,
+		InstanceID:           lifecycleDetail.EC2InstanceID,
+		Description:          fmt.Sprintf("ASG Lifecycle Termination event received. Instance will be interrupted at %s \n", event.getTime()),
 	}
 
 	interruptionEvent.PostDrainTask = func(interruptionEvent monitor.InterruptionEvent, _ node.Node) error {

--- a/pkg/monitor/sqsevent/ec2-state-change-event.go
+++ b/pkg/monitor/sqsevent/ec2-state-change-event.go
@@ -65,14 +65,15 @@ func (m SQSMonitor) ec2StateChangeToInterruptionEvent(event EventBridgeEvent, me
 	if err != nil {
 		return monitor.InterruptionEvent{}, err
 	}
-
+	asgName, err := m.retrieveAutoScalingGroupName(ec2StateChangeDetail.InstanceID)
 	interruptionEvent := monitor.InterruptionEvent{
-		EventID:     fmt.Sprintf("ec2-state-change-event-%x", event.ID),
-		Kind:        SQSTerminateKind,
-		StartTime:   event.getTime(),
-		NodeName:    nodeName,
-		InstanceID:  ec2StateChangeDetail.InstanceID,
-		Description: fmt.Sprintf("EC2 State Change event received. Instance went into %s at %s \n", ec2StateChangeDetail.State, event.getTime()),
+		EventID:              fmt.Sprintf("ec2-state-change-event-%x", event.ID),
+		Kind:                 SQSTerminateKind,
+		StartTime:            event.getTime(),
+		NodeName:             nodeName,
+		AutoScalingGroupName: asgName,
+		InstanceID:           ec2StateChangeDetail.InstanceID,
+		Description:          fmt.Sprintf("EC2 State Change event received. Instance went into %s at %s \n", ec2StateChangeDetail.State, event.getTime()),
 	}
 	interruptionEvent.PostDrainTask = func(interruptionEvent monitor.InterruptionEvent, n node.Node) error {
 		errs := m.deleteMessages([]*sqs.Message{message})

--- a/pkg/monitor/sqsevent/rebalance-recommendation-event.go
+++ b/pkg/monitor/sqsevent/rebalance-recommendation-event.go
@@ -57,14 +57,16 @@ func (m SQSMonitor) rebalanceRecommendationToInterruptionEvent(event EventBridge
 	if err != nil {
 		return monitor.InterruptionEvent{}, err
 	}
+	asgName, err := m.retrieveAutoScalingGroupName(rebalanceRecDetail.InstanceID)
 
 	interruptionEvent := monitor.InterruptionEvent{
-		EventID:     fmt.Sprintf("rebalance-recommendation-event-%x", event.ID),
-		Kind:        SQSTerminateKind,
-		StartTime:   event.getTime(),
-		NodeName:    nodeName,
-		InstanceID:  rebalanceRecDetail.InstanceID,
-		Description: fmt.Sprintf("Rebalance recommendation event received. Instance will be cordoned at %s \n", event.getTime()),
+		EventID:              fmt.Sprintf("rebalance-recommendation-event-%x", event.ID),
+		Kind:                 SQSTerminateKind,
+		AutoScalingGroupName: asgName,
+		StartTime:            event.getTime(),
+		NodeName:             nodeName,
+		InstanceID:           rebalanceRecDetail.InstanceID,
+		Description:          fmt.Sprintf("Rebalance recommendation event received. Instance will be cordoned at %s \n", event.getTime()),
 	}
 	interruptionEvent.PostDrainTask = func(interruptionEvent monitor.InterruptionEvent, n node.Node) error {
 		errs := m.deleteMessages([]*sqs.Message{message})

--- a/pkg/monitor/sqsevent/spot-itn-event.go
+++ b/pkg/monitor/sqsevent/spot-itn-event.go
@@ -59,14 +59,15 @@ func (m SQSMonitor) spotITNTerminationToInterruptionEvent(event EventBridgeEvent
 	if err != nil {
 		return monitor.InterruptionEvent{}, err
 	}
-
+	asgName, err := m.retrieveAutoScalingGroupName(spotInterruptionDetail.InstanceID)
 	interruptionEvent := monitor.InterruptionEvent{
-		EventID:     fmt.Sprintf("spot-itn-event-%x", event.ID),
-		Kind:        SQSTerminateKind,
-		StartTime:   event.getTime(),
-		NodeName:    nodeName,
-		InstanceID:  spotInterruptionDetail.InstanceID,
-		Description: fmt.Sprintf("Spot Interruption event received. Instance will be interrupted at %s \n", event.getTime()),
+		EventID:              fmt.Sprintf("spot-itn-event-%x", event.ID),
+		Kind:                 SQSTerminateKind,
+		AutoScalingGroupName: asgName,
+		StartTime:            event.getTime(),
+		NodeName:             nodeName,
+		InstanceID:           spotInterruptionDetail.InstanceID,
+		Description:          fmt.Sprintf("Spot Interruption event received. Instance will be interrupted at %s \n", event.getTime()),
 	}
 	interruptionEvent.PostDrainTask = func(interruptionEvent monitor.InterruptionEvent, n node.Node) error {
 		errs := m.deleteMessages([]*sqs.Message{message})

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -24,18 +24,20 @@ type DrainTask func(InterruptionEvent, node.Node) error
 
 // InterruptionEvent gives more context of the interruption event
 type InterruptionEvent struct {
-	EventID       string
-	Kind          string
-	Description   string
-	State         string
-	NodeName      string
-	InstanceID    string
-	StartTime     time.Time
-	EndTime       time.Time
-	Drained       bool
-	InProgress    bool
-	PreDrainTask  DrainTask `json:"-"`
-	PostDrainTask DrainTask `json:"-"`
+	EventID              string
+	Kind                 string
+	Description          string
+	State                string
+	AutoScalingGroupName string
+	NodeName             string
+	NodeLabels           map[string]string
+	InstanceID           string
+	StartTime            time.Time
+	EndTime              time.Time
+	Drained              bool
+	InProgress           bool
+	PreDrainTask         DrainTask `json:"-"`
+	PostDrainTask        DrainTask `json:"-"`
 }
 
 // TimeUntilEvent returns the duration until the event start time


### PR DESCRIPTION
Issue #, if available: https://github.com/aws/aws-node-termination-handler/issues/357

Description of changes: Provide AutoScalingGroupName for webhook notifications in Queue Processor mode only as we require creds to fetch ASG name. The user can provide override sample webhook template like following:

```
`{"text":"[NTH][Instance Interruption] EventID: {{ .EventID }} - Kind: {{ .Kind }} - Node: {{ .NodeName }} - AutoScalingGroupName: {{ .AutoScalingGroupName }} - Start Time: {{ .StartTime }}"}`
``` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
