### PR TITLE
Align build/integration test badge in ReadMe with updated gha workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@
   <a href="https://gallery.ecr.aws/aws-ec2/aws-node-termination-handler">
     <img src="https://img.shields.io/docker/pulls/amazon/aws-node-termination-handler" alt="docker-pulls">
   </a>
+    <a href="https://github.com/aws/aws-node-termination-handler/workflows">
+    <img src="https://img.shields.io/github/workflow/status/aws/aws-node-termination-handler/Build%20and%20Test?label=Builds%20%26%20Tests">
+  </a>
 </p>
-
-![NTH Continuous Integration and Release](https://github.com/aws/aws-node-termination-handler/workflows/NTH%20Continuous%20Integration%20and%20Release/badge.svg)
 
 <div>
 <hr>


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
* Current Build + integ test badge shows failing because it's looking up the old workflow name. This updates the name and aligns style with other badges

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
