### PR TITLE
Update ClusterRole to include 'get' for pods

### DIFF
--- a/config/helm/aws-node-termination-handler/templates/clusterrole.yaml
+++ b/config/helm/aws-node-termination-handler/templates/clusterrole.yaml
@@ -18,6 +18,7 @@ rules:
     - pods
   verbs:
     - list
+    - get
 - apiGroups:
     - ""
   resources:

--- a/config/helm/aws-node-termination-handler/templates/clusterrole.yaml
+++ b/config/helm/aws-node-termination-handler/templates/clusterrole.yaml
@@ -19,7 +19,6 @@ rules:
   verbs:
     - list
     - get
-    - watch
 - apiGroups:
     - ""
   resources:

--- a/config/helm/aws-node-termination-handler/templates/clusterrole.yaml
+++ b/config/helm/aws-node-termination-handler/templates/clusterrole.yaml
@@ -19,6 +19,7 @@ rules:
   verbs:
     - list
     - get
+    - watch
 - apiGroups:
     - ""
   resources:

--- a/config/helm/prometheus-operator/templates/prometheus-operator/clusterrole.yaml
+++ b/config/helm/prometheus-operator/templates/prometheus-operator/clusterrole.yaml
@@ -49,7 +49,6 @@ rules:
   - pods
   verbs:
   - list
-  - get
   - delete
 - apiGroups:
   - ""

--- a/config/helm/prometheus-operator/templates/prometheus-operator/clusterrole.yaml
+++ b/config/helm/prometheus-operator/templates/prometheus-operator/clusterrole.yaml
@@ -49,6 +49,7 @@ rules:
   - pods
   verbs:
   - list
+  - get
   - delete
 - apiGroups:
   - ""

--- a/test/e2e/prometheus-metrics-test
+++ b/test/e2e/prometheus-metrics-test
@@ -143,7 +143,7 @@ PORT_FORWARD_PID=$!
 trap 'kill ${PORT_FORWARD_PID}' EXIT SIGINT SIGTERM ERR
 echo "✅ Port-forwarded pod $POD_NAME"
 
-sleep 1
+sleep 30
 
 METRICS_RESPONSE=$(curl -L localhost:7000/metrics)
 echo "✅ Fetched /metrics."


### PR DESCRIPTION
Issue #, if available: https://github.com/aws/aws-node-termination-handler/issues/355

Description of changes: Add permissions for 'get' to pod resources. This was causing eviction to fail internally while seeming to a successful eviction and mask all errors.  After overriding the kubectl lib and adding logs (unfortunately, missing within the package), I found the error to be:

`"spark-pi-driver" is forbidden: User "system:serviceaccount:kube-system:aws-node-termination-handler" cannot get resource "pods" in API group "" in the namespace "default"`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
