### PR TITLE
Sync Helm chart version to NTH app version

### DIFF
--- a/config/helm/aws-node-termination-handler/Chart.yaml
+++ b/config/helm/aws-node-termination-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler.
 type: application
-version: 0.16.1
+version: 1.14.1
 appVersion: 1.14.1
 kubeVersion: ">= 1.16-0"
 keywords:


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: The Helm chart version has been out of sync with the NTH app version for a long time. NTH `v1.14.1` contained some breaking changes to the Helm chart, so this is a good opportunity to get them back in sync.

A corresponding PR will be opened to https://github.com/aws/eks-charts after this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
