### PR TITLE
up sqs max messages and lower wait time and visibility timeout on messages

### DIFF
--- a/pkg/monitor/sqsevent/sqs-monitor.go
+++ b/pkg/monitor/sqsevent/sqs-monitor.go
@@ -155,7 +155,7 @@ func (m SQSMonitor) receiveQueueMessages(qURL string) ([]*sqs.Message, error) {
 		},
 		QueueUrl:            &qURL,
 		MaxNumberOfMessages: aws.Int64(10),
-		VisibilityTimeout:   aws.Int64(10), // 10 seconds
+		VisibilityTimeout:   aws.Int64(20), // 20 seconds
 		WaitTimeSeconds:     aws.Int64(20), // Max long polling
 	})
 


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-node-termination-handler/issues/494

Description of changes:

These changes will increase throughput of NTH message processing

 - Raised Max Messages to fetch from SQS per query to 10 (which is the max the API supports)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
