### PR TITLE
make queue-processor mode replicas configurable

### DIFF
--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -98,6 +98,8 @@ Parameter | Description | Default
 `checkASGTagBeforeDraining` | If true, check that the instance is tagged with "aws-node-termination-handler/managed" as the key before draining the node | `true`
 `managedAsgTag` | The tag to ensure is on a node if checkASGTagBeforeDraining is true | `aws-node-termination-handler/managed`
 `workers` | The maximum amount of parallel event processors | `10`
+`replicas` | The number of replicas in the NTH deployment when using queue-processor mode (NOTE: increasing replicas may cause duplicate webhooks since NTH pods are stateless)
+ | `1`
 
 ### AWS Node Termination Handler - IMDS Mode Configuration
 

--- a/config/helm/aws-node-termination-handler/templates/deployment.yaml
+++ b/config/helm/aws-node-termination-handler/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
 {{ include "aws-node-termination-handler.labels" . | indent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "aws-node-termination-handler.name" . }}

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -216,3 +216,6 @@ useHostNetwork: true
 
 # The maximal amount of parallel event processors to handle concurrent events
 workers: 10
+
+# The number of replicas in the NTH deployment when using queue-processor mode (NOTE: increasing this may cause duplicate webhooks since NTH pods are stateless)
+replicas: 1


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Make NTH deployment replicas configurable via helm when using queue-processor mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
