### PR TITLE
Switch to use SQS long polling

### DIFF
--- a/pkg/monitor/sqsevent/sqs-monitor.go
+++ b/pkg/monitor/sqsevent/sqs-monitor.go
@@ -155,7 +155,7 @@ func (m SQSMonitor) receiveQueueMessages(qURL string) ([]*sqs.Message, error) {
 		QueueUrl:            &qURL,
 		MaxNumberOfMessages: aws.Int64(5),
 		VisibilityTimeout:   aws.Int64(20), // 20 seconds
-		WaitTimeSeconds:     aws.Int64(0),
+		WaitTimeSeconds:     aws.Int64(20), // Max long polling
 	})
 
 	if err != nil {


### PR DESCRIPTION
Issue #398 

Description of changes:
Switch SQS to use the long-polling pattern (fixed max-wait of 20 seconds).  Credit to @tskinn for spotting this & happy to close this if they already have some better way of fixing this trivial PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
