### PR TITLE
don't exit(1) in queue processor mode

### DIFF
--- a/test/go-report-card-test/run-report-card-test.sh
+++ b/test/go-report-card-test/run-report-card-test.sh
@@ -12,18 +12,18 @@ function fail() {
 trap fail ERR
 
 docker build --build-arg=GOPROXY=direct -t go-report-card-cli $SCRIPTPATH
-if [[ ! $(docker run -it -v $SCRIPTPATH/../..:/app go-report-card-cli /go/bin/goimports -l /app) ]]; then
+if [[ $(docker run -it -v $SCRIPTPATH/../../:/app go-report-card-cli /go/bin/goimports -l /app/) ]]; then
     echo "❌ goimports found a problem in go source files. See above for the files with problems."
     EXIT_CODE=2
 else
     echo "✅ goimports found no formatting errors in go source files"
 fi
 
-if grep -r -i -e 'cancelled' --exclude-dir={build,vendor,"$(basename $SCRIPTPATH)"} $SCRIPTPATH/../../* ; then
+if grep -r -i -e 'cancelled' --exclude-dir={build,"$(basename $SCRIPTPATH)"} $SCRIPTPATH/../../* ; then
     echo "❌ Found a misspelling of 'canceled'!"
     EXIT_CODE=3
 fi
 
-docker run -t -v $SCRIPTPATH/../../:/app go-report-card-cli /go/bin/goreportcard-cli -v -t $THRESHOLD -d /app
+docker run -t -v $SCRIPTPATH/../../:/app go-report-card-cli /go/bin/goreportcard-cli -v -t $THRESHOLD
 
 exit $EXIT_CODE

--- a/test/go-report-card-test/run-report-card-test.sh
+++ b/test/go-report-card-test/run-report-card-test.sh
@@ -12,18 +12,18 @@ function fail() {
 trap fail ERR
 
 docker build --build-arg=GOPROXY=direct -t go-report-card-cli $SCRIPTPATH
-if [[ $(docker run -it -v $SCRIPTPATH/../../:/app go-report-card-cli /go/bin/goimports -l /app/) ]]; then
+if [[ ! $(docker run -it -v $SCRIPTPATH/../..:/app go-report-card-cli /go/bin/goimports -l /app) ]]; then
     echo "❌ goimports found a problem in go source files. See above for the files with problems."
     EXIT_CODE=2
 else
     echo "✅ goimports found no formatting errors in go source files"
 fi
 
-if grep -r -i -e 'cancelled' --exclude-dir={build,"$(basename $SCRIPTPATH)"} $SCRIPTPATH/../../* ; then
+if grep -r -i -e 'cancelled' --exclude-dir={build,vendor,"$(basename $SCRIPTPATH)"} $SCRIPTPATH/../../* ; then
     echo "❌ Found a misspelling of 'canceled'!"
     EXIT_CODE=3
 fi
 
-docker run -t -v $SCRIPTPATH/../../:/app go-report-card-cli /go/bin/goreportcard-cli -v -t $THRESHOLD
+docker run -t -v $SCRIPTPATH/../../:/app go-report-card-cli /go/bin/goreportcard-cli -v -t $THRESHOLD -d /app
 
 exit $EXIT_CODE


### PR DESCRIPTION
Issue #, if available: #412

Description of changes: Don't `exit(1)` on drain errors when in queue processor mode

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
