### PR TITLE
Add option to fetch node name through Kubernetes node .spec.providerID in case custom names are used

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The termination handler DaemonSet installs into your cluster a [ServiceAccount](
 You can use kubectl to directly add all of the above resources with the default configuration into your cluster.
 
 ```
-kubectl apply -f https://github.com/aws/aws-node-termination-handler/releases/download/v1.16.0/all-resources.yaml
+kubectl apply -f https://github.com/aws/aws-node-termination-handler/releases/download/v1.16.1/all-resources.yaml
 ```
 
 For a full list of releases and associated artifacts see our [releases page](https://github.com/aws/aws-node-termination-handler/releases).
@@ -426,7 +426,7 @@ Queue Processor needs an **sqs queue url** to function; therefore, manifest chan
 Minimal Config:
 
 ```
-curl -L https://github.com/aws/aws-node-termination-handler/releases/download/v1.16.0/all-resources-queue-processor.yaml -o all-resources-queue-processor.yaml
+curl -L https://github.com/aws/aws-node-termination-handler/releases/download/v1.16.1/all-resources-queue-processor.yaml -o all-resources-queue-processor.yaml
 <open all-resources-queue-processor.yaml and update QUEUE_URL value>
 kubectl apply -f ./all-resources-queue-processor.yaml
 ```

--- a/config/helm/aws-node-termination-handler/Chart.yaml
+++ b/config/helm/aws-node-termination-handler/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aws-node-termination-handler
 description: A Helm chart for the AWS Node Termination Handler.
 type: application
-version: 0.18.0
-appVersion: 1.16.0
+version: 0.18.1
+appVersion: 1.16.1
 kubeVersion: ">= 1.16-0"
 keywords:
   - aws

--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -113,7 +113,7 @@ The configuration in this table applies to AWS Node Termination Handler in queue
 | `checkASGTagBeforeDraining`  | If `true`, check that the instance is tagged with the `managedAsgTag` before draining the node.                                                                           | `true`                                 |
 | `managedAsgTag`              | The node tag to check if `checkASGTagBeforeDraining` is `true`.                                                                                                           | `aws-node-termination-handler/managed` |
 | `assumeAsgTagPropagation`    | If `true`, assume that ASG tags will be appear on the ASG's instances.                                                                                                    | `false`                                |
-| `useProviderId`    | If true, fetch node name through Kubernetes node spec ProviderID instead of AWS event PrivateDnsHostname. instances.                                                                                                    | `false`                                |
+| `useProviderId`    | If `true`, fetch node name through Kubernetes node spec ProviderID instead of AWS event PrivateDnsHostname.                                                                                                    | `false`                                |
 
 ### IMDS Mode Configuration
 

--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -113,6 +113,7 @@ The configuration in this table applies to AWS Node Termination Handler in queue
 | `checkASGTagBeforeDraining`  | If `true`, check that the instance is tagged with the `managedAsgTag` before draining the node.                                                                           | `true`                                 |
 | `managedAsgTag`              | The node tag to check if `checkASGTagBeforeDraining` is `true`.                                                                                                           | `aws-node-termination-handler/managed` |
 | `assumeAsgTagPropagation`    | If `true`, assume that ASG tags will be appear on the ASG's instances.                                                                                                    | `false`                                |
+| `useProviderId`    | If true, fetch node name through Kubernetes node spec ProviderID instead of AWS event PrivateDnsHostname. instances.                                                                                                    | `false`                                |
 
 ### IMDS Mode Configuration
 

--- a/config/helm/aws-node-termination-handler/templates/deployment.yaml
+++ b/config/helm/aws-node-termination-handler/templates/deployment.yaml
@@ -88,6 +88,8 @@ spec:
               value: {{ .Values.managedAsgTag | quote }}
             - name: ASSUME_ASG_TAG_PROPAGATION
               value: {{ .Values.assumeAsgTagPropagation | quote }}
+            - name: USE_PROVIDER_ID
+              value: {{ .Values.useProviderId | quote }}
             - name: DRY_RUN
               value: {{ .Values.dryRun | quote }}
             - name: CORDON_ONLY

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -179,6 +179,9 @@ managedAsgTag: "aws-node-termination-handler/managed"
 # If true, assume that ASG tags will be appear on the ASG's instances
 assumeAsgTagPropagation: false
 
+# If true, fetch node name through Kubernetes node spec ProviderID instead of AWS event PrivateDnsHostname.
+useProviderId: false
+
 # ---------------------------------------------------------------------------------------------------------------------
 # IMDS Mode
 # ---------------------------------------------------------------------------------------------------------------------

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,6 +64,8 @@ const (
 	managedAsgTagDefault                    = "aws-node-termination-handler/managed"
 	assumeAsgTagPropagationKey              = "ASSUME_ASG_TAG_PROPAGATION"
 	assumeAsgTagPropagationDefault          = false
+	useProviderIdConfigKey                  = "USE_PROVIDER_ID"
+	useProviderIdDefault                    = false
 	metadataTriesConfigKey                  = "METADATA_TRIES"
 	metadataTriesDefault                    = 3
 	cordonOnly                              = "CORDON_ONLY"
@@ -144,6 +146,7 @@ type Config struct {
 	AWSEndpoint                      string
 	QueueURL                         string
 	Workers                          int
+	UseProviderId                    bool
 }
 
 //ParseCliArgs parses cli arguments and uses environment variables as fallback values
@@ -200,6 +203,7 @@ func ParseCliArgs() (config Config, err error) {
 	flag.StringVar(&config.QueueURL, "queue-url", getEnv(queueURLConfigKey, ""), "Listens for messages on the specified SQS queue URL")
 	flag.IntVar(&config.Workers, "workers", getIntEnv(workersConfigKey, workersDefault), "The amount of parallel event processors.")
 	flag.BoolVar(&config.AssumeAsgTagPropagation, "assume-asg-tag-propagation", getBoolEnv(assumeAsgTagPropagationKey, assumeAsgTagPropagationDefault), "If true, assume that ASG tags will be appear on the ASG's instances.")
+	flag.BoolVar(&config.UseProviderId, "use-provider-id", getBoolEnv(useProviderIdConfigKey, useProviderIdDefault), "If true, fetch node name through Kubernetes node spec ProviderID instead of AWS event PrivateDnsHostname.")
 	flag.Parse()
 
 	if isConfigProvided("pod-termination-grace-period", podTerminationGracePeriodConfigKey) && isConfigProvided("grace-period", gracePeriodConfigKey) {
@@ -276,6 +280,7 @@ func (c Config) PrintJsonConfigArgs() {
 		Bool("check_asg_tag_before_draining", c.CheckASGTagBeforeDraining).
 		Str("ManagedAsgTag", c.ManagedAsgTag).
 		Bool("assume_asg_tag_propagation", c.AssumeAsgTagPropagation).
+		Bool("use_provider_id", c.UseProviderId).
 		Msg("aws-node-termination-handler arguments")
 }
 
@@ -324,6 +329,7 @@ func (c Config) PrintHumanConfigArgs() {
 			"\tcheck-asg-tag-before-draining: %t,\n"+
 			"\tmanaged-asg-tag: %s,\n"+
 			"\tassume-asg-tag-propagation: %t,\n"+
+			"\tuse-provider-id: %t,\n"+
 			"\taws-endpoint: %s,\n",
 		c.DryRun,
 		c.NodeName,
@@ -361,6 +367,7 @@ func (c Config) PrintHumanConfigArgs() {
 		c.CheckASGTagBeforeDraining,
 		c.ManagedAsgTag,
 		c.AssumeAsgTagPropagation,
+		c.UseProviderId,
 		c.AWSEndpoint,
 	)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -43,6 +43,7 @@ func setEnvForTest(key string, val string) {
 func TestParseCliArgsEnvSuccess(t *testing.T) {
 	resetFlagsForTest()
 	setEnvForTest("ASSUME_ASG_TAG_PROPAGATION", "true")
+	setEnvForTest("USE_PROVIDER_ID", "true")
 	setEnvForTest("DELETE_LOCAL_DATA", "false")
 	setEnvForTest("DRY_RUN", "true")
 	setEnvForTest("ENABLE_SCHEDULED_EVENT_DRAINING", "true")
@@ -68,6 +69,7 @@ func TestParseCliArgsEnvSuccess(t *testing.T) {
 
 	// Assert all the values were set
 	h.Equals(t, true, nthConfig.AssumeAsgTagPropagation)
+	h.Equals(t, true, nthConfig.UseProviderId)
 	h.Equals(t, false, nthConfig.DeleteLocalData)
 	h.Equals(t, true, nthConfig.DryRun)
 	h.Equals(t, true, nthConfig.EnableScheduledEventDraining)
@@ -103,6 +105,7 @@ func TestParseCliArgsSuccess(t *testing.T) {
 	os.Args = []string{
 		"cmd",
 		"--assume-asg-tag-propagation=true",
+		"--use-provider-id=true",
 		"--delete-local-data=false",
 		"--dry-run=true",
 		"--enable-scheduled-event-draining=true",
@@ -128,6 +131,7 @@ func TestParseCliArgsSuccess(t *testing.T) {
 
 	// Assert all the values were set
 	h.Equals(t, true, nthConfig.AssumeAsgTagPropagation)
+	h.Equals(t, true, nthConfig.UseProviderId)
 	h.Equals(t, false, nthConfig.DeleteLocalData)
 	h.Equals(t, true, nthConfig.DryRun)
 	h.Equals(t, true, nthConfig.EnableScheduledEventDraining)
@@ -158,6 +162,7 @@ func TestParseCliArgsSuccess(t *testing.T) {
 func TestParseCliArgsOverrides(t *testing.T) {
 	resetFlagsForTest()
 	setEnvForTest("ASSUME_ASG_TAG_PROPAGATION", "true")
+	setEnvForTest("USE_PROVIDER_ID", "true")
 	setEnvForTest("DELETE_LOCAL_DATA", "true")
 	setEnvForTest("DRY_RUN", "false")
 	setEnvForTest("ENABLE_SCHEDULED_EVENT_DRAINING", "false")
@@ -181,6 +186,7 @@ func TestParseCliArgsOverrides(t *testing.T) {
 	os.Args = []string{
 		"cmd",
 		"--assume-asg-tag-propagation=false",
+		"--use-provider-id=false",
 		"--delete-local-data=false",
 		"--dry-run=true",
 		"--enable-scheduled-event-draining=true",
@@ -208,6 +214,7 @@ func TestParseCliArgsOverrides(t *testing.T) {
 
 	// Assert all the values were set
 	h.Equals(t, false, nthConfig.AssumeAsgTagPropagation)
+	h.Equals(t, false, nthConfig.UseProviderId)
 	h.Equals(t, false, nthConfig.DeleteLocalData)
 	h.Equals(t, true, nthConfig.DryRun)
 	h.Equals(t, true, nthConfig.EnableScheduledEventDraining)

--- a/pkg/monitor/sqsevent/asg-lifecycle-event.go
+++ b/pkg/monitor/sqsevent/asg-lifecycle-event.go
@@ -79,6 +79,7 @@ func (m SQSMonitor) asgTerminationToInterruptionEvent(event *EventBridgeEvent, m
 		NodeName:             nodeInfo.Name,
 		IsManaged:            nodeInfo.IsManaged,
 		InstanceID:           lifecycleDetail.EC2InstanceID,
+		ProviderID:           nodeInfo.ProviderID,
 		Description:          fmt.Sprintf("ASG Lifecycle Termination event received. Instance will be interrupted at %s \n", event.getTime()),
 	}
 

--- a/pkg/monitor/sqsevent/ec2-state-change-event.go
+++ b/pkg/monitor/sqsevent/ec2-state-change-event.go
@@ -73,6 +73,7 @@ func (m SQSMonitor) ec2StateChangeToInterruptionEvent(event *EventBridgeEvent, m
 		IsManaged:            nodeInfo.IsManaged,
 		AutoScalingGroupName: nodeInfo.AsgName,
 		InstanceID:           ec2StateChangeDetail.InstanceID,
+		ProviderID:           nodeInfo.ProviderID,
 		Description:          fmt.Sprintf("EC2 State Change event received. Instance %s went into %s at %s \n", ec2StateChangeDetail.InstanceID, ec2StateChangeDetail.State, event.getTime()),
 	}
 

--- a/pkg/monitor/sqsevent/rebalance-recommendation-event.go
+++ b/pkg/monitor/sqsevent/rebalance-recommendation-event.go
@@ -65,6 +65,7 @@ func (m SQSMonitor) rebalanceRecommendationToInterruptionEvent(event *EventBridg
 		NodeName:             nodeInfo.Name,
 		IsManaged:            nodeInfo.IsManaged,
 		InstanceID:           nodeInfo.InstanceID,
+		ProviderID:           nodeInfo.ProviderID,
 		Description:          fmt.Sprintf("Rebalance recommendation event received. Instance %s will be cordoned at %s \n", rebalanceRecDetail.InstanceID, event.getTime()),
 	}
 	interruptionEvent.PostDrainTask = func(interruptionEvent monitor.InterruptionEvent, n node.Node) error {

--- a/pkg/monitor/sqsevent/scheduled-change-event.go
+++ b/pkg/monitor/sqsevent/scheduled-change-event.go
@@ -100,6 +100,7 @@ func (m SQSMonitor) scheduledEventToInterruptionEvents(event *EventBridgeEvent, 
 			StartTime:            time.Now(),
 			NodeName:             nodeInfo.Name,
 			InstanceID:           nodeInfo.InstanceID,
+			ProviderID:           nodeInfo.ProviderID,
 			IsManaged:            nodeInfo.IsManaged,
 			Description:          fmt.Sprintf("AWS Health scheduled change event received. Instance %s will be interrupted at %s \n", nodeInfo.InstanceID, event.getTime()),
 		}

--- a/pkg/monitor/sqsevent/spot-itn-event.go
+++ b/pkg/monitor/sqsevent/spot-itn-event.go
@@ -67,6 +67,7 @@ func (m SQSMonitor) spotITNTerminationToInterruptionEvent(event *EventBridgeEven
 		NodeName:             nodeInfo.Name,
 		IsManaged:            nodeInfo.IsManaged,
 		InstanceID:           spotInterruptionDetail.InstanceID,
+		ProviderID:           nodeInfo.ProviderID,
 		Description:          fmt.Sprintf("Spot Interruption event received. Instance %s will be interrupted at %s \n", spotInterruptionDetail.InstanceID, event.getTime()),
 	}
 	interruptionEvent.PostDrainTask = func(interruptionEvent monitor.InterruptionEvent, n node.Node) error {

--- a/pkg/monitor/sqsevent/sqs-monitor.go
+++ b/pkg/monitor/sqsevent/sqs-monitor.go
@@ -260,6 +260,7 @@ func (m SQSMonitor) deleteMessages(messages []*sqs.Message) []error {
 type NodeInfo struct {
 	AsgName    string
 	InstanceID string
+	ProviderID string
 	IsManaged  bool
 	Name       string
 	Tags       map[string]string
@@ -303,9 +304,15 @@ func (m SQSMonitor) getNodeInfo(instanceID string) (*NodeInfo, error) {
 		return nil, fmt.Errorf("unable to retrieve PrivateDnsName name for '%s' in state '%s'", instanceID, state)
 	}
 
+	providerID := ""
+	if *instance.Placement.AvailabilityZone != "" {
+		providerID = fmt.Sprintf("aws:///%s/%s", *instance.Placement.AvailabilityZone, instanceID)
+	}
+
 	nodeInfo := &NodeInfo{
 		Name:       *instance.PrivateDnsName,
 		InstanceID: instanceID,
+		ProviderID: providerID,
 		Tags:       make(map[string]string),
 		IsManaged:  true,
 	}

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -34,6 +34,7 @@ type InterruptionEvent struct {
 	NodeLabels           map[string]string
 	Pods                 []string
 	InstanceID           string
+	ProviderID           string
 	IsManaged            bool
 	StartTime            time.Time
 	EndTime              time.Time

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -388,7 +388,7 @@ func (n Node) GetNodeNameFromProviderID(providerId string) (string, error) {
 		}
 	}
 
-	return "", nil
+	return "", fmt.Errorf("Node with ProviderID '%s' was not found in the cluster", providerId)
 }
 
 // TaintSpotItn adds the spot termination notice taint onto a node


### PR DESCRIPTION
**Issue description:**
At our organization we run Kubernetes on EC2 administered with kubeadm. We wanted to add NTH to allow spot instances to be used with proper cordon/draining logic. We use the queue processor mode which means that we receive events through SQS that is then mapped to the `NodeInfo` struct.

```
{
     "InstanceID": "i-1234567890",
     "IsManaged": true,
     "Name": "ip-10.0.0.1.ap-northeast-2.compute.internal",
     "Tags": {
         "Name": "Kubernetes-worker",
         "aws-node-termination-handler/managed": "true",
         "aws:autoscaling:groupName": "Kubernetes-worker",
         "example.com/environment": "testing",
         "example.com/role": "Kubernetes-worker"
     }
 }
```

Now here is the problem: Our nodes have different hostnames from the default `ip-<ip>.<availability-zone>.compute.internal` format. It seems like the Kubernetes node fetching logic only supports the default hostname format which means that node lookup fails and produces the following logs:

```
2022/04/11 02:35:22 INF Error when trying to list Nodes w/ label, falling back to direct Get lookup of node
2022/04/11 02:35:22 ERR Unable to fetch node labels for node 'ip-10.0.0.1.ap-northeast-2.compute.internal'  error="nodes \"ip-10.0.0.1.ap-northeast-2.compute.internal\" not found"
2022/04/11 02:35:22 INF Pods on node node_name=ip-10.0.0.1.ap-northeast-2.compute.internal pod_names=[]
2022/04/11 02:35:22 DBG Not marking for exclusion from load balancers because the configuration flag is not set
2022/04/11 02:35:22 INF Error when trying to list Nodes w/ label, falling back to direct Get lookup of node
2022/04/11 02:35:22 ERR node 'ip-10.0.0.1.ap-northeast-2.compute.internal' not found in the cluster error="nodes \"ip-10.0.0.1.ap-northeast-2.compute.internal\" not found"
```

This PR implements logic that allows the nodes to be selected through the Kubernetes node spec `providerID` field instead. This field is also required for autoscaling (cluster-autoscaler) and has the `aws:///<availabilityzone>/<instanceID>` format. This is also set by EKS clusters.

Because I realize the use of kubelet's `--hostname-override` is probably not a very common concern I implemented the following logic behind a `USE_PROVIDER_ID` environment variable/CLI flag for those running into similar problems as us.


**Description of changes:**
The changes only apply to the Queue mode processor.

* Add `providerID` key/value to `NodeInfo` and `InterruptionEvent`
* Add `GetNodeNameFromProviderID` function to Node struct.
  * This functions loops over all nodes and tries to find a matching ProviderID. (Unfortunately FieldSelector was not supported for this field)
  * When no matching node is found reverts to using node name from the original AWS event.
  * Tries to extract `kubernetes.io/hostname` label first. If unavailable extracts Kubernetes node metadata name instead.
* Add logic into go routine `drainOrCordonIfNecessary` that runs before `GetNodeLabels` that requires the nodeName
* Add `use-provider-id` flag to CLI
* Add `USE_PROVIDER_ID` environment variable (default: false)
* Add configuration tests
* Include option into Helm template and documentation

We currently run this branch in our environment, here are the debug level logs:

```
2022/04/11 07:03:45 DBG Got node info from AWS: {
     "AsgName": "Kubernetes-worker",
     "InstanceID": "i-1234567890",
     "ProviderID": "aws:///ap-northeast-2c/i-1234567890",
     "IsManaged": true,
     "Name": "ip-10-0-0-1.ap-northeast-2.compute.internal",
     "Tags": {
         "Name": "Kubernetes-worker",
         "aws-node-termination-handler/managed": "true",
         "aws:autoscaling:groupName": "Kubernetes-worker",
         "example.com/environment": "testing",
         "example.com/role": "kubernetes-worker"
     }
 }
2022/04/11 07:03:45 DBG Sending SQS_TERMINATE interruption event to the interruption channel
2022/04/11 07:03:45 DBG Checking for queue messages
2022/04/11 07:03:45 INF Adding new event to the event store event={"AutoScalingGroupName":"Kubernetes-worker","Description":"ASG Lifecycle Termination event received. Instance will be interrupted at 2022-04-11 07:03:44 +0000 UTC \n","EndTime":"0001-01-01T00:00:00Z","EventID":"asg-lifecycle-term-9876543210","InProgress":false,"InstanceID":"i-1234567890","IsManaged":true,"Kind":"SQS_TERMINATE","NodeLabels":null,"NodeName":"ip-10-0-0-1.ap-northeast-2.compute.internal","NodeProcessed":false,"Pods":null,"ProviderID":"aws:///ap-northeast-2c/i-1234567890","StartTime":"2022-04-11T07:03:44Z","State":""}
2022/04/11 07:03:45 INF Requesting instance drain event-id=asg-lifecycle-term-9876543210 instance-id=i-1234567890 kind=SQS_TERMINATE node-name=ip-10-0-0-1.ap-northeast-2.compute.internal provider-id=aws:///ap-northeast-2c/i-1234567890
2022/04/11 07:03:45 INF Pods on node node_name=ip-10-0-0-1 pod_names=["calico-node-bzckb","ebs-csi-node-jl4mx","kube-proxy-mktdj","prometheus-node-exporter-fscjc","filebeat-pxwwv"]
2022/04/11 07:03:45 DBG Not marking for exclusion from load balancers because the configuration flag is not set
2022/04/11 07:03:45 INF Draining the node
2022/04/11 07:03:45 ??? WARNING: ignoring DaemonSet-managed Pods: kube-system/calico-node-bzckb, kube-system/ebs-csi-node-jl4mx, kube-system/kube-proxy-mktdj, monitoring/prometheus-node-exporter-fscjc, monitoring/filebeat-pxwwv
2022/04/11 07:03:45 INF Node successfully cordoned and drained node_name=ip-10-0-0-1 reason="ASG Lifecycle Termination event received. Instance will be interrupted at 2022-04-11 07:03:44 +0000 UTC \n"
```

As this is my first pull request on this repository, if there is any additional work please let me know!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Best Regards,

Jordy
