### PR TITLE
Move golangci-lint action to its own job

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   fastTests:
-    name: Fast Tests and Lints
+    name: Fast Test
     runs-on: ubuntu-20.04
     steps:
     - name: Set up Go 1.x
@@ -51,12 +51,18 @@ jobs:
       env: 
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v2.5.2
-
     - name: Generate K8s YAML
       run: make generate-k8s-yaml
   
+  golangci:
+    # this action needs to run in its own job per setup
+    name: Lint Eastwood
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up golangci-lint
+        uses: golangci/golangci-lint-action@v2.5.2
+    
   buildLinux:
     name: Build Linux Binaries
     runs-on: ubuntu-20.04


### PR DESCRIPTION
#### Issue #, if available:
* https://github.com/aws/aws-node-termination-handler/issues/589
* https://github.com/golangci/golangci-lint-action/issues/23

#### Description of changes
Moving `golangci-lint` into its own job per the [updated onboarding instructions](https://github.com/golangci/golangci-lint-action#how-to-use)


#### Contribution disclaimer
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
