### PR TITLE
always do license check and use dockerhub for go-report-card image pulls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
     - name: Lints
       run: make spellcheck shellcheck helm-lint
 
+    - name: License Check
+      run: make license-test
+
     - name: Go Report Card Tests
       run: make go-report-card-test
 
@@ -127,9 +130,6 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
-
-    - name: License Check
-      run: make license-test
 
     - name: Release Linux Assets
       run: make release

--- a/test/go-report-card-test/Dockerfile
+++ b/test/go-report-card-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/golang:latest
+FROM golang:latest
 
 WORKDIR /app
 


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - ECR rate limits pulls for unauthenticated users, so pull go-report-card image from dockerhub 
 - Always run license tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
