### PR TITLE
Add IsManaged nodeinfo field to scheduled events

### DIFF
--- a/pkg/monitor/sqsevent/scheduled-change-event.go
+++ b/pkg/monitor/sqsevent/scheduled-change-event.go
@@ -100,6 +100,7 @@ func (m SQSMonitor) scheduledEventToInterruptionEvents(event *EventBridgeEvent, 
 			StartTime:            time.Now(),
 			NodeName:             nodeInfo.Name,
 			InstanceID:           nodeInfo.InstanceID,
+			IsManaged:            nodeInfo.IsManaged,
 			Description:          fmt.Sprintf("AWS Health scheduled change event received. Instance %s will be interrupted at %s \n", nodeInfo.InstanceID, event.getTime()),
 		}
 		interruptionEvent.PostDrainTask = func(interruptionEvent monitor.InterruptionEvent, n node.Node) error {


### PR DESCRIPTION
In all other creations of `InterruptionEvent`, the `IsManaged` field is populated via `getNodeInfo`. This seems to have been missed in the work to support Scheduled Events. 

Without this, managed node checking doesn't work correctly for scheduled events.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
