### PR TITLE
feat: add ability to drain on rebalance

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -145,7 +145,7 @@ func main() {
 		imdsScheduledEventMonitor := scheduledevent.NewScheduledEventMonitor(imds, interruptionChan, cancelChan, nthConfig.NodeName)
 		monitoringFns[scheduledMaintenance] = imdsScheduledEventMonitor
 	}
-	if nthConfig.EnableRebalanceMonitoring {
+	if nthConfig.EnableRebalanceMonitoring || nthConfig.EnableRebalanceDraining {
 		imdsRebalanceMonitor := rebalancerecommendation.NewRebalanceRecommendationMonitor(imds, interruptionChan, nthConfig.NodeName)
 		monitoringFns[rebalanceRecommendation] = imdsRebalanceMonitor
 	}

--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -291,7 +291,7 @@ func drainOrCordonIfNecessary(interruptionEventStore *interruptioneventstore.Sto
 		metrics.NodeActionsInc("pre-drain", nodeName, err)
 	}
 
-	if nthConfig.CordonOnly || drainEvent.IsRebalanceRecommendation() && !nthConfig.DrainOnRebalance {
+	if nthConfig.CordonOnly || (drainEvent.IsRebalanceRecommendation() && !nthConfig.EnableRebalanceDraining) {
 		err := node.Cordon(nodeName)
 		if err != nil {
 			if errors.IsNotFound(err) {

--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -291,7 +291,7 @@ func drainOrCordonIfNecessary(interruptionEventStore *interruptioneventstore.Sto
 		metrics.NodeActionsInc("pre-drain", nodeName, err)
 	}
 
-	if nthConfig.CordonOnly || drainEvent.IsRebalanceRecommendation() {
+	if nthConfig.CordonOnly || drainEvent.IsRebalanceRecommendation() && !nthConfig.DrainOnRebalance {
 		err := node.Cordon(nodeName)
 		if err != nil {
 			if errors.IsNotFound(err) {

--- a/config/helm/aws-node-termination-handler/Chart.yaml
+++ b/config/helm/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.15.1
+version: 0.14.2
 appVersion: 1.12.2
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/config/helm/aws-node-termination-handler/Chart.yaml
+++ b/config/helm/aws-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler
-version: 0.14.2
+version: 0.15.1
 appVersion: 1.12.2
 home: https://github.com/aws/eks-charts
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png

--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -69,7 +69,8 @@ Parameter | Description | Default
 `webhookTemplateConfigMapKey` | Name of the template file stored in the configmap| None
 `metadataTries` | The number of times to try requesting metadata. If you would like 2 retries, set metadata-tries to 3. | `3`
 `cordonOnly` | If true, nodes will be cordoned but not drained when an interruption event occurs. | `false`
-`taintNode` | If true, nodes will be tainted when an interruption event occurs. Currently used taint keys are `aws-node-termination-handler/scheduled-maintenance`, `aws-node-termination-handler/spot-itn`, and `aws-node-termination-handler/asg-lifecycle-termination` | `false`
+`drainOnRebalance` | If true, nodes will be drained when a rebalance recommendation notice is received. | `false`
+`taintNode` | If true, nodes will be tainted when an interruption event occurs. Currently used taint keys are `aws-node-termination-handler/scheduled-maintenance`, `aws-node-termination-handler/spot-itn`, `aws-node-termination-handler/asg-lifecycle-termination` and `aws-node-termination-handler/rebalance-recommendation`| `false`
 `jsonLogging` | If true, use JSON-formatted logs instead of human readable logs. | `false`
 `logLevel` | Sets the log level (INFO, DEBUG, or ERROR) | `INFO`
 `enablePrometheusServer` | If true, start an http server exposing `/metrics` endpoint for prometheus. | `false`

--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -69,7 +69,6 @@ Parameter | Description | Default
 `webhookTemplateConfigMapKey` | Name of the template file stored in the configmap| None
 `metadataTries` | The number of times to try requesting metadata. If you would like 2 retries, set metadata-tries to 3. | `3`
 `cordonOnly` | If true, nodes will be cordoned but not drained when an interruption event occurs. | `false`
-`drainOnRebalance` | If true, nodes will be drained when a rebalance recommendation notice is received. | `false`
 `taintNode` | If true, nodes will be tainted when an interruption event occurs. Currently used taint keys are `aws-node-termination-handler/scheduled-maintenance`, `aws-node-termination-handler/spot-itn`, `aws-node-termination-handler/asg-lifecycle-termination` and `aws-node-termination-handler/rebalance-recommendation`| `false`
 `jsonLogging` | If true, use JSON-formatted logs instead of human readable logs. | `false`
 `logLevel` | Sets the log level (INFO, DEBUG, or ERROR) | `INFO`
@@ -101,7 +100,8 @@ Parameter | Description | Default
 --- | --- | ---
 `enableScheduledEventDraining` | [EXPERIMENTAL] If true, drain nodes before the maintenance window starts for an EC2 instance scheduled event | `false`
 `enableSpotInterruptionDraining` | If true, drain nodes when the spot interruption termination notice is received | `true`
-`enableRebalanceMonitoring` | If true, cordon nodes when rebalance recommendation is received | `false`
+`enableRebalanceMonitoring` | If true, cordon nodes when the rebalance recommendation notice is received | `false`
+`enableRebalanceDraining` | If true, drain nodes when the rebalance recommendation notice is received | `false`
 `useHostNetwork` | If `true`, enables `hostNetwork` for the Linux DaemonSet. NOTE: setting this to `false` may cause issues accessing IMDSv2 if your account is not configured with an IP hop count of 2 | `true`
 
 ### Kubernetes Configuration

--- a/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -74,7 +74,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       serviceAccountName: {{ template "aws-node-termination-handler.serviceAccountName" . }}
-      hostNetwork: {{ .Values.useHostNetwork }} 
+      hostNetwork: {{ .Values.useHostNetwork }}
       dnsPolicy: {{ .Values.dnsPolicy | default "ClusterFirstWithHostNet" | quote }}
       containers:
         - name: {{ include "aws-node-termination-handler.name" . }}
@@ -148,10 +148,16 @@ spec:
             value: {{ .Values.enableScheduledEventDraining | quote }}
           - name: ENABLE_REBALANCE_MONITORING
             value: {{ .Values.enableRebalanceMonitoring | quote }}
+          - name: CHECK_ASG_TAG_BEFORE_DRAINING
+            value: {{ .Values.checkASGTagBeforeDraining | quote }}
+          - name: MANAGED_ASG_TAG
+            value: {{ .Values.managedAsgTag | quote }}
           - name: METADATA_TRIES
             value: {{ .Values.metadataTries | quote }}
           - name: CORDON_ONLY
             value: {{ .Values.cordonOnly | quote }}
+          - name: DRAIN_ON_REBALANCE
+            value: {{ .Values.drainOnRebalance | quote }}
           - name: TAINT_NODE
             value: {{ .Values.taintNode | quote }}
           - name: JSON_LOGGING

--- a/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -148,6 +148,8 @@ spec:
             value: {{ .Values.enableScheduledEventDraining | quote }}
           - name: ENABLE_REBALANCE_MONITORING
             value: {{ .Values.enableRebalanceMonitoring | quote }}
+          - name: ENABLE_REBALANCE_DRAINING
+            value: {{ .Values.enableRebalanceDraining | quote }}
           - name: CHECK_ASG_TAG_BEFORE_DRAINING
             value: {{ .Values.checkASGTagBeforeDraining | quote }}
           - name: MANAGED_ASG_TAG
@@ -156,8 +158,6 @@ spec:
             value: {{ .Values.metadataTries | quote }}
           - name: CORDON_ONLY
             value: {{ .Values.cordonOnly | quote }}
-          - name: DRAIN_ON_REBALANCE
-            value: {{ .Values.drainOnRebalance | quote }}
           - name: TAINT_NODE
             value: {{ .Values.taintNode | quote }}
           - name: JSON_LOGGING

--- a/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -122,10 +122,16 @@ spec:
             value: {{ .Values.enableScheduledEventDraining | quote }}
           - name: ENABLE_REBALANCE_MONITORING
             value: {{ .Values.enableRebalanceMonitoring | quote }}
+          - name: CHECK_ASG_TAG_BEFORE_DRAINING
+            value: {{ .Values.checkASGTagBeforeDraining | quote }}
+          - name: MANAGED_ASG_TAG
+            value: {{ .Values.managedAsgTag | quote }}
           - name: METADATA_TRIES
             value: {{ .Values.metadataTries | quote }}
           - name: CORDON_ONLY
             value: {{ .Values.cordonOnly | quote }}
+          - name: DRAIN_ON_REBALANCE
+            value: {{ .Values.drainOnRebalance | quote }}
           - name: TAINT_NODE
             value: {{ .Values.taintNode | quote }}
           - name: JSON_LOGGING

--- a/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -122,6 +122,8 @@ spec:
             value: {{ .Values.enableScheduledEventDraining | quote }}
           - name: ENABLE_REBALANCE_MONITORING
             value: {{ .Values.enableRebalanceMonitoring | quote }}
+          - name: ENABLE_REBALANCE_DRAINING
+            value: {{ .Values.enableRebalanceDraining | quote }}
           - name: CHECK_ASG_TAG_BEFORE_DRAINING
             value: {{ .Values.checkASGTagBeforeDraining | quote }}
           - name: MANAGED_ASG_TAG
@@ -130,8 +132,6 @@ spec:
             value: {{ .Values.metadataTries | quote }}
           - name: CORDON_ONLY
             value: {{ .Values.cordonOnly | quote }}
-          - name: DRAIN_ON_REBALANCE
-            value: {{ .Values.drainOnRebalance | quote }}
           - name: TAINT_NODE
             value: {{ .Values.taintNode | quote }}
           - name: JSON_LOGGING

--- a/config/helm/aws-node-termination-handler/templates/deployment.yaml
+++ b/config/helm/aws-node-termination-handler/templates/deployment.yaml
@@ -108,6 +108,8 @@ spec:
             value: {{ .Values.metadataTries | quote }}
           - name: CORDON_ONLY
             value: {{ .Values.cordonOnly | quote }}
+          - name: DRAIN_ON_REBALANCE
+            value: {{ .Values.drainOnRebalance | quote }}
           - name: TAINT_NODE
             value: {{ .Values.taintNode | quote }}
           - name: JSON_LOGGING

--- a/config/helm/aws-node-termination-handler/templates/deployment.yaml
+++ b/config/helm/aws-node-termination-handler/templates/deployment.yaml
@@ -108,8 +108,6 @@ spec:
             value: {{ .Values.metadataTries | quote }}
           - name: CORDON_ONLY
             value: {{ .Values.cordonOnly | quote }}
-          - name: DRAIN_ON_REBALANCE
-            value: {{ .Values.drainOnRebalance | quote }}
           - name: TAINT_NODE
             value: {{ .Values.taintNode | quote }}
           - name: JSON_LOGGING
@@ -127,6 +125,8 @@ spec:
           - name: ENABLE_SCHEDULED_EVENT_DRAINING
             value: "false"
           - name: ENABLE_REBALANCE_MONITORING
+            value: "false"
+          - name: ENABLE_REBALANCE_DRAINING
             value: "false"
           - name: ENABLE_SQS_TERMINATION_DRAINING
             value: "true"

--- a/config/helm/aws-node-termination-handler/test.yaml
+++ b/config/helm/aws-node-termination-handler/test.yaml
@@ -7,7 +7,7 @@ image:
     tag: v1.6.1
     pullPolicy: IfNotPresent
     pullSecrets: ["test"]
-  
+
 securityContext:
     runAsUserID: 1000
     runAsGroupID: 1000

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -41,7 +41,7 @@ resources:
     memory: "128Mi"
     cpu: "100m"
 
-# enableSqsTerminationDraining If true, this turns on queue-processor mode which drains nodes when an SQS termination event is received 
+# enableSqsTerminationDraining If true, this turns on queue-processor mode which drains nodes when an SQS termination event is received
 enableSqsTerminationDraining: false
 
 # enableRebalanceMonitoring If true, cordon nodes when a rebalance recommendation notice is received
@@ -77,6 +77,9 @@ metadataTries: 3
 
 # Cordon but do not drain nodes upon spot interruption termination notice.
 cordonOnly: false
+
+# If true, nodes will be drained when a rebalance recommendation notice is received.
+drainOnRebalance: false
 
 # Taint node upon spot interruption termination notice.
 taintNode: false

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -44,8 +44,11 @@ resources:
 # enableSqsTerminationDraining If true, this turns on queue-processor mode which drains nodes when an SQS termination event is received
 enableSqsTerminationDraining: false
 
-# enableRebalanceMonitoring If true, cordon nodes when a rebalance recommendation notice is received
+# enableRebalanceMonitoring If true, cordon nodes when the rebalance recommendation notice is received
 enableRebalanceMonitoring: false
+
+# enableRebalanceDraining If true, drain nodes when the rebalance recommendation notice is received
+enableRebalanceDraining: false
 
 # queueURL Listens for messages on the specified SQS queue URL
 queueURL: ""
@@ -77,9 +80,6 @@ metadataTries: 3
 
 # Cordon but do not drain nodes upon spot interruption termination notice.
 cordonOnly: false
-
-# If true, nodes will be drained when a rebalance recommendation notice is received.
-drainOnRebalance: false
 
 # Taint node upon spot interruption termination notice.
 taintNode: false

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -63,6 +63,7 @@ const (
 	metadataTriesConfigKey                  = "METADATA_TRIES"
 	metadataTriesDefault                    = 3
 	cordonOnly                              = "CORDON_ONLY"
+	drainOnRebalance                        = "DRAIN_ON_REBALANCE"
 	taintNode                               = "TAINT_NODE"
 	jsonLoggingConfigKey                    = "JSON_LOGGING"
 	jsonLoggingDefault                      = false
@@ -116,6 +117,7 @@ type Config struct {
 	ManagedAsgTag                  string
 	MetadataTries                  int
 	CordonOnly                     bool
+	DrainOnRebalance               bool
 	TaintNode                      bool
 	JsonLogging                    bool
 	LogLevel                       string
@@ -166,6 +168,7 @@ func ParseCliArgs() (config Config, err error) {
 	flag.StringVar(&config.ManagedAsgTag, "managed-asg-tag", getEnv(managedAsgTagConfigKey, managedAsgTagDefault), "Sets the tag to check for on instances that is propogated from the ASG before taking action, default to aws-node-termination-handler/managed")
 	flag.IntVar(&config.MetadataTries, "metadata-tries", getIntEnv(metadataTriesConfigKey, metadataTriesDefault), "The number of times to try requesting metadata. If you would like 2 retries, set metadata-tries to 3.")
 	flag.BoolVar(&config.CordonOnly, "cordon-only", getBoolEnv(cordonOnly, false), "If true, nodes will be cordoned but not drained when an interruption event occurs.")
+	flag.BoolVar(&config.DrainOnRebalance, "drain-on-rebalance", getBoolEnv(drainOnRebalance, false), "If true, nodes will be drained when a rebalance recommendation notice is received.")
 	flag.BoolVar(&config.TaintNode, "taint-node", getBoolEnv(taintNode, false), "If true, nodes will be tainted when an interruption event occurs.")
 	flag.BoolVar(&config.JsonLogging, "json-logging", getBoolEnv(jsonLoggingConfigKey, jsonLoggingDefault), "If true, use JSON-formatted logs instead of human readable logs.")
 	flag.StringVar(&config.LogLevel, "log-level", getEnv(logLevelConfigKey, logLevelDefault), "Sets the log level (INFO, DEBUG, or ERROR)")
@@ -255,6 +258,7 @@ func (c Config) PrintJsonConfigArgs() {
 		Bool("enable_rebalance_monitoring", c.EnableRebalanceMonitoring).
 		Int("metadata_tries", c.MetadataTries).
 		Bool("cordon_only", c.CordonOnly).
+		Bool("drain_on_rebalance", c.DrainOnRebalance).
 		Bool("taint_node", c.TaintNode).
 		Bool("json_logging", c.JsonLogging).
 		Str("log_level", c.LogLevel).
@@ -294,6 +298,7 @@ func (c Config) PrintHumanConfigArgs() {
 			"\tenable-rebalance-monitoring: %t,\n"+
 			"\tmetadata-tries: %d,\n"+
 			"\tcordon-only: %t,\n"+
+			"\tdrain-on-rebalance: %t,\n"+
 			"\ttaint-node: %t,\n"+
 			"\tjson-logging: %t,\n"+
 			"\tlog-level: %s,\n"+
@@ -324,6 +329,7 @@ func (c Config) PrintHumanConfigArgs() {
 		c.EnableRebalanceMonitoring,
 		c.MetadataTries,
 		c.CordonOnly,
+		c.DrainOnRebalance,
 		c.TaintNode,
 		c.JsonLogging,
 		c.LogLevel,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -48,6 +48,7 @@ func TestParseCliArgsEnvSuccess(t *testing.T) {
 	setEnvForTest("ENABLE_SPOT_INTERRUPTION_DRAINING", "false")
 	setEnvForTest("ENABLE_SQS_TERMINATION_DRAINING", "false")
 	setEnvForTest("ENABLE_REBALANCE_MONITORING", "true")
+	setEnvForTest("ENABLE_REBALANCE_DRAINING", "true")
 	setEnvForTest("GRACE_PERIOD", "12345")
 	setEnvForTest("IGNORE_DAEMON_SETS", "false")
 	setEnvForTest("KUBERNETES_SERVICE_HOST", "KUBERNETES_SERVICE_HOST")
@@ -61,7 +62,6 @@ func TestParseCliArgsEnvSuccess(t *testing.T) {
 	setEnvForTest("WEBHOOK_TEMPLATE", "WEBHOOK_TEMPLATE")
 	setEnvForTest("METADATA_TRIES", "100")
 	setEnvForTest("CORDON_ONLY", "false")
-	setEnvForTest("DRAIN_ON_REBALANCE", "false")
 	nthConfig, err := config.ParseCliArgs()
 	h.Ok(t, err)
 
@@ -72,6 +72,7 @@ func TestParseCliArgsEnvSuccess(t *testing.T) {
 	h.Equals(t, false, nthConfig.EnableSpotInterruptionDraining)
 	h.Equals(t, false, nthConfig.EnableSQSTerminationDraining)
 	h.Equals(t, true, nthConfig.EnableRebalanceMonitoring)
+	h.Equals(t, true, nthConfig.EnableRebalanceDraining)
 	h.Equals(t, false, nthConfig.IgnoreDaemonSets)
 	h.Equals(t, "KUBERNETES_SERVICE_HOST", nthConfig.KubernetesServiceHost)
 	h.Equals(t, "KUBERNETES_SERVICE_PORT", nthConfig.KubernetesServicePort)
@@ -84,7 +85,6 @@ func TestParseCliArgsEnvSuccess(t *testing.T) {
 	h.Equals(t, "WEBHOOK_TEMPLATE", nthConfig.WebhookTemplate)
 	h.Equals(t, 100, nthConfig.MetadataTries)
 	h.Equals(t, false, nthConfig.CordonOnly)
-	h.Equals(t, false, nthConfig.DrainOnRebalance)
 
 	// Check that env vars were set
 	value, ok := os.LookupEnv("KUBERNETES_SERVICE_HOST")
@@ -106,6 +106,7 @@ func TestParseCliArgsSuccess(t *testing.T) {
 		"--enable-spot-interruption-draining=false",
 		"--enable-sqs-termination-draining=false",
 		"--enable-rebalance-monitoring=true",
+		"--enable-rebalance-draining=true",
 		"--ignore-daemon-sets=false",
 		"--kubernetes-service-host=KUBERNETES_SERVICE_HOST",
 		"--kubernetes-service-port=KUBERNETES_SERVICE_PORT",
@@ -118,7 +119,6 @@ func TestParseCliArgsSuccess(t *testing.T) {
 		"--webhook-template=WEBHOOK_TEMPLATE",
 		"--metadata-tries=100",
 		"--cordon-only=false",
-		"--drain-on-rebalance=false",
 	}
 	nthConfig, err := config.ParseCliArgs()
 	h.Ok(t, err)
@@ -130,6 +130,7 @@ func TestParseCliArgsSuccess(t *testing.T) {
 	h.Equals(t, false, nthConfig.EnableSpotInterruptionDraining)
 	h.Equals(t, false, nthConfig.EnableSQSTerminationDraining)
 	h.Equals(t, true, nthConfig.EnableRebalanceMonitoring)
+	h.Equals(t, true, nthConfig.EnableRebalanceDraining)
 	h.Equals(t, false, nthConfig.IgnoreDaemonSets)
 	h.Equals(t, "KUBERNETES_SERVICE_HOST", nthConfig.KubernetesServiceHost)
 	h.Equals(t, "KUBERNETES_SERVICE_PORT", nthConfig.KubernetesServicePort)
@@ -142,7 +143,6 @@ func TestParseCliArgsSuccess(t *testing.T) {
 	h.Equals(t, "WEBHOOK_TEMPLATE", nthConfig.WebhookTemplate)
 	h.Equals(t, 100, nthConfig.MetadataTries)
 	h.Equals(t, false, nthConfig.CordonOnly)
-	h.Equals(t, false, nthConfig.DrainOnRebalance)
 	h.Equals(t, false, nthConfig.EnablePrometheus)
 
 	// Check that env vars were set
@@ -159,6 +159,7 @@ func TestParseCliArgsOverrides(t *testing.T) {
 	setEnvForTest("ENABLE_SPOT_INTERRUPTION_DRAINING", "true")
 	setEnvForTest("ENABLE_SQS_TERMINATION_DRAINING", "false")
 	setEnvForTest("ENABLE_REBALANCE_MONITORING", "true")
+	setEnvForTest("ENABLE_REBALANCE_DRAINING", "true")
 	setEnvForTest("GRACE_PERIOD", "99999")
 	setEnvForTest("IGNORE_DAEMON_SETS", "true")
 	setEnvForTest("KUBERNETES_SERVICE_HOST", "no")
@@ -172,7 +173,6 @@ func TestParseCliArgsOverrides(t *testing.T) {
 	setEnvForTest("WEBHOOK_TEMPLATE", "no")
 	setEnvForTest("METADATA_TRIES", "100")
 	setEnvForTest("CORDON_ONLY", "true")
-	setEnvForTest("DRAIN_ON_REBALANCE", "true")
 	os.Args = []string{
 		"cmd",
 		"--delete-local-data=false",
@@ -181,6 +181,7 @@ func TestParseCliArgsOverrides(t *testing.T) {
 		"--enable-spot-interruption-draining=false",
 		"--enable-sqs-termination-draining=true",
 		"--enable-rebalance-monitoring=false",
+		"--enable-rebalance-draining=false",
 		"--ignore-daemon-sets=false",
 		"--kubernetes-service-host=KUBERNETES_SERVICE_HOST",
 		"--kubernetes-service-port=KUBERNETES_SERVICE_PORT",
@@ -193,7 +194,6 @@ func TestParseCliArgsOverrides(t *testing.T) {
 		"--webhook-template=WEBHOOK_TEMPLATE",
 		"--metadata-tries=101",
 		"--cordon-only=false",
-		"--drain-on-rebalance=false",
 		"--enable-prometheus-server=true",
 		"--prometheus-server-port=2112",
 	}
@@ -207,6 +207,7 @@ func TestParseCliArgsOverrides(t *testing.T) {
 	h.Equals(t, false, nthConfig.EnableSpotInterruptionDraining)
 	h.Equals(t, true, nthConfig.EnableSQSTerminationDraining)
 	h.Equals(t, false, nthConfig.EnableRebalanceMonitoring)
+	h.Equals(t, false, nthConfig.EnableRebalanceDraining)
 	h.Equals(t, false, nthConfig.IgnoreDaemonSets)
 	h.Equals(t, "KUBERNETES_SERVICE_HOST", nthConfig.KubernetesServiceHost)
 	h.Equals(t, "KUBERNETES_SERVICE_PORT", nthConfig.KubernetesServicePort)
@@ -219,7 +220,6 @@ func TestParseCliArgsOverrides(t *testing.T) {
 	h.Equals(t, "WEBHOOK_TEMPLATE", nthConfig.WebhookTemplate)
 	h.Equals(t, 101, nthConfig.MetadataTries)
 	h.Equals(t, false, nthConfig.CordonOnly)
-	h.Equals(t, false, nthConfig.DrainOnRebalance)
 	h.Equals(t, true, nthConfig.EnablePrometheus)
 	h.Equals(t, 2112, nthConfig.PrometheusPort)
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -61,6 +61,7 @@ func TestParseCliArgsEnvSuccess(t *testing.T) {
 	setEnvForTest("WEBHOOK_TEMPLATE", "WEBHOOK_TEMPLATE")
 	setEnvForTest("METADATA_TRIES", "100")
 	setEnvForTest("CORDON_ONLY", "false")
+	setEnvForTest("DRAIN_ON_REBALANCE", "false")
 	nthConfig, err := config.ParseCliArgs()
 	h.Ok(t, err)
 
@@ -83,6 +84,7 @@ func TestParseCliArgsEnvSuccess(t *testing.T) {
 	h.Equals(t, "WEBHOOK_TEMPLATE", nthConfig.WebhookTemplate)
 	h.Equals(t, 100, nthConfig.MetadataTries)
 	h.Equals(t, false, nthConfig.CordonOnly)
+	h.Equals(t, false, nthConfig.DrainOnRebalance)
 
 	// Check that env vars were set
 	value, ok := os.LookupEnv("KUBERNETES_SERVICE_HOST")
@@ -116,6 +118,7 @@ func TestParseCliArgsSuccess(t *testing.T) {
 		"--webhook-template=WEBHOOK_TEMPLATE",
 		"--metadata-tries=100",
 		"--cordon-only=false",
+		"--drain-on-rebalance=false",
 	}
 	nthConfig, err := config.ParseCliArgs()
 	h.Ok(t, err)
@@ -139,6 +142,7 @@ func TestParseCliArgsSuccess(t *testing.T) {
 	h.Equals(t, "WEBHOOK_TEMPLATE", nthConfig.WebhookTemplate)
 	h.Equals(t, 100, nthConfig.MetadataTries)
 	h.Equals(t, false, nthConfig.CordonOnly)
+	h.Equals(t, false, nthConfig.DrainOnRebalance)
 	h.Equals(t, false, nthConfig.EnablePrometheus)
 
 	// Check that env vars were set
@@ -168,6 +172,7 @@ func TestParseCliArgsOverrides(t *testing.T) {
 	setEnvForTest("WEBHOOK_TEMPLATE", "no")
 	setEnvForTest("METADATA_TRIES", "100")
 	setEnvForTest("CORDON_ONLY", "true")
+	setEnvForTest("DRAIN_ON_REBALANCE", "true")
 	os.Args = []string{
 		"cmd",
 		"--delete-local-data=false",
@@ -188,6 +193,7 @@ func TestParseCliArgsOverrides(t *testing.T) {
 		"--webhook-template=WEBHOOK_TEMPLATE",
 		"--metadata-tries=101",
 		"--cordon-only=false",
+		"--drain-on-rebalance=false",
 		"--enable-prometheus-server=true",
 		"--prometheus-server-port=2112",
 	}
@@ -213,6 +219,7 @@ func TestParseCliArgsOverrides(t *testing.T) {
 	h.Equals(t, "WEBHOOK_TEMPLATE", nthConfig.WebhookTemplate)
 	h.Equals(t, 101, nthConfig.MetadataTries)
 	h.Equals(t, false, nthConfig.CordonOnly)
+	h.Equals(t, false, nthConfig.DrainOnRebalance)
 	h.Equals(t, true, nthConfig.EnablePrometheus)
 	h.Equals(t, 2112, nthConfig.PrometheusPort)
 

--- a/test/e2e/rebalance-recommendation-drain-test
+++ b/test/e2e/rebalance-recommendation-drain-test
@@ -38,7 +38,6 @@ anth_helm_args=(
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
   --set enableScheduledEventDraining="false"
   --set enableSpotInterruptionDraining="false"
-  --set enableRebalanceMonitoring="true"
   --set enableRebalanceDraining="true"
   --set taintNode="true"
   --set tolerations=""

--- a/test/e2e/rebalance-recommendation-drain-test
+++ b/test/e2e/rebalance-recommendation-drain-test
@@ -1,0 +1,166 @@
+#!/bin/bash
+set -euo pipefail
+
+# Available env vars:
+#   $TMP_DIR
+#   $CLUSTER_NAME
+#   $KUBECONFIG
+#   $NODE_TERMINATION_HANDLER_DOCKER_REPO
+#   $NODE_TERMINATION_HANDLER_DOCKER_TAG
+#   $WEBHOOK_DOCKER_REPO
+#   $WEBHOOK_DOCKER_TAG
+#   $AEMM_URL
+#   $AEMM_VERSION
+
+function fail_and_exit {
+    echo "❌ Rebalance Recommendation Drain test failed $CLUSTER_NAME ❌"
+    exit "${1:-1}"
+}
+
+echo "Starting Rebalance Recommendation Drain Test for Node Termination Handler"
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+common_helm_args=()
+[[ "${TEST_WINDOWS-}" == "true" ]] && common_helm_args+=(--set targetNodeOs="windows")
+[[ -n "${NTH_WORKER_LABEL-}" ]] && common_helm_args+=(--set nodeSelector."$NTH_WORKER_LABEL")
+
+anth_helm_args=(
+  upgrade
+  --install
+  "$CLUSTER_NAME-anth"
+  "$SCRIPTPATH/../../config/helm/aws-node-termination-handler/"
+  --wait
+  --force
+  --namespace kube-system
+  --set instanceMetadataURL="${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}"
+  --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
+  --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
+  --set enableScheduledEventDraining="false"
+  --set enableSpotInterruptionDraining="true"
+  --set enableRebalanceMonitoring="true"
+  --set drainOnRebalance="true"
+  --set taintNode="true"
+  --set tolerations=""
+)
+[[ -n "${NODE_TERMINATION_HANDLER_DOCKER_PULL_POLICY-}" ]] &&
+    anth_helm_args+=(--set image.pullPolicy="$NODE_TERMINATION_HANDLER_DOCKER_PULL_POLICY")
+[[ ${#common_helm_args[@]} -gt 0 ]] &&
+    anth_helm_args+=("${common_helm_args[@]}")
+
+set -x
+helm "${anth_helm_args[@]}"
+set +x
+
+emtp_helm_args=(
+  upgrade
+  --install
+  "$CLUSTER_NAME-emtp"
+  "$SCRIPTPATH/../../config/helm/webhook-test-proxy/"
+  --wait
+  --force
+  --namespace default
+  --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
+  --set webhookTestProxy.image.tag="$WEBHOOK_DOCKER_TAG"
+)
+[[ -n "${WEBHOOK_DOCKER_PULL_POLICY-}" ]] &&
+    emtp_helm_args+=(--set webhookTestProxy.image.pullPolicy="$WEBHOOK_DOCKER_PULL_POLICY")
+[[ ${#common_helm_args[@]} -gt 0 ]] &&
+    emtp_helm_args+=("${common_helm_args[@]}")
+
+set -x
+helm "${emtp_helm_args[@]}"
+set +x
+
+aemm_helm_args=(
+  upgrade
+  --install
+  "$CLUSTER_NAME-aemm"
+  "$AEMM_DL_URL"
+  --wait
+  --namespace default
+  --set servicePort="$IMDS_PORT"
+  --set aemm.mockDelaySec=60
+  --set 'tolerations[0].effect=NoSchedule'
+  --set 'tolerations[0].operator=Exists'
+  --set arguments='{spot}'
+)
+
+[[ ${#common_helm_args[@]} -gt 0 ]] &&
+    aemm_helm_args+=("${common_helm_args[@]}")
+
+set -x
+retry 5 helm "${aemm_helm_args[@]}"
+set +x
+
+TAINT_CHECK_CYCLES=15
+TAINT_CHECK_SLEEP=15
+
+deployed=0
+for i in $(seq 1 $TAINT_CHECK_CYCLES); do
+    if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
+        echo "✅ Verified regular-pod-test pod was scheduled and started!"
+        deployed=1
+        break
+    fi
+    echo "Setup Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
+    sleep $TAINT_CHECK_SLEEP
+done
+
+if [[ $deployed -eq 0 ]]; then
+    echo "❌ regular-pod-test pod deployment failed"
+    fail_and_exit 2
+fi
+
+cordoned=0
+tainted=0
+evicted=0
+test_node="${TEST_NODE:-$CLUSTER_NAME-worker}"
+for i in $(seq 1 $TAINT_CHECK_CYCLES); do
+    if [[ $cordoned -eq 0 ]] && kubectl get nodes "${test_node}" | grep SchedulingDisabled > /dev/null; then
+        echo "✅ Verified the worker node was cordoned!"
+        cordoned=1
+    fi
+
+    if [[ $cordoned -eq 1 ]] && kubectl get nodes "${test_node}" -o json | grep "aws-node-termination-handler/rebalance-recommendation" >/dev/null; then
+        echo "✅ Verified the worker node was tainted!"
+        tainted=1
+    fi
+
+    if [[ $cordoned -eq 1 && $(kubectl get deployments regular-pod-test -o=jsonpath='{.status.unavailableReplicas}') -eq 1 ]]; then
+        echo "✅ Verified the regular-pod-test pod was evicted!"
+        echo "✅ Rebalance Recommendation Drain test passed!"
+        evicted=1
+        break
+    fi
+    echo "Assertion Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
+    sleep $TAINT_CHECK_SLEEP
+done
+
+if [[ $cordoned -eq 0 ]]; then
+  echo "❌ Worker node was not cordoned"
+  fail_and_exit 3
+elif [[ $tainted -eq 0 ]]; then
+  echo "❌ Worker node was not tainted"
+  fail_and_exit 3
+elif [[ $evicted -eq 0 ]]; then
+  echo "❌ regular-pod-test not was evicted"
+  fail_and_exit 3
+fi
+
+echo "🥑 Waiting for Spot ITN..."
+# Spot ITN will eventually become available since aemm.MockDelaySec will not exceed TAINT_CHECK_CYCLES x TAINT_CHECK_SLEEP
+for i in $(seq 1 $TAINT_CHECK_CYCLES); do
+    if [[ $(kubectl get deployments regular-pod-test -o=jsonpath='{.status.unavailableReplicas}') -eq 1 ]]; then
+        echo "✅ Verified the regular-pod-test pod was evicted!"
+        echo "✅ Rebalance Recommendation Spot ITN Test Passed $CLUSTER_NAME! ✅"
+        exit 0
+    fi
+    echo "Assertion Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
+    sleep $TAINT_CHECK_SLEEP
+done
+
+echo "❌ regular-pod-test was NOT evicted"
+
+echo "❌ Rebalance Recommendation Test Failed $CLUSTER_NAME ❌"
+fail_and_exit 1

--- a/test/e2e/rebalance-recommendation-drain-test
+++ b/test/e2e/rebalance-recommendation-drain-test
@@ -37,9 +37,9 @@ anth_helm_args=(
   --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
   --set enableScheduledEventDraining="false"
-  --set enableSpotInterruptionDraining="true"
+  --set enableSpotInterruptionDraining="false"
   --set enableRebalanceMonitoring="true"
-  --set drainOnRebalance="true"
+  --set enableRebalanceDraining="true"
   --set taintNode="true"
   --set tolerations=""
 )
@@ -148,12 +148,12 @@ elif [[ $evicted -eq 0 ]]; then
   fail_and_exit 3
 fi
 
-echo "🥑 Waiting for Spot ITN..."
-# Spot ITN will eventually become available since aemm.MockDelaySec will not exceed TAINT_CHECK_CYCLES x TAINT_CHECK_SLEEP
+echo "🥑 Waiting for Rebalance Recommendation..."
+# Rebalance Recommendation will eventually become available since aemm.MockDelaySec will not exceed TAINT_CHECK_CYCLES x TAINT_CHECK_SLEEP
 for i in $(seq 1 $TAINT_CHECK_CYCLES); do
     if [[ $(kubectl get deployments regular-pod-test -o=jsonpath='{.status.unavailableReplicas}') -eq 1 ]]; then
         echo "✅ Verified the regular-pod-test pod was evicted!"
-        echo "✅ Rebalance Recommendation Spot ITN Test Passed $CLUSTER_NAME! ✅"
+        echo "✅ Rebalance Recommendation Drain Test Passed $CLUSTER_NAME! ✅"
         exit 0
     fi
     echo "Assertion Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
@@ -162,5 +162,5 @@ done
 
 echo "❌ regular-pod-test was NOT evicted"
 
-echo "❌ Rebalance Recommendation Test Failed $CLUSTER_NAME ❌"
+echo "❌ Rebalance Recommendation Drain Test Failed $CLUSTER_NAME ❌"
 fail_and_exit 1

--- a/test/e2e/rebalance-recommendation-dry-run-test
+++ b/test/e2e/rebalance-recommendation-dry-run-test
@@ -1,0 +1,139 @@
+#!/bin/bash
+set -euo pipefail
+
+# Available env vars:
+#   $TMP_DIR
+#   $CLUSTER_NAME
+#   $KUBECONFIG
+#   $NODE_TERMINATION_HANDLER_DOCKER_REPO
+#   $NODE_TERMINATION_HANDLER_DOCKER_TAG
+#   $WEBHOOK_DOCKER_REPO
+#   $WEBHOOK_DOCKER_TAG
+#   $AEMM_URL
+#   $AEMM_VERSION
+
+function fail_and_exit {
+    echo "❌ Rebalance Recommendation Drain test failed $CLUSTER_NAME ❌"
+    exit "${1:-1}"
+}
+
+echo "Starting Rebalance Recommendation Drain Test for Node Termination Handler"
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+common_helm_args=()
+[[ "${TEST_WINDOWS-}" == "true" ]] && common_helm_args+=(--set targetNodeOs="windows")
+[[ -n "${NTH_WORKER_LABEL-}" ]] && common_helm_args+=(--set nodeSelector."$NTH_WORKER_LABEL")
+
+anth_helm_args=(
+  upgrade
+  --install
+  "$CLUSTER_NAME-anth"
+  "$SCRIPTPATH/../../config/helm/aws-node-termination-handler/"
+  --wait
+  --force
+  --namespace kube-system
+  --set instanceMetadataURL="${INSTANCE_METADATA_URL:-"http://$AEMM_URL:$IMDS_PORT"}"
+  --set image.repository="$NODE_TERMINATION_HANDLER_DOCKER_REPO"
+  --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
+  --set dryRun="true"
+  --set enableScheduledEventDraining="false"
+  --set enableSpotInterruptionDraining="true"
+  --set enableRebalanceMonitoring="true"
+  --set drainOnRebalance="true"
+  --set taintNode="true"
+  --set tolerations=""
+)
+[[ -n "${NODE_TERMINATION_HANDLER_DOCKER_PULL_POLICY-}" ]] &&
+    anth_helm_args+=(--set image.pullPolicy="$NODE_TERMINATION_HANDLER_DOCKER_PULL_POLICY")
+[[ ${#common_helm_args[@]} -gt 0 ]] &&
+    anth_helm_args+=("${common_helm_args[@]}")
+
+set -x
+helm "${anth_helm_args[@]}"
+set +x
+
+emtp_helm_args=(
+  upgrade
+  --install
+  "$CLUSTER_NAME-emtp"
+  "$SCRIPTPATH/../../config/helm/webhook-test-proxy/"
+  --wait
+  --force
+  --namespace default
+  --set webhookTestProxy.image.repository="$WEBHOOK_DOCKER_REPO"
+  --set webhookTestProxy.image.tag="$WEBHOOK_DOCKER_TAG"
+)
+[[ -n "${WEBHOOK_DOCKER_PULL_POLICY-}" ]] &&
+    emtp_helm_args+=(--set webhookTestProxy.image.pullPolicy="$WEBHOOK_DOCKER_PULL_POLICY")
+[[ ${#common_helm_args[@]} -gt 0 ]] &&
+    emtp_helm_args+=("${common_helm_args[@]}")
+
+set -x
+helm "${emtp_helm_args[@]}"
+set +x
+
+aemm_helm_args=(
+  upgrade
+  --install
+  "$CLUSTER_NAME-aemm"
+  "$AEMM_DL_URL"
+  --wait
+  --namespace default
+  --set servicePort="$IMDS_PORT"
+  --set aemm.mockDelaySec=60
+  --set 'tolerations[0].effect=NoSchedule'
+  --set 'tolerations[0].operator=Exists'
+  --set arguments='{spot}'
+)
+
+[[ ${#common_helm_args[@]} -gt 0 ]] &&
+    aemm_helm_args+=("${common_helm_args[@]}")
+
+set -x
+retry 5 helm "${aemm_helm_args[@]}"
+set +x
+
+TAINT_CHECK_CYCLES=15
+TAINT_CHECK_SLEEP=15
+
+deployed=0
+for i in $(seq 1 $TAINT_CHECK_CYCLES); do
+    if [[ $(kubectl get deployments regular-pod-test -o jsonpath='{.status.unavailableReplicas}') -eq 0 ]]; then
+        echo "✅ Verified regular-pod-test pod was scheduled and started!"
+        deployed=1
+        break
+    fi
+    echo "Setup Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
+    sleep $TAINT_CHECK_SLEEP
+done
+
+if [[ $deployed -eq 0 ]]; then
+    echo "❌ regular-pod-test pod deployment failed"
+    fail_and_exit 2
+fi
+
+logs=0
+pod_id=$(get_nth_worker_pod)
+test_node="${TEST_NODE:-$CLUSTER_NAME-worker}"
+for i in $(seq 1 $TAINT_CHECK_CYCLES); do
+  if [[ $logs -eq 0 && ! -z $(kubectl logs $pod_id -n kube-system | grep -i -e 'would have been cordoned and drained') ]]; then
+      echo "✅ Verified the dryrun logs were executed"
+      logs=1
+  fi
+
+  if [[ $logs -eq 1 ]] && kubectl get nodes $test_node --no-headers | grep -v SchedulingDisabled >/dev/null; then
+      echo "✅ Verified the worker node was not cordoned!"
+      echo "✅ Spot Interruption Dry Run Test Passed $CLUSTER_NAME! ✅"
+      exit 0
+  fi
+  echo "Assertion Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"
+  sleep $TAINT_CHECK_SLEEP
+done
+
+if [[ $logs -eq 0 ]]; then
+    echo "❌ dryrun logs were not executed"
+else
+    echo "❌ Worker node was cordoned"
+fi
+fail_and_exit 1

--- a/test/e2e/rebalance-recommendation-dry-run-test
+++ b/test/e2e/rebalance-recommendation-dry-run-test
@@ -13,11 +13,11 @@ set -euo pipefail
 #   $AEMM_VERSION
 
 function fail_and_exit {
-    echo "❌ Rebalance Recommendation Drain test failed $CLUSTER_NAME ❌"
+    echo "❌ Rebalance Recommendation Dry Run test failed $CLUSTER_NAME ❌"
     exit "${1:-1}"
 }
 
-echo "Starting Rebalance Recommendation Drain Test for Node Termination Handler"
+echo "Starting Rebalance Recommendation Dry Run Test for Node Termination Handler"
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
@@ -38,9 +38,9 @@ anth_helm_args=(
   --set image.tag="$NODE_TERMINATION_HANDLER_DOCKER_TAG"
   --set dryRun="true"
   --set enableScheduledEventDraining="false"
-  --set enableSpotInterruptionDraining="true"
+  --set enableSpotInterruptionDraining="false"
   --set enableRebalanceMonitoring="true"
-  --set drainOnRebalance="true"
+  --set enableRebalanceDraining="true"
   --set taintNode="true"
   --set tolerations=""
 )
@@ -124,7 +124,7 @@ for i in $(seq 1 $TAINT_CHECK_CYCLES); do
 
   if [[ $logs -eq 1 ]] && kubectl get nodes $test_node --no-headers | grep -v SchedulingDisabled >/dev/null; then
       echo "✅ Verified the worker node was not cordoned!"
-      echo "✅ Spot Interruption Dry Run Test Passed $CLUSTER_NAME! ✅"
+      echo "✅ Rebalance Recommendation Dry Run Test Passed $CLUSTER_NAME! ✅"
       exit 0
   fi
   echo "Assertion Loop $i/$TAINT_CHECK_CYCLES, sleeping for $TAINT_CHECK_SLEEP seconds"

--- a/test/e2e/rebalance-recommendation-dry-run-test
+++ b/test/e2e/rebalance-recommendation-dry-run-test
@@ -39,7 +39,6 @@ anth_helm_args=(
   --set dryRun="true"
   --set enableScheduledEventDraining="false"
   --set enableSpotInterruptionDraining="false"
-  --set enableRebalanceMonitoring="true"
   --set enableRebalanceDraining="true"
   --set taintNode="true"
   --set tolerations=""


### PR DESCRIPTION
Issue #, if available: https://github.com/aws/aws-node-termination-handler/issues/368

Description of changes:

Currently NTH will only cordon a node when a rebalance recommendation signal is received. This PR adds the ability to also drain the node when such signal is received.

Also adding a couple of missing parameters in the Helm chart.
