### PR TITLE
fixes #423: Populate pod list in webhook notification

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -322,6 +322,11 @@ func drainOrCordonIfNecessary(interruptionEventStore *interruptioneventstore.Sto
         if err != nil {
                 log.Err(err).Msgf("Unable to fetch running pods for node '%s' ", nodeName)
         }
+        drainEvent.Pods = podNameList
+        err = node.LogPods(podNameList, nodeName)
+        if err != nil {
+                log.Err(err).Msg("There was a problem while trying to log all pod names on the node")
+        }
 
 	if nthConfig.CordonOnly || (drainEvent.IsRebalanceRecommendation() && !nthConfig.EnableRebalanceDraining) {
 		err = cordonNode(node, nodeName, drainEvent, metrics, recorder)
@@ -329,20 +334,19 @@ func drainOrCordonIfNecessary(interruptionEventStore *interruptioneventstore.Sto
 		err = cordonAndDrainNode(node, nodeName, metrics, recorder, nthConfig.EnableSQSTerminationDraining)
 	}
         
-        drainEvent.Pods = podNameList
-        err = node.LogPods(podNameList, nodeName)
-        if err != nil {
-                log.Err(err).Msg("There was a problem while trying to log all pod names on the node")
-        }
-
-	interruptionEventStore.MarkAllAsProcessed(nodeName)
 	if nthConfig.WebhookURL != "" {
 		webhook.Post(nodeMetadata, drainEvent, nthConfig)
 	}
-	if drainEvent.PostDrainTask != nil {
-		runPostDrainTask(node, nodeName, drainEvent, metrics, recorder)
-	}
-	<-interruptionEventStore.Workers
+
+        if err != nil {
+                <-interruptionEventStore.Workers
+        } else {
+	        interruptionEventStore.MarkAllAsProcessed(nodeName)
+	        if drainEvent.PostDrainTask != nil {
+		        runPostDrainTask(node, nodeName, drainEvent, metrics, recorder)
+	        }
+	        <-interruptionEventStore.Workers
+        }
 
 }
 

--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -318,23 +318,22 @@ func drainOrCordonIfNecessary(interruptionEventStore *interruptioneventstore.Sto
 		runPreDrainTask(node, nodeName, drainEvent, metrics, recorder)
 	}
 
+        podNameList, err := node.FetchPodNameList(nodeName)
+        if err != nil {
+                log.Err(err).Msgf("Unable to fetch running pods for node '%s' ", nodeName)
+        }
+
 	if nthConfig.CordonOnly || (drainEvent.IsRebalanceRecommendation() && !nthConfig.EnableRebalanceDraining) {
 		err = cordonNode(node, nodeName, drainEvent, metrics, recorder)
 	} else {
 		err = cordonAndDrainNode(node, nodeName, metrics, recorder, nthConfig.EnableSQSTerminationDraining)
 	}
-
-	if err != nil {
-		podNameList, err := node.FetchPodNameList(nodeName)
-		drainEvent.Pods = podNameList
-		if err != nil {
-			log.Err(err).Msgf("Unable to fetch running pods for node '%s' ", nodeName)
-		}
-		err = node.LogPods(podNameList, nodeName)
-		if err != nil {
-			log.Err(err).Msg("There was a problem while trying to log all pod names on the node")
-		}
-	}
+        
+        drainEvent.Pods = podNameList
+        err = node.LogPods(podNameList, nodeName)
+        if err != nil {
+                log.Err(err).Msg("There was a problem while trying to log all pod names on the node")
+        }
 
 	interruptionEventStore.MarkAllAsProcessed(nodeName)
 	if nthConfig.WebhookURL != "" {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -513,9 +513,6 @@ func getDrainHelper(nthConfig config.Config) (*drain.Helper, error) {
 		Out:                 log.Logger,
 		ErrOut:              log.Logger,
 	}
-	if nthConfig.DryRun {
-		return drainHelper, nil
-	}
 
 	clusterConfig, err := rest.InClusterConfig()
 	if err != nil {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -496,6 +496,10 @@ func (n Node) fetchKubernetesNode(nodeName string) (*corev1.Node, error) {
 }
 
 func (n Node) fetchAllPods(nodeName string) (*corev1.PodList, error) {
+	if n.nthConfig.DryRun {
+		log.Info().Msgf("Would have retrieved running pod list on node %s, but dry-run flag was set", nodeName)
+		return &corev1.PodList{}, nil
+	}
 	return n.drainHelper.Client.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{
 		FieldSelector: "spec.nodeName=" + nodeName,
 	})
@@ -512,6 +516,10 @@ func getDrainHelper(nthConfig config.Config) (*drain.Helper, error) {
 		Timeout:             time.Duration(nthConfig.NodeTerminationGracePeriod) * time.Second,
 		Out:                 log.Logger,
 		ErrOut:              log.Logger,
+	}
+
+	if nthConfig.DryRun {
+		return drainHelper, nil
 	}
 
 	clusterConfig, err := rest.InClusterConfig()


### PR DESCRIPTION
Issue #, if available:
#423

Description of changes:
- `cordonNode` & `cordonAndDrainNode` returns nil on successful execution and hence the `podName` and `node.LogPods` is not subsequently called in current implementation.

- Pod list should be fetched before `cordonNode` or `cordonAndDrainNode`. After successful `cordonAndDrainNode` operation the running pods will be evicted from the node and pod list be will empty in that case.

- Even if `cordonNode` or `cordonAndDrainNode` fails one still needs the list of running pods in notification message to capture which all pods will be impacted by the interruption event. Helpful in debugging issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
