### PR TITLE
Add extraEnv to helm chart

### DIFF
--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -148,6 +148,7 @@ Parameter | Description | Default
 `updateStrategy` | Update strategy for the all DaemonSets (Linux and Windows) | `type=RollingUpdate,rollingUpdate.maxUnavailable=1`
 `linuxUpdateStrategy` | Update strategy for the Linux DaemonSet | `type=RollingUpdate,rollingUpdate.maxUnavailable=1`
 `windowsUpdateStrategy` | Update strategy for the Windows DaemonSet | `type=RollingUpdate,rollingUpdate.maxUnavailable=1`
+`extraEnv` | Additional environment variables to inject into pod configuration | `[]`
 
 ### Testing Configuration (NOT RECOMMENDED FOR PROD DEPLOYMENTS)
 

--- a/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -176,6 +176,10 @@ spec:
             value: {{ .Values.emitKubernetesEvents | quote }}
           - name: KUBERNETES_EVENTS_EXTRA_ANNOTATIONS
             value: {{ .Values.kubernetesEventsExtraAnnotations | quote }}
+{{- range $key, $value := .Values.extraEnv }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+{{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if or .Values.enablePrometheusServer .Values.enableProbesServer }}

--- a/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -150,6 +150,10 @@ spec:
             value: {{ .Values.emitKubernetesEvents | quote }}
           - name: KUBERNETES_EVENTS_EXTRA_ANNOTATIONS
             value: {{ .Values.kubernetesEventsExtraAnnotations | quote }}
+{{- range $key, $value := .Values.extraEnv }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+{{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if or .Values.enablePrometheusServer .Values.enableProbesServer }}

--- a/config/helm/aws-node-termination-handler/templates/deployment.yaml
+++ b/config/helm/aws-node-termination-handler/templates/deployment.yaml
@@ -152,6 +152,10 @@ spec:
             value: {{ .Values.emitKubernetesEvents | quote }}
           - name: KUBERNETES_EVENTS_EXTRA_ANNOTATIONS
             value: {{ .Values.kubernetesEventsExtraAnnotations | quote }}
+{{- range $key, $value := .Values.extraEnv }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+{{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if or .Values.enablePrometheusServer .Values.enableProbesServer }}

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -15,6 +15,8 @@ securityContext:
 nameOverride: ""
 fullnameOverride: ""
 
+extraEnv: []
+
 priorityClassName: system-node-critical
 
 podAnnotations: {}


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-node-termination-handler/issues/484

Description of changes:
This change will allow for additional environment variables to be passed to the NTH pod (i.e. proxy config).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
