### PR TITLE
Fix Not taint node after meet conflict error when node update

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -571,7 +571,6 @@ func addTaint(node *corev1.Node, nth Node, taintKey string, taintValue string, e
 				refresh = true
 				continue
 			}
-			return nil
 		}
 		_, err = client.CoreV1().Nodes().Update(context.TODO(), freshNode, metav1.UpdateOptions{})
 		if err != nil && errors.IsConflict(err) && time.Now().Before(retryDeadline) {


### PR DESCRIPTION
Issue #542 

Description of changes:
Remove `return nil` in if section (`if !addTaintToSpec(freshNode, taintKey, taintValue, effect) {...}`) in function `addTaint`.
