### PR TITLE
Remove last reference to Docker Hub and use a more precise term

### DIFF
--- a/scripts/push-docker-images
+++ b/scripts/push-docker-images
@@ -14,7 +14,7 @@ DOCKER_CLI_CONFIG="$HOME/.docker/config.json"
 
 USAGE=$(cat << 'EOM'
   Usage: push-docker-images  [-p <platform pairs>]
-  Pushes docker images for the platform pairs passed in w/ a dockerhub manifest
+  Pushes docker images for the platform pairs passed in w/ a manifest list
   Example: push-docker-images -p "linux/amd64,linux/arm"
           Optional:
             -p          Platform pair list (os/architecture) [DEFAULT: linux/amd64]


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: We only publish container images to ECR now, so we're removing any remaining references to our previous Docker Hub workflows. This appears to be the last one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
