### PR TITLE
Add stale github action for Issues / PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,46 +2,46 @@ name: Stale Issues / PRs
 
 on:
   schedule:
-    - cron: "0 17 * * *"  # Runs every day at noon
+    - cron: "0 17 * * *"  # Runs every day at 12:00PM CST
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      # 7+3 day stale policy for PRs
-      # * Except PRs marked as "no-stale"
+      # 15+5 day stale policy for PRs
+      # * Except PRs marked as "stalebot-ignore"
       - name: Stale PRs policy
         uses: actions/stale@v4.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          exempt-pr-labels: "no-stale"
-          days-before-stale: 7
-          days-before-close: 3
+          exempt-pr-labels: "stalebot-ignore"
+          days-before-stale: 15
+          days-before-close: 5
           days-before-issue-stale: -1
           days-before-issue-close: -1
           remove-stale-when-updated: true
           stale-pr-label: "stale"
           stale-pr-message: >
             This PR has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs.
-            If you want this PR to never become stale, please ask a collaborators to apply the "no-stale" label.
+            If you want this PR to never become stale, please ask a maintainer to apply the "stalebot-ignore" label.
           close-pr-message: >
-            This PR was closed because it has been staled with no activity.
+            This PR was closed because is has become stale with no activity.
 
-      # 7+3 day stale policy for open issues
-      # * Except Issues marked as "no-stale"
+      # 30+5 day stale policy for open issues
+      # * Except Issues marked as "stalebot-ignore"
       - name: Stale Issues policy
         uses: actions/stale@v4.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          exempt-issue-labels: "no-stale"
-          days-before-stale: 7
-          days-before-close: 3
+          exempt-issue-labels: "stalebot-ignore"
+          days-before-stale: 30
+          days-before-close: 5
           days-before-pr-stale: -1
           days-before-pr-close: -1
           remove-stale-when-updated: true
           stale-issue-label: "stale"
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs.
-            If you want this issue to never become stale, please ask a collaborators to apply the "no-stale" label.
+            If you want this issue to never become stale, please ask a collaborators to apply the "stalebot-ignore" label.
           close-issue-message: >
-            This issue was closed because it has been staled with no activity.
+            This issue was closed because is has become stale with no activity.


### PR DESCRIPTION
Issue #, if available: https://github.com/aws/aws-node-termination-handler/issues/503

Description of changes: Add stale github action for Issues / PRs. We will mark issues/prs with 'stale' tag after 7 days of no activity along with a warning and close the issue / pr after 3 days if there wasn't any activity after the warning. Issues / PRs marked with 'no-stale' label will not be touched. We will run the workflow at 12 noon CST (17:00 UTC) every day 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
