### PR TITLE
Update golangci action to increase timeout and hard-code version

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -62,6 +62,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
+        with:
+          skip-cache: true
     
   buildLinux:
     name: Build Linux Binaries

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -63,7 +63,8 @@ jobs:
       - name: Set up golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          skip-cache: true
+          version: v1.45.2
+          args: --timeout=5m
     
   buildLinux:
     name: Build Linux Binaries


### PR DESCRIPTION
**Issue #, if available:** N/A `golangci` job failing due to timing out

**Description of changes:** increases timeout time of `golangci` job and hard-codes version instead of pulling in latest



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
