### PR TITLE
Ignore test notification events

### DIFF
--- a/pkg/monitor/sqsevent/asg-lifecycle-event.go
+++ b/pkg/monitor/sqsevent/asg-lifecycle-event.go
@@ -66,6 +66,10 @@ func (m SQSMonitor) asgTerminationToInterruptionEvent(event *EventBridgeEvent, m
 		return nil, err
 	}
 
+	if lifecycleDetail.LifecycleTransition == "autoscaling:TEST_NOTIFICATION" {
+		return nil, skip{fmt.Errorf("message is an ASG test notification")}
+	}
+
 	nodeInfo, err := m.getNodeInfo(lifecycleDetail.EC2InstanceID)
 	if err != nil {
 		return nil, err

--- a/pkg/monitor/sqsevent/sqs-monitor_test.go
+++ b/pkg/monitor/sqsevent/sqs-monitor_test.go
@@ -190,7 +190,7 @@ func TestMonitor_EventBridgeTestNotification(t *testing.T) {
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
 		ManagedAsgTag:    "aws-node-termination-handler/managed",
-		ASG:              mockIsManagedTrue(nil), // TODO: is this the right mock factory function?
+		ASG:              mockIsManagedFalse(nil),
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
 		InterruptionChan: drainChan,
@@ -277,7 +277,7 @@ func TestMonitor_AsgDirectToSqsTestNotification(t *testing.T) {
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
 		ManagedAsgTag:    "aws-node-termination-handler/managed",
-		ASG:              mockIsManagedTrue(nil),
+		ASG:              mockIsManagedFalse(nil),
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
 		InterruptionChan: drainChan,

--- a/pkg/monitor/sqsevent/sqs-monitor_test.go
+++ b/pkg/monitor/sqsevent/sqs-monitor_test.go
@@ -77,6 +77,16 @@ var asgLifecycleEventFromSQS = sqsevent.LifecycleDetail{
 	LifecycleActionToken: "b4dd0f5b-0ef2-4479-9dad-6c55f027000e",
 }
 
+var asgLifecycleTestNotificationFromSQS = sqsevent.LifecycleDetail{
+	LifecycleHookName:    "test-nth-asg-to-sqs",
+	RequestID:            "3775fac9-93c3-7ead-8713-159816566000",
+	LifecycleTransition:  "autoscaling:TEST_NOTIFICATION",
+	AutoScalingGroupName: "my-asg",
+	Time:                 "2022-01-31T23:07:47.872Z",
+	EC2InstanceID:        "i-040107f6ba000e5ee",
+	LifecycleActionToken: "b4dd0f5b-0ef2-4479-9dad-6c55f027000e",
+}
+
 var rebalanceRecommendationEvent = sqsevent.EventBridgeEvent{
 	Version:    "0",
 	ID:         "5d5555d5-dd55-5555-5555-5555dd55d55d",
@@ -189,6 +199,46 @@ func TestMonitor_AsgDirectToSqsSuccess(t *testing.T) {
 		h.Ok(t, fmt.Errorf("Expected an event to be generated"))
 	}
 
+}
+
+func TestMonitor_AsgDirectToSqsTestNotification(t *testing.T) {
+	eventBytes, err := json.Marshal(&asgLifecycleTestNotificationFromSQS)
+	h.Ok(t, err)
+	eventStr := string(eventBytes)
+	msg := sqs.Message{Body: &eventStr}
+	h.Ok(t, err)
+	messages := []*sqs.Message{
+		&msg,
+	}
+	sqsMock := h.MockedSQS{
+		ReceiveMessageResp: sqs.ReceiveMessageOutput{Messages: messages},
+		ReceiveMessageErr:  nil,
+	}
+	dnsNodeName := "ip-10-0-0-157.us-east-2.compute.internal"
+	ec2Mock := h.MockedEC2{
+		DescribeInstancesResp: getDescribeInstancesResp(dnsNodeName, true, true),
+	}
+	drainChan := make(chan monitor.InterruptionEvent, 1)
+
+	sqsMonitor := sqsevent.SQSMonitor{
+		SQS:              sqsMock,
+		EC2:              ec2Mock,
+		ManagedAsgTag:    "aws-node-termination-handler/managed",
+		ASG:              mockIsManagedTrue(nil),
+		CheckIfManaged:   true,
+		QueueURL:         "https://test-queue",
+		InterruptionChan: drainChan,
+	}
+
+	err = sqsMonitor.Monitor()
+	h.Ok(t, err)
+
+	select {
+	case result := <-drainChan:
+		h.Ok(t, fmt.Errorf("Did not expect a result on the drain channel: %#v", result))
+	default:
+		h.Ok(t, nil)
+	}
 }
 
 func TestMonitor_DrainTasks(t *testing.T) {


### PR DESCRIPTION
**Issue #, if available:**

#619 TEST_NOTIFICATION event sent to newly added ASG lifecycle hook w/o Event Bridge triggers NTH panic

**Description of changes:**

Added check for TEST_NOTIFICATION lifecycle transistion and logic to skip remaining processing rather than erroring.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
