### PR TITLE
Update deployment.yaml file

### DIFF
--- a/config/helm/aws-node-termination-handler/templates/deployment.yaml
+++ b/config/helm/aws-node-termination-handler/templates/deployment.yaml
@@ -139,13 +139,13 @@ spec:
               value: {{ .Values.webhookTemplate | quote }}
             {{- end }}
             - name: ENABLE_SPOT_INTERRUPTION_DRAINING
-              value: "false"
+              value: {{ .Values.enableSpotInterruptionDraining | quote }}
             - name: ENABLE_SCHEDULED_EVENT_DRAINING
-              value: "false"
+              value: {{ .Values.enableScheduledEventDraining | quote }}
             - name: ENABLE_REBALANCE_MONITORING
-              value: "false"
+              value: {{ .Values.enableRebalanceMonitoring | quote }}
             - name: ENABLE_REBALANCE_DRAINING
-              value: "false"
+              value: {{ .Values.enableRebalanceDraining | quote }}
             - name: ENABLE_SQS_TERMINATION_DRAINING
               value: "true"
             {{- with .Values.awsRegion }}


### PR DESCRIPTION
Fixing properties to take the values from the values.yaml file and not to be hardcoded.

**Issue #, if available:** Values were hardcoded and when we are running helm upgrade command and sending the properties with --set command, is not setting the values. 

**Description of changes:**

To test it, you can run the code in the documentation https://github.com/aws/aws-node-termination-handler:

helm upgrade --install aws-node-termination-handler \
  --namespace kube-system \
  --set enableSpotInterruptionDraining="true" \
  --set enableRebalanceMonitoring="true" \
  --set enableScheduledEventDraining="false" \
  eks/aws-node-termination-handler
  
  and you will see that the properties enableRebalanceMonitoring and enableSpotInterruptionDraining are not set. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
