### PR TITLE
fix docker layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
-# Build the manager binary
 FROM golang:1.16 as builder
 
 ## GOLANG env
 ARG GOPROXY="https://proxy.golang.org|direct"
 ARG GO111MODULE="on"
-ARG CGO_ENABLED=0
-ARG GOOS=linux
-ARG GOARCH=amd64
 
 # Copy go.mod and download dependencies
 WORKDIR /node-termination-handler
@@ -14,14 +10,18 @@ COPY go.mod .
 COPY go.sum .
 RUN go mod download
 
+ARG CGO_ENABLED=0
+ARG GOOS=linux
+ARG GOARCH=amd64
+
 # Build
 COPY . .
 RUN make build
 # In case the target is build for testing:
-# $ docker build  --target=builder -t test .
+# $ docker build --target=builder -t test .
 ENTRYPOINT ["/node-termination-handler/build/node-termination-handler"]
 
-# Copy the controller-manager into a thin image
+# Build the final image with only the binary
 FROM amazonlinux:2 as amazonlinux
 FROM scratch
 WORKDIR /


### PR DESCRIPTION
## Issue #, if available:
N/A

## Description of changes:
Reduce build times by leveraging docker caching layers. Previously, go mod downloads were not cached between os/arch variants because the build args changed which resulted in docker invalidating the go mod download layer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
