### PR TITLE
Remove exit when cordon failed

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -378,7 +378,6 @@ func cordonNode(node node.Node, nodeName string, drainEvent *monitor.Interruptio
 		} else {
 			log.Err(err).Msg("There was a problem while trying to cordon the node")
 			recorder.Emit(nodeName, observability.Warning, observability.CordonErrReason, observability.CordonErrMsgFmt, err.Error())
-			os.Exit(1)
 		}
 		return err
 	} else {
@@ -398,9 +397,6 @@ func cordonAndDrainNode(node node.Node, nodeName string, drainEvent *monitor.Int
 			log.Err(err).Msg("There was a problem while trying to cordon and drain the node")
 			metrics.NodeActionsInc("cordon-and-drain", nodeName, err)
 			recorder.Emit(nodeName, observability.Warning, observability.CordonAndDrainErrReason, observability.CordonAndDrainErrMsgFmt, err.Error())
-			if !sqsTerminationDraining {
-				os.Exit(1)
-			}
 		}
 		return err
 	} else {


### PR DESCRIPTION
Issue #545, if available:

Description of changes:
Don't crash when failing to drain a node due to a PDB.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
