### PR TITLE
Update go & lib versions in Dockerfiles

### DIFF
--- a/test/license-test/Dockerfile
+++ b/test/license-test/Dockerfile
@@ -4,6 +4,6 @@ WORKDIR /app
 
 COPY license-config.hcl .
 ARG GOPROXY="https://proxy.golang.org,direct"
-RUN GO111MODULE=on go get github.com/mitchellh/golicense
+RUN GO111MODULE=on go install github.com/mitchellh/golicense@v0.2.0
 
 CMD $GOPATH/bin/golicense

--- a/test/license-test/Dockerfile
+++ b/test/license-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1
+FROM golang:1.16
 
 WORKDIR /app
 

--- a/test/license-test/gen-license-report.sh
+++ b/test/license-test/gen-license-report.sh
@@ -7,7 +7,7 @@ mkdir -p $BUILD_DIR
 GOBIN=$(go env GOPATH | sed 's+:+/bin+g')/bin
 export PATH="$PATH:$GOBIN"
 
-go get github.com/mitchellh/golicense
+go install github.com/mitchellh/golicense@v0.2.0
 go build -o $BUILD_DIR/nth $SCRIPTPATH/../../.
 golicense -out-xlsx=$BUILD_DIR/report.xlsx $SCRIPTPATH/license-config.hcl $BUILD_DIR/nth
 

--- a/test/readme-test/spellcheck-Dockerfile
+++ b/test/readme-test/spellcheck-Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1
+FROM golang:1.16
 
 RUN go get -u github.com/client9/misspell/cmd/misspell
 

--- a/test/readme-test/spellcheck-Dockerfile
+++ b/test/readme-test/spellcheck-Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.16
 
-RUN go get -u github.com/client9/misspell/cmd/misspell
+RUN go install github.com/client9/misspell/cmd/misspell@v0.3.4
 
 CMD [ "/go/bin/misspell" ]

--- a/test/webhook-test-proxy/Dockerfile
+++ b/test/webhook-test-proxy/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1-alpine as builder
+FROM golang:1.16-alpine as builder
 
 ## GOLANG env
 ARG GOPROXY="https://proxy.golang.org|direct"


### PR DESCRIPTION
**Issue #, if available:** ci/cd jobs using these Dockerfiles are pulling the latest go version (1.18) which deprecates `go get` functionality which leads to failures.

**Description of changes:**
* aligns golang version with app
* follow best practices for installing a command using go install
* similar PR: https://github.com/aws/amazon-ec2-metadata-mock/pull/168 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
