### PR TITLE
:bug: :fire: only add the dns config not the entire chart....

### DIFF
--- a/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -46,9 +46,9 @@ spec:
       {{- end }}
       hostNetwork: {{ .Values.useHostNetwork }}
       dnsPolicy: {{ default .Values.linuxDnsPolicy .Values.dnsPolicy }}
-      {{- if .Values.dnsConfig }}
+      {{- with .Values.dnsConfig }}
       dnsConfig:
-        {{- toYaml . | nindent 10 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: aws-node-termination-handler

--- a/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -46,9 +46,9 @@ spec:
       {{- end }}
       hostNetwork: false
       dnsPolicy: {{ default .Values.windowsDnsPolicy .Values.dnsPolicy }}
-      {{- if .Values.dnsConfig }}
+      {{-  with .Values.dnsConfig }}
       dnsConfig:
-        {{- toYaml . | nindent 10 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: aws-node-termination-handler

--- a/config/helm/aws-node-termination-handler/templates/deployment.yaml
+++ b/config/helm/aws-node-termination-handler/templates/deployment.yaml
@@ -43,9 +43,9 @@ spec:
       {{- with .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ . }}
       {{- end }}
-      {{- if .Values.dnsConfig }}
+      {{- with .Values.dnsConfig }}
       dnsConfig:
-        {{- toYaml . | nindent 10 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: aws-node-termination-handler


### PR DESCRIPTION
Issue #, if available: Fixes bug introduced in #571

Description of changes: If you set dnsConfig option it put into yaml the whole context...it should have just been the `.Values.dnsConfig`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
