### PR TITLE
remove tty on container execs

### DIFF
--- a/test/e2e/asg-lifecycle-sqs-test
+++ b/test/e2e/asg-lifecycle-sqs-test
@@ -47,13 +47,13 @@ localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="st
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \
                                   | awk '$2 >= "'"${START_TIME//+0000/Z}"'" { print $1 }')
 echo "🥑 Using localstack pod ${localstack_pod}"
-run_instances_resp=$(kubectl exec -it "${localstack_pod}" -- bash -c "${RUN_INSTANCE_CMD}")
+run_instances_resp=$(kubectl exec -i "${localstack_pod}" -- bash -c "${RUN_INSTANCE_CMD}")
 private_dns_name=$(echo "${run_instances_resp}" | jq -r '.Instances[] .PrivateDnsName')
 instance_id=$(echo "${run_instances_resp}" | jq -r '.Instances[] .InstanceId')
 echo "🥑 Started mock EC2 instance ($instance_id) w/ private DNS name: ${private_dns_name}"
 set -x
 CREATE_SQS_CMD="awslocal sqs create-queue --queue-name "${CLUSTER_NAME}-queue" --attributes MessageRetentionPeriod=300 --region ${AWS_REGION}"
-queue_url=$(kubectl exec -it "${localstack_pod}" -- bash -c "${CREATE_SQS_CMD}" | jq -r .QueueUrl)
+queue_url=$(kubectl exec -i "${localstack_pod}" -- bash -c "${CREATE_SQS_CMD}" | jq -r .QueueUrl)
 
 echo "🥑 Created SQS Queue ${queue_url}"
 
@@ -148,7 +148,7 @@ EOF
 
 ASG_TERMINATE_EVENT_ONE_LINE=$(echo "${ASG_TERMINATE_EVENT}" | tr -d '\n' |sed 's/\"/\\"/g')
 SEND_SQS_CMD="awslocal sqs send-message --queue-url ${queue_url} --message-body \"${ASG_TERMINATE_EVENT_ONE_LINE}\" --region ${AWS_REGION}"
-kubectl exec -it "${localstack_pod}" -- bash -c "$SEND_SQS_CMD"
+kubectl exec -i "${localstack_pod}" -- bash -c "$SEND_SQS_CMD"
 echo "✅ Sent Spot Interruption Event to SQS queue: ${queue_url}"
 
 cordoned=0

--- a/test/e2e/ec2-state-change-sqs-test
+++ b/test/e2e/ec2-state-change-sqs-test
@@ -48,13 +48,13 @@ localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="st
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \
                                   | awk '$2 >= "'"${START_TIME//+0000/Z}"'" { print $1 }')
 echo "🥑 Using localstack pod $localstack_pod"
-run_instances_resp=$(kubectl exec -it "${localstack_pod}" -- bash -c "$RUN_INSTANCE_CMD")
+run_instances_resp=$(kubectl exec -i "${localstack_pod}" -- bash -c "$RUN_INSTANCE_CMD")
 private_dns_name=$(echo "${run_instances_resp}" | jq -r '.Instances[] .PrivateDnsName')
 instance_id=$(echo "${run_instances_resp}" | jq -r '.Instances[] .InstanceId')
 echo "🥑 Started mock EC2 instance ($instance_id) w/ private DNS name: ${private_dns_name}"
 
 CREATE_SQS_CMD="awslocal sqs create-queue --queue-name "${CLUSTER_NAME}-queue" --attributes MessageRetentionPeriod=300 --region ${AWS_REGION}"
-queue_url=$(kubectl exec -it "${localstack_pod}" -- bash -c "$CREATE_SQS_CMD" | jq -r .QueueUrl)
+queue_url=$(kubectl exec -i "${localstack_pod}" -- bash -c "$CREATE_SQS_CMD" | jq -r .QueueUrl)
 
 echo "🥑 Created SQS Queue ${queue_url}"
 
@@ -147,7 +147,7 @@ EOF
 
 EC2_STATE_CHANGE_EVENT_ONE_LINE=$(echo "${EC2_STATE_CHANGE_EVENT}" | tr -d '\n' |sed 's/\"/\\"/g')
 SEND_SQS_CMD="awslocal sqs send-message --queue-url ${queue_url} --message-body \"${EC2_STATE_CHANGE_EVENT_ONE_LINE}\" --region ${AWS_REGION}"
-kubectl exec -it "${localstack_pod}" -- bash -c "$SEND_SQS_CMD"
+kubectl exec -i "${localstack_pod}" -- bash -c "$SEND_SQS_CMD"
 echo "✅ Sent EC2 State Change Event to SQS queue: ${queue_url}"
 
 GET_ATTRS_SQS_CMD="awslocal sqs get-queue-attributes --queue-url ${queue_url} --attribute-names All --region ${AWS_REGION}"
@@ -166,8 +166,8 @@ for i in $(seq 1 $TAINT_CHECK_CYCLES); do
         evicted=1
     fi
 
-    if [[ ${evicted} -eq 1 && $(kubectl exec -it "${localstack_pod}" -- bash -c "$GET_ATTRS_SQS_CMD" | jq '(.Attributes.ApproximateNumberOfMessagesNotVisible|tonumber) + (.Attributes.ApproximateNumberOfMessages|tonumber)' ) -eq 0 ]]; then
-        kubectl exec -it "${localstack_pod}" -- bash -c "$GET_ATTRS_SQS_CMD"
+    if [[ ${evicted} -eq 1 && $(kubectl exec -i "${localstack_pod}" -- bash -c "$GET_ATTRS_SQS_CMD" | jq '(.Attributes.ApproximateNumberOfMessagesNotVisible|tonumber) + (.Attributes.ApproximateNumberOfMessages|tonumber)' ) -eq 0 ]]; then
+        kubectl exec -i "${localstack_pod}" -- bash -c "$GET_ATTRS_SQS_CMD"
         echo "✅ Verified the message was deleted from the queue after processing!"
         echo "✅ EC2 State Change SQS Test Passed $CLUSTER_NAME! ✅"
         exit 0

--- a/test/e2e/rebalance-recommendation-sqs-test
+++ b/test/e2e/rebalance-recommendation-sqs-test
@@ -47,13 +47,13 @@ localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="st
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \
                                   | awk '$2 >= "'"${START_TIME//+0000/Z}"'" { print $1 }')
 echo "🥑 Using localstack pod ${localstack_pod}"
-run_instances_resp=$(kubectl exec -it "${localstack_pod}" -- bash -c "${RUN_INSTANCE_CMD}")
+run_instances_resp=$(kubectl exec -i "${localstack_pod}" -- bash -c "${RUN_INSTANCE_CMD}")
 private_dns_name=$(echo "${run_instances_resp}" | jq -r '.Instances[] .PrivateDnsName')
 instance_id=$(echo "${run_instances_resp}" | jq -r '.Instances[] .InstanceId')
 echo "🥑 Started mock EC2 instance (${instance_id}) w/ private DNS name: ${private_dns_name}"
 
 CREATE_SQS_CMD="awslocal sqs create-queue --queue-name "${CLUSTER_NAME}-queue" --attributes MessageRetentionPeriod=300 --region ${AWS_REGION}"
-queue_url=$(kubectl exec -it "${localstack_pod}" -- bash -c "${CREATE_SQS_CMD}" | jq -r .QueueUrl)
+queue_url=$(kubectl exec -i "${localstack_pod}" -- bash -c "${CREATE_SQS_CMD}" | jq -r .QueueUrl)
 
 echo "🥑 Created SQS Queue ${queue_url}"
 
@@ -146,7 +146,7 @@ EOF
 
 REBALANCE_EVENT_ONE_LINE=$(echo "${REBALANCE_EVENT}" | tr -d '\n' |sed 's/\"/\\"/g')
 SEND_SQS_CMD="awslocal sqs send-message --queue-url ${queue_url} --message-body \"${REBALANCE_EVENT_ONE_LINE}\" --region ${AWS_REGION}"
-kubectl exec -it "${localstack_pod}" -- bash -c "${SEND_SQS_CMD}"
+kubectl exec -i "${localstack_pod}" -- bash -c "${SEND_SQS_CMD}"
 echo "✅ Sent Rebalance Recommendation to SQS queue: ${queue_url}"
 
 GET_ATTRS_SQS_CMD="awslocal sqs get-queue-attributes --queue-url ${queue_url} --attribute-names All --region ${AWS_REGION}"
@@ -172,8 +172,8 @@ for i in $(seq 1 $TAINT_CHECK_CYCLES); do
         not_evicted=1
     fi
 
-    if [[ ${tainted} -eq 1 && $(kubectl exec -it "${localstack_pod}" -- bash -c "${GET_ATTRS_SQS_CMD}" | jq '(.Attributes.ApproximateNumberOfMessagesNotVisible|tonumber) + (.Attributes.ApproximateNumberOfMessages|tonumber)' ) -eq 0 ]]; then
-        kubectl exec -it "${localstack_pod}" -- bash -c "${GET_ATTRS_SQS_CMD}"
+    if [[ ${tainted} -eq 1 && $(kubectl exec -i "${localstack_pod}" -- bash -c "${GET_ATTRS_SQS_CMD}" | jq '(.Attributes.ApproximateNumberOfMessagesNotVisible|tonumber) + (.Attributes.ApproximateNumberOfMessages|tonumber)' ) -eq 0 ]]; then
+        kubectl exec -i "${localstack_pod}" -- bash -c "${GET_ATTRS_SQS_CMD}"
         echo "✅ Verified the message was deleted from the queue after processing!"
         message_deleted=1
         break
@@ -220,7 +220,7 @@ EOF
 
 SPOT_EVENT_ONE_LINE=$(echo "${SPOT_EVENT}" | tr -d '\n' |sed 's/\"/\\"/g')
 SEND_SQS_CMD="awslocal sqs send-message --queue-url ${queue_url} --message-body \"${SPOT_EVENT_ONE_LINE}\" --region ${AWS_REGION}"
-kubectl exec -it "${localstack_pod}" -- bash -c "${SEND_SQS_CMD}"
+kubectl exec -i "${localstack_pod}" -- bash -c "${SEND_SQS_CMD}"
 echo "✅ Sent Spot Interruption Event to SQS queue: ${queue_url}"
 GET_ATTRS_SQS_CMD="awslocal sqs get-queue-attributes --queue-url ${queue_url} --attribute-names All --region ${AWS_REGION}"
 
@@ -232,8 +232,8 @@ for i in $(seq 1 $TAINT_CHECK_CYCLES); do
         evicted=1
     fi
 
-    if [[ ${evicted} -eq 1 && $(kubectl exec -it "${localstack_pod}" -- bash -c "${GET_ATTRS_SQS_CMD}" | jq '(.Attributes.ApproximateNumberOfMessagesNotVisible|tonumber) + (.Attributes.ApproximateNumberOfMessages|tonumber)' ) -eq 0 ]]; then
-        kubectl exec -it "${localstack_pod}" -- bash -c "${GET_ATTRS_SQS_CMD}"
+    if [[ ${evicted} -eq 1 && $(kubectl exec -i "${localstack_pod}" -- bash -c "${GET_ATTRS_SQS_CMD}" | jq '(.Attributes.ApproximateNumberOfMessagesNotVisible|tonumber) + (.Attributes.ApproximateNumberOfMessages|tonumber)' ) -eq 0 ]]; then
+        kubectl exec -i "${localstack_pod}" -- bash -c "${GET_ATTRS_SQS_CMD}"
         echo "✅ Verified the message was deleted from the queue after processing!"
         echo "✅ Rebalance Recommendation SQS Test Passed $CLUSTER_NAME! ✅"
         exit 0

--- a/test/e2e/spot-interruption-sqs-test
+++ b/test/e2e/spot-interruption-sqs-test
@@ -47,13 +47,13 @@ localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="st
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \
                                   | awk '$2 >= "'"${START_TIME//+0000/Z}"'" { print $1 }')
 echo "🥑 Using localstack pod ${localstack_pod}"
-run_instances_resp=$(kubectl exec -it "${localstack_pod}" -- bash -c "${RUN_INSTANCE_CMD}")
+run_instances_resp=$(kubectl exec -i "${localstack_pod}" -- bash -c "${RUN_INSTANCE_CMD}")
 private_dns_name=$(echo "${run_instances_resp}" | jq -r '.Instances[] .PrivateDnsName')
 instance_id=$(echo "${run_instances_resp}" | jq -r '.Instances[] .InstanceId')
 echo "🥑 Started mock EC2 instance (${instance_id}) w/ private DNS name: ${private_dns_name}"
 
 CREATE_SQS_CMD="awslocal sqs create-queue --queue-name "${CLUSTER_NAME}-queue" --attributes MessageRetentionPeriod=300 --region ${AWS_REGION}"
-queue_url=$(kubectl exec -it "${localstack_pod}" -- bash -c "${CREATE_SQS_CMD}" | jq -r .QueueUrl)
+queue_url=$(kubectl exec -i "${localstack_pod}" -- bash -c "${CREATE_SQS_CMD}" | jq -r .QueueUrl)
 
 echo "🥑 Created SQS Queue ${queue_url}"
 
@@ -145,7 +145,7 @@ EOF
 
 SPOT_EVENT_ONE_LINE=$(echo "${SPOT_EVENT}" | tr -d '\n' |sed 's/\"/\\"/g')
 SEND_SQS_CMD="awslocal sqs send-message --queue-url ${queue_url} --message-body \"${SPOT_EVENT_ONE_LINE}\" --region ${AWS_REGION}"
-kubectl exec -it "${localstack_pod}" -- bash -c "${SEND_SQS_CMD}"
+kubectl exec -i "${localstack_pod}" -- bash -c "${SEND_SQS_CMD}"
 echo "✅ Sent Spot Interruption Event to SQS queue: ${queue_url}"
 
 GET_ATTRS_SQS_CMD="awslocal sqs get-queue-attributes --queue-url ${queue_url} --attribute-names All --region ${AWS_REGION}"
@@ -164,8 +164,8 @@ for i in $(seq 1 $TAINT_CHECK_CYCLES); do
         evicted=1
     fi
 
-    if [[ ${evicted} -eq 1 && $(kubectl exec -it "${localstack_pod}" -- bash -c "${GET_ATTRS_SQS_CMD}" | jq '(.Attributes.ApproximateNumberOfMessagesNotVisible|tonumber) + (.Attributes.ApproximateNumberOfMessages|tonumber)' ) -eq 0 ]]; then
-        kubectl exec -it "${localstack_pod}" -- bash -c "${GET_ATTRS_SQS_CMD}"
+    if [[ ${evicted} -eq 1 && $(kubectl exec -i "${localstack_pod}" -- bash -c "${GET_ATTRS_SQS_CMD}" | jq '(.Attributes.ApproximateNumberOfMessagesNotVisible|tonumber) + (.Attributes.ApproximateNumberOfMessages|tonumber)' ) -eq 0 ]]; then
+        kubectl exec -i "${localstack_pod}" -- bash -c "${GET_ATTRS_SQS_CMD}"
         echo "✅ Verified the message was deleted from the queue after processing!"
         echo "✅ Spot Interruption SQS Test Passed $CLUSTER_NAME! ✅"
         exit 0

--- a/test/e2e/webhook-http-proxy-test
+++ b/test/e2e/webhook-http-proxy-test
@@ -181,7 +181,7 @@ for i in `seq 1 $TAINT_CHECK_CYCLES`; do
   fi
 
   webhook_hostname=$(echo "${WEBHOOK_URL}" | sed -e 's@^[^/]*//@@' -e 's@/.*$@@')
-  if [[ $sent -eq 1 ]] && kubectl exec -it "$(echo $squid_worker_pods | cut -d' ' -f1)" -- cat /var/log/squid/access.log | grep "${webhook_hostname}" >/dev/null; then
+  if [[ $sent -eq 1 ]] && kubectl exec -i "$(echo $squid_worker_pods | cut -d' ' -f1)" -- cat /var/log/squid/access.log | grep "${webhook_hostname}" >/dev/null; then
      echo "✅ Verified the webhook POST used the http proxy"
         exit 0
   fi
@@ -200,7 +200,7 @@ else
 fi
 
 echo "=====================================   SQUID LOGS   ===================================================="
-kubectl exec -it "$(echo $squid_worker_pods | cut -d' ' -f1)" -- cat /var/log/squid/access.log
+kubectl exec -i "$(echo $squid_worker_pods | cut -d' ' -f1)" -- cat /var/log/squid/access.log
 echo "===================================== END SQUID LOGS ===================================================="
 
 fail_and_exit 1

--- a/test/go-report-card-test/Dockerfile
+++ b/test/go-report-card-test/Dockerfile
@@ -2,7 +2,9 @@ FROM public.ecr.aws/bitnami/golang:latest
 
 WORKDIR /app
 
-ARG GO111MODULE=auto
+ENV GO111MODULE=auto
+ENV GOPROXY=direct
+
 RUN go get github.com/gojp/goreportcard
 RUN cd $GOPATH/src/github.com/gojp/goreportcard && (make install || cd / && curl -L https://git.io/vp6lP | sh)
 

--- a/test/go-report-card-test/run-report-card-test.sh
+++ b/test/go-report-card-test/run-report-card-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-THRESHOLD=98
+THRESHOLD=93
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 EXIT_CODE=0
 


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - GithubActions doesn't run with a TTY so remove `-t` from all container exec commands. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
