### PR TITLE
Fix service monitor selector

### DIFF
--- a/config/helm/aws-node-termination-handler/Chart.yaml
+++ b/config/helm/aws-node-termination-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler.
 type: application
-version: 0.18.1
+version: 0.18.0
 appVersion: 1.16.0
 kubeVersion: ">= 1.16-0"
 keywords:

--- a/config/helm/aws-node-termination-handler/Chart.yaml
+++ b/config/helm/aws-node-termination-handler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler.
 type: application
-version: 0.18.0
+version: 0.18.1
 appVersion: 1.16.0
 kubeVersion: ">= 1.16-0"
 keywords:

--- a/config/helm/aws-node-termination-handler/templates/servicemonitor.yaml
+++ b/config/helm/aws-node-termination-handler/templates/servicemonitor.yaml
@@ -25,5 +25,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "aws-node-termination-handler.selectorLabelsDeployment" . | nindent 6 }}
+      {{- include "aws-node-termination-handler.labels" . | nindent 6 }}
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Victor Boissiere <victor.boissiere@qonto.com>

**Issue #, if available:**

**Description of changes:**
Fix issue on service monitor selector.

Current service monitor selector:
```yaml
  selector:
    matchLabels:
      app.kubernetes.io/component: deployment
      app.kubernetes.io/instance: aws-node-termination-handler
      app.kubernetes.io/name: termination-handler
     ...
```

But the servicelabel  is
```yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    app.kubernetes.io/component: aws-node-termination-handler <== here
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: termination-handler
    ...
```

Fix the issue by ensuring service monitor is target the same labels as the service


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
