### PR TITLE
[ec2metadata] Switch IMDSv2 token warning message to debug

### DIFF
--- a/pkg/ec2metadata/ec2metadata.go
+++ b/pkg/ec2metadata/ec2metadata.go
@@ -226,7 +226,7 @@ func (e *Service) Request(contextPath string) (*http.Response, error) {
 			if err != nil {
 				e.v2Token = ""
 				e.tokenTTL = -1
-				log.Warn().Msgf("Unable to retrieve an IMDSv2 token, continuing with IMDSv1, %v", err)
+				log.Debug().Msgf("Unable to retrieve an IMDSv2 token, continuing with IMDSv1, %v", err)
 			} else {
 				e.v2Token = token
 				e.tokenTTL = ttl


### PR DESCRIPTION
If IMDSv2 is unreachable or disabled on the EC2 instances, the logs
are filled with such messages without providing any real value or action
as the application fallbacks to IMDSv1 anyway.  We can move such messages
to the debug level in order to try and keep the log messages clean for
any warnings that might be missed with this flooding.

These messages probably fail into the debug category anyway as they are
mostly helpful when debugging the application.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
