### PR TITLE
Wrap volumes key in conditional to protect from being nil

### DIFF
--- a/config/helm/aws-node-termination-handler/templates/deployment.yaml
+++ b/config/helm/aws-node-termination-handler/templates/deployment.yaml
@@ -26,12 +26,12 @@ spec:
         {{ $key }}: {{ $value | quote }}
       {{- end }}
     spec:
+      {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
       volumes:
-        {{- if and .Values.webhookTemplateConfigMapName .Values.webhookTemplateConfigMapKey }}
         - name: "webhook-template"
           configMap:
             name: {{ .Values.webhookTemplateConfigMapName }}
-        {{- end }}
+      {{- end }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       affinity:
         {{- with .Values.affinity }}


### PR DESCRIPTION
Description of changes:

If `webhookTemplateConfigMapName` and `webhookTemplateConfigMapKey` are not set in the values.yaml file, we end up with a deployment.yaml file that has key `volumes` with a `nil` value. This causes other tools like `kustomize` to throw warnings:

```
2022/01/03 18:04:29 nil value at `volumes.configMap.name` ignored in mutation attempt
2022/01/03 18:04:29 nil value at `volumes.projected.sources.configMap.name` ignored in mutation attempt
2022/01/03 18:04:29 nil value at `volumes.secret.secretName` ignored in mutation attempt
2022/01/03 18:04:29 nil value at `volumes.projected.sources.secret.name` ignored in mutation attempt
2022/01/03 18:04:29 nil value at `volumes.persistentVolumeClaim.claimName` ignored in mutation attempt
```

This PR wraps the `volumes` key in the conditional as well so that if it is not being used it doesn't cause these warnings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
