### PR TITLE
Populate pods list to drain event

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -349,6 +349,7 @@ func cordonNode(node node.Node, nodeName string, drainEvent *monitor.Interruptio
 	} else {
 		log.Info().Str("node_name", nodeName).Msg("Node successfully cordoned")
 		podNameList, err := node.FetchPodNameList(nodeName)
+		drainEvent.Pods = podNameList
 		if err != nil {
 			log.Err(err).Msgf("Unable to fetch running pods for node '%s' ", nodeName)
 		}


### PR DESCRIPTION
Populate running pods list to drain event for webhook when node is cordoned.

Issue #, if available: https://github.com/aws/aws-node-termination-handler/issues/423

Description of changes: Populate running pods list to drain event for webhook when node is cordoned. This line of code was removed as a part of https://github.com/aws/aws-node-termination-handler/pull/411

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
