### PR TITLE
feat(chart): Stop using hostPort on deployment

### DIFF
--- a/config/helm/aws-node-termination-handler/templates/deployment.yaml
+++ b/config/helm/aws-node-termination-handler/templates/deployment.yaml
@@ -178,13 +178,11 @@ spec:
           {{- end }}
           {{- if .Values.enablePrometheusServer }}
           - containerPort: {{ .Values.prometheusServerPort }}
-            hostPort: {{ .Values.prometheusServerPort }}
             name: http-metrics
             protocol: TCP
           {{- end }}
           {{- if .Values.enableProbesServer }}
           - containerPort: {{ .Values.probesServerPort }}
-            hostPort: {{ .Values.probesServerPort }}
             name: liveness-probe
             protocol: TCP
           {{- end }}

--- a/config/helm/aws-node-termination-handler/templates/psp.yaml
+++ b/config/helm/aws-node-termination-handler/templates/psp.yaml
@@ -12,10 +12,16 @@ spec:
   hostIPC: false
   hostNetwork: {{ .Values.useHostNetwork }}
   hostPID: false
-{{- if and .Values.rbac.pspEnabled .Values.enablePrometheusServer }}
+{{- if and (and (not .Values.enableSqsTerminationDraining) .Values.useHostNetwork ) (or .Values.enablePrometheusServer .Values.enableProbesServer) }}
   hostPorts:
+{{- if .Values.enablePrometheusServer }}
   - min: {{ .Values.prometheusServerPort }}
     max: {{ .Values.prometheusServerPort }}
+{{- end }}
+{{- if .Values.enableProbesServer }}
+  - min: {{ .Values.probesServerPort }}
+    max: {{ .Values.probesServerPort }}
+{{- end }}
 {{- end }}
   readOnlyRootFilesystem: false
   allowPrivilegeEscalation: false


### PR DESCRIPTION
Fixes #500.

Description of changes:

- Remove the setting of `hostPort` in Deployment
- Fix PSP to only set `hostPorts` if needed
- Fix PSP to work with `enableProbesServer: true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
