### PR TITLE
helm: Use hostPort only with hostNetwork

### DIFF
--- a/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -183,14 +183,18 @@ spec:
           {{- if .Values.enablePrometheusServer }}
           ports:
           - containerPort: {{ .Values.prometheusServerPort }}
+            {{- if .Values.useHostNetwork }}
             hostPort: {{ .Values.prometheusServerPort }}
+            {{- end }}
             name: http-metrics
             protocol: TCP
           {{- end }}
           {{- if .Values.enableProbesServer }}
           ports:
           - containerPort: {{ .Values.probesServerPort }}
+            {{- if .Values.useHostNetwork }}
             hostPort: {{ .Values.probesServerPort }}
+            {{- end }}
             name: liveness-probe
             protocol: TCP
           {{- end }}


### PR DESCRIPTION
There is no need to use the hostPort option if we are not directly
connected to the hostNetwork. Using the hostPort option makes that port
unavailable for binding to any other service on the node which is
not really desirable if the pod itself is not on the host network.

ps: This is a copy of https://github.com/aws/eks-charts/pull/527