### PR TITLE
change drop message log to WARN instead of ERR

### DIFF
--- a/pkg/monitor/sqsevent/sqs-monitor.go
+++ b/pkg/monitor/sqsevent/sqs-monitor.go
@@ -69,7 +69,7 @@ func (m SQSMonitor) Monitor() error {
 		switch {
 		case errors.Is(err, ErrNodeStateNotRunning):
 			// If the node is no longer running, just log and delete the message.  If message deletion fails, count it as an error.
-			log.Err(err).Msg("dropping event for an already terminated node")
+			log.Warn().Err(err).Msg("dropping event for an already terminated node")
 			errs := m.deleteMessages([]*sqs.Message{message})
 			if len(errs) > 0 {
 				log.Err(errs[0]).Msg("error deleting event for already terminated node")


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-node-termination-handler/issues/413

Description of changes:
 - Change drop message log to WARN instead of ERROR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
