### PR TITLE
aws-node-termination-handler chart: use .Values.webhookTemplateConfig* parameters

### DIFF
--- a/config/helm/aws-node-termination-handler/templates/deployment.yaml
+++ b/config/helm/aws-node-termination-handler/templates/deployment.yaml
@@ -26,6 +26,12 @@ spec:
         {{ $key }}: {{ $value | quote }}
       {{- end }}
     spec:
+      volumes:
+        {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
+        - name: "webhook-template"
+          configMap:
+            name: {{ .Values.webhookTemplateConfigMapName }}
+        {{- end }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       affinity:
         nodeAffinity:
@@ -60,6 +66,11 @@ spec:
             runAsUser: {{ .Values.securityContext.runAsUserID }}
             runAsGroup: {{ .Values.securityContext.runAsGroupID }}
             allowPrivilegeEscalation: false
+          volumeMounts:
+            {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
+            - name: "webhook-template"
+              mountPath: "/config/"
+            {{- end }}
           env:
           - name: NODE_NAME
             valueFrom:
@@ -94,6 +105,10 @@ spec:
           {{- end }}
           - name: WEBHOOK_HEADERS
             value: {{ .Values.webhookHeaders | quote }}
+          {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
+          - name: WEBHOOK_TEMPLATE_FILE
+            value: {{ print "/config/" .Values.webhookTemplateConfigMapKey | quote }}
+          {{- end }}
           - name: WEBHOOK_TEMPLATE
             value: {{ .Values.webhookTemplate | quote }}
           - name: DRY_RUN


### PR DESCRIPTION
Using `.Values. webhookTemplateConfigMapName` and `.Values. webhookTemplateConfigMapName` in the Queue Processor mode Deployment, the same way it's done in the Daemonsets.

Resolves #487