### PR TITLE
add event action config to Terminator

### DIFF
--- a/src/api/v1alpha1/terminator_logging.go
+++ b/src/api/v1alpha1/terminator_logging.go
@@ -31,6 +31,7 @@ func (t *TerminatorSpec) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	}
 	enc.AddObject("sqs", t.SQS)
 	enc.AddObject("drain", t.Drain)
+	enc.AddObject("events", t.Events)
 	return nil
 }
 
@@ -45,5 +46,14 @@ func (d DrainSpec) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddBool("ignoreAllDaemonSets", d.IgnoreAllDaemonSets)
 	enc.AddBool("deleteEmptyDirData", d.DeleteEmptyDirData)
 	enc.AddInt("timeoutSeconds", d.TimeoutSeconds)
+	return nil
+}
+
+func (e EventsSpec) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("autoScalingTermination", e.AutoScalingTermination)
+	enc.AddString("rebalanceRecommendation", e.RebalanceRecommendation)
+	enc.AddString("scheduledChange", e.ScheduledChange)
+	enc.AddString("spotInterruption", e.SpotInterruption)
+	enc.AddString("stateChange", e.StateChange)
 	return nil
 }

--- a/src/api/v1alpha1/terminator_types.go
+++ b/src/api/v1alpha1/terminator_types.go
@@ -33,6 +33,7 @@ type TerminatorSpec struct {
 	MatchLabels map[string]string `json:"matchLabels,omitempty"`
 	SQS         SQSSpec           `json:"sqs,omitempty"`
 	Drain       DrainSpec         `json:"drain,omitempty"`
+	Events      EventsSpec        `json:"events,omitempty"`
 }
 
 // SQSSpec defines inputs to SQS "receive messages" requests.
@@ -49,6 +50,27 @@ type DrainSpec struct {
 	IgnoreAllDaemonSets bool `json:"ignoreAllDaemonSets,omitempty"`
 	DeleteEmptyDirData  bool `json:"deleteEmptyDirData,omitempty"`
 	TimeoutSeconds      int  `json:"timeoutSeconds,omitempty"`
+}
+
+type Action = string
+
+var Actions = struct {
+	CordonAndDrain,
+	Cordon,
+	NoAction Action
+}{
+	CordonAndDrain: "CordonAndDrain",
+	Cordon:         "Cordon",
+	NoAction:       "NoAction",
+}
+
+// EventsSpec defines the action(s) that should be performed in response to a particular event.
+type EventsSpec struct {
+	AutoScalingTermination  Action `json:"autoScalingTermination,omitempty"`
+	RebalanceRecommendation Action `json:"rebalanceRecommendation,omitempty"`
+	ScheduledChange         Action `json:"scheduledChange,omitempty"`
+	SpotInterruption        Action `json:"spotInterruption,omitempty"`
+	StateChange             Action `json:"stateChange,omitempty"`
 }
 
 // TerminatorStatus defines the observed state of Terminator

--- a/src/api/v1alpha1/terminator_types.go
+++ b/src/api/v1alpha1/terminator_types.go
@@ -59,9 +59,9 @@ var Actions = struct {
 	Cordon,
 	NoAction Action
 }{
-	CordonAndDrain: "CordonAndDrain",
-	Cordon:         "Cordon",
-	NoAction:       "NoAction",
+	CordonAndDrain: Action("CordonAndDrain"),
+	Cordon:         Action("Cordon"),
+	NoAction:       Action("NoAction"),
 }
 
 // EventsSpec defines the action(s) that should be performed in response to a particular event.

--- a/src/charts/aws-node-termination-handler-2/templates/node.k8s.aws_terminators.yaml
+++ b/src/charts/aws-node-termination-handler-2/templates/node.k8s.aws_terminators.yaml
@@ -97,6 +97,45 @@ spec:
                     {{- with .Values.terminator.defaults.drain.timeoutSeconds }}
                     default: {{ . }}
                     {{- end }}
+              events:
+                description: Specify what action should be taken when a particular message type is received.
+                type: object
+                properties:
+                  autoScalingTermination:
+                    type: string
+                    enum:
+                      - CordonAndDrain
+                      - Cordon
+                      - NoAction
+                    default: CordonAndDrain
+                  rebalanceRecommendation:
+                    type: string
+                    enum:
+                      - CordonAndDrain
+                      - Cordon
+                      - NoAction
+                    default: CordonAndDrain
+                  scheduledChange:
+                    type: string
+                    enum:
+                      - CordonAndDrain
+                      - Cordon
+                      - NoAction
+                    default: CordonAndDrain
+                  spotInterruption:
+                    type: string
+                    enum:
+                      - CordonAndDrain
+                      - Cordon
+                      - NoAction
+                    default: CordonAndDrain
+                  stateChange:
+                    type: string
+                    enum:
+                      - CordonAndDrain
+                      - Cordon
+                      - NoAction
+                    default: CordonAndDrain
           status:
             description: TerminatorStatus defines the observed state of Terminator
             type: object

--- a/src/pkg/event/asgterminate/v1/handler.go
+++ b/src/pkg/event/asgterminate/v1/handler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-node-termination-handler/pkg/event/asgterminate/lifecycleaction"
+	"github.com/aws/aws-node-termination-handler/pkg/terminator"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -28,6 +29,10 @@ import (
 type EC2InstanceTerminateLifecycleAction struct {
 	ASGLifecycleActionCompleter
 	AWSEvent
+}
+
+func (EC2InstanceTerminateLifecycleAction) Kind() terminator.EventKind {
+	return terminator.EventKinds.AutoScalingTermination
 }
 
 func (e EC2InstanceTerminateLifecycleAction) EC2InstanceIDs() []string {

--- a/src/pkg/event/asgterminate/v2/handler.go
+++ b/src/pkg/event/asgterminate/v2/handler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-node-termination-handler/pkg/event/asgterminate/lifecycleaction"
+	"github.com/aws/aws-node-termination-handler/pkg/terminator"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -28,6 +29,10 @@ import (
 type EC2InstanceTerminateLifecycleAction struct {
 	ASGLifecycleActionCompleter
 	AWSEvent
+}
+
+func (EC2InstanceTerminateLifecycleAction) Kind() terminator.EventKind {
+	return terminator.EventKinds.AutoScalingTermination
 }
 
 func (e EC2InstanceTerminateLifecycleAction) EC2InstanceIDs() []string {

--- a/src/pkg/event/rebalancerecommendation/v0/handler.go
+++ b/src/pkg/event/rebalancerecommendation/v0/handler.go
@@ -19,17 +19,23 @@ package v0
 import (
 	"context"
 
+	"github.com/aws/aws-node-termination-handler/pkg/terminator"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
 type EC2InstanceRebalanceRecommendation AWSEvent
 
+func (EC2InstanceRebalanceRecommendation) Kind() terminator.EventKind {
+	return terminator.EventKinds.RebalanceRecommendation
+}
+
 func (e EC2InstanceRebalanceRecommendation) EC2InstanceIDs() []string {
 	return []string{e.Detail.InstanceID}
 }
 
-func (e EC2InstanceRebalanceRecommendation) Done(_ context.Context) (bool, error) {
+func (EC2InstanceRebalanceRecommendation) Done(_ context.Context) (bool, error) {
 	return false, nil
 }
 

--- a/src/pkg/event/scheduledchange/v1/handler.go
+++ b/src/pkg/event/scheduledchange/v1/handler.go
@@ -19,11 +19,17 @@ package v1
 import (
 	"context"
 
+	"github.com/aws/aws-node-termination-handler/pkg/terminator"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
 type AWSHealthEvent AWSEvent
+
+func (AWSHealthEvent) Kind() terminator.EventKind {
+	return terminator.EventKinds.ScheduledChange
+}
 
 func (e AWSHealthEvent) EC2InstanceIDs() []string {
 	ids := make([]string, len(e.Detail.AffectedEntities))
@@ -33,7 +39,7 @@ func (e AWSHealthEvent) EC2InstanceIDs() []string {
 	return ids
 }
 
-func (e AWSHealthEvent) Done(_ context.Context) (bool, error) {
+func (AWSHealthEvent) Done(_ context.Context) (bool, error) {
 	return false, nil
 }
 

--- a/src/pkg/event/spotinterruption/v1/handler.go
+++ b/src/pkg/event/spotinterruption/v1/handler.go
@@ -19,17 +19,23 @@ package v1
 import (
 	"context"
 
+	"github.com/aws/aws-node-termination-handler/pkg/terminator"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
 type EC2SpotInstanceInterruptionWarning AWSEvent
 
+func (EC2SpotInstanceInterruptionWarning) Kind() terminator.EventKind {
+	return terminator.EventKinds.SpotInterruption
+}
+
 func (e EC2SpotInstanceInterruptionWarning) EC2InstanceIDs() []string {
 	return []string{e.Detail.InstanceID}
 }
 
-func (e EC2SpotInstanceInterruptionWarning) Done(_ context.Context) (bool, error) {
+func (EC2SpotInstanceInterruptionWarning) Done(_ context.Context) (bool, error) {
 	return false, nil
 }
 

--- a/src/pkg/event/statechange/v1/handler.go
+++ b/src/pkg/event/statechange/v1/handler.go
@@ -19,17 +19,23 @@ package v1
 import (
 	"context"
 
+	"github.com/aws/aws-node-termination-handler/pkg/terminator"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
 type EC2InstanceStateChangeNotification AWSEvent
 
+func (EC2InstanceStateChangeNotification) Kind() terminator.EventKind {
+	return terminator.EventKinds.StateChange
+}
+
 func (e EC2InstanceStateChangeNotification) EC2InstanceIDs() []string {
 	return []string{e.Detail.InstanceID}
 }
 
-func (e EC2InstanceStateChangeNotification) Done(_ context.Context) (bool, error) {
+func (EC2InstanceStateChangeNotification) Done(_ context.Context) (bool, error) {
 	return false, nil
 }
 

--- a/src/pkg/terminator/eventkind.go
+++ b/src/pkg/terminator/eventkind.go
@@ -14,32 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package event
+package terminator
 
-import (
-	"context"
+type EventKind string
 
-	"github.com/aws/aws-node-termination-handler/pkg/terminator"
-
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-)
-
-type noop AWSMetadata
-
-func (noop) Kind() terminator.EventKind {
-	return terminator.EventKinds.Noop
+var EventKinds = struct {
+	AutoScalingTermination,
+	RebalanceRecommendation,
+	ScheduledChange,
+	SpotInterruption,
+	StateChange,
+	Noop EventKind
+}{
+	AutoScalingTermination:  EventKind("autoScalingTermination"),
+	RebalanceRecommendation: EventKind("rebalanceRecommendation"),
+	ScheduledChange:         EventKind("scheduledChange"),
+	SpotInterruption:        EventKind("spotInterruption"),
+	StateChange:             EventKind("stateChange"),
+	Noop:                    EventKind("noop"),
 }
 
-func (noop) EC2InstanceIDs() []string {
-	return []string{}
-}
-
-func (noop) Done(_ context.Context) (bool, error) {
-	return true, nil
-}
-
-func (n noop) MarshalLogObject(enc zapcore.ObjectEncoder) error {
-	zap.Inline(AWSMetadata(n)).AddTo(enc)
-	return nil
+func (e EventKind) String() string {
+	return string(e)
 }

--- a/src/pkg/terminator/reconciler.go
+++ b/src/pkg/terminator/reconciler.go
@@ -124,81 +124,80 @@ func (r Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (recon
 		return reconcile.Result{}, err
 	}
 
-	origCtx := ctx
 	for _, msg := range sqsMessages {
-		ctx = logging.WithLogger(origCtx, logging.FromContext(origCtx).
-			With("sqsMessage", logging.NewMessageMarshaler(msg)),
-		)
-
-		evt := r.Parse(ctx, msg)
-		ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("event", evt))
-
-		evtAction := actionForEvent(evt, terminator)
-		ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("action", evtAction))
-
-		allInstancesHandled := true
-		ec2InstanceIDs := evt.EC2InstanceIDs()
-		savedCtx := ctx
-		for i := 0; i < len(ec2InstanceIDs) && evtAction != v1alpha1.Actions.NoAction; i++ {
-			ec2InstanceID := ec2InstanceIDs[i]
-
-			ctx = logging.WithLogger(savedCtx, logging.FromContext(savedCtx).
-				With("ec2InstanceID", ec2InstanceID),
-			)
-
-			nodeName, e := r.GetNodeName(ctx, ec2InstanceID)
-			if e != nil {
-				err = multierr.Append(err, e)
-				allInstancesHandled = false
-				continue
-			}
-
-			ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("node", nodeName))
-
-			node, e := nodeGetter.GetNode(ctx, nodeName)
-			if node == nil {
-				logger := logging.FromContext(ctx)
-				if e != nil {
-					logger = logger.With("error", e)
-				}
-				logger.Warn("no matching node found")
-				allInstancesHandled = false
-				continue
-			}
-
-			if e = cordondrainer.Cordon(ctx, node); e != nil {
-				err = multierr.Append(err, e)
-				continue
-			}
-
-			if evtAction == v1alpha1.Actions.Cordon {
-				continue
-			}
-
-			if e = cordondrainer.Drain(ctx, node); e != nil {
-				err = multierr.Append(err, e)
-				continue
-			}
-		}
-		ctx = savedCtx
-
-		tryAgain, e := evt.Done(ctx)
-		if e != nil {
-			err = multierr.Append(err, e)
-		}
-
-		if tryAgain || !allInstancesHandled {
-			continue
-		}
-
-		err = multierr.Append(err, sqsClient.DeleteSQSMessage(ctx, msg))
+		e := r.handleMessage(ctx, msg, terminator, nodeGetter, cordondrainer, sqsClient)
+		err = multierr.Append(err, e)
 	}
-	ctx = origCtx
 
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{RequeueAfter: r.RequeueInterval}, nil
+}
+
+func (r Reconciler) handleMessage(ctx context.Context, msg *sqs.Message, terminator *v1alpha1.Terminator, nodeGetter NodeGetter, cordondrainer CordonDrainer, sqsClient SQSClient) (err error) {
+	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("sqsMessage", logging.NewMessageMarshaler(msg)))
+
+	evt := r.Parse(ctx, msg)
+	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("event", evt))
+
+	evtAction := actionForEvent(evt, terminator)
+	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("action", evtAction))
+
+	allInstancesHandled := true
+	if evtAction != v1alpha1.Actions.NoAction {
+		for _, ec2InstanceID := range evt.EC2InstanceIDs() {
+			instanceHandled, e := r.handleInstance(ctx, ec2InstanceID, evtAction, nodeGetter, cordondrainer)
+			err = multierr.Append(err, e)
+			allInstancesHandled = allInstancesHandled && instanceHandled
+		}
+	}
+
+	tryAgain, e := evt.Done(ctx)
+	if e != nil {
+		err = multierr.Append(err, e)
+	}
+
+	if tryAgain || !allInstancesHandled {
+		return err
+	}
+
+	return multierr.Append(err, sqsClient.DeleteSQSMessage(ctx, msg))
+}
+
+func (r Reconciler) handleInstance(ctx context.Context, ec2InstanceID string, evtAction v1alpha1.Action, nodeGetter NodeGetter, cordondrainer CordonDrainer) (bool, error) {
+	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("ec2InstanceID", ec2InstanceID))
+
+	nodeName, err := r.GetNodeName(ctx, ec2InstanceID)
+	if err != nil {
+		return false, err
+	}
+
+	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("node", nodeName))
+
+	node, err := nodeGetter.GetNode(ctx, nodeName)
+	if node == nil {
+		logger := logging.FromContext(ctx)
+		if err != nil {
+			logger = logger.With("error", err)
+		}
+		logger.Warn("no matching node found")
+		return false, nil
+	}
+
+	if err = cordondrainer.Cordon(ctx, node); err != nil {
+		return true, err
+	}
+
+	if evtAction == v1alpha1.Actions.Cordon {
+		return true, nil
+	}
+
+	if err = cordondrainer.Drain(ctx, node); err != nil {
+		return true, err
+	}
+
+	return true, nil
 }
 
 func (r Reconciler) BuildController(builder *builder.Builder) error {

--- a/src/pkg/terminator/reconciler.go
+++ b/src/pkg/terminator/reconciler.go
@@ -51,6 +51,7 @@ type (
 
 		Done(context.Context) (tryAgain bool, err error)
 		EC2InstanceIDs() []string
+		Kind() EventKind
 	}
 
 	Getter interface {


### PR DESCRIPTION
**Issue #, if available:**

#556 Initial NTH v2 design proposal

**Description of changes:**

Add `events` property to the Terminator spec which gives the option to instruct NTH to take no action, or only cordon nodes, when particular message types are received.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
