### PR TITLE
Fix AWS Health Event Bridge Rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ $ aws events put-targets --rule MyK8sInstanceStateChangeRule \
 
 $ aws events put-rule \
   --name MyK8sScheduledChangeRule \
-  --event-pattern "{\"source\": [\"aws.health\"],\"detail-type\": [\"AWS Health Event\"]}"
+  --event-pattern "{\"source\": [\"aws.health\"],\"detail-type\": [\"AWS Health Event\"],\"detail\": {\"service\": [\"EC2\"],\"eventTypeCategory\": [\"scheduledChange\"]}}"
 
 $ aws events put-targets --rule MyK8sScheduledChangeRule \
   --targets "Id"="1","Arn"="arn:aws:sqs:us-east-1:123456789012:MyK8sTermQueue"

--- a/pkg/monitor/sqsevent/scheduled-change-event.go
+++ b/pkg/monitor/sqsevent/scheduled-change-event.go
@@ -76,13 +76,13 @@ func (m SQSMonitor) scheduledEventToInterruptionEvents(event *EventBridgeEvent, 
 	}
 
 	if scheduledChangeEventDetail.Service != "EC2" {
-		log.Warn().Msgf("events from Amazon EventBridge for service (%s) are not supported", scheduledChangeEventDetail.Service)
-		return append(interruptionEventWrappers, InterruptionEventWrapper{nil, nil})
+		err := skip{fmt.Errorf("events from Amazon EventBridge for service (%s) are not supported", scheduledChangeEventDetail.Service)}
+		return append(interruptionEventWrappers, InterruptionEventWrapper{nil, err})
 	}
 
 	if scheduledChangeEventDetail.EventTypeCategory != "scheduledChange" {
-		log.Warn().Msgf("events from Amazon EventBridge with EventTypeCategory (%s) are not supported", scheduledChangeEventDetail.EventTypeCategory)
-		return append(interruptionEventWrappers, InterruptionEventWrapper{nil, nil})
+		err := skip{fmt.Errorf("events from Amazon EventBridge with EventTypeCategory (%s) are not supported", scheduledChangeEventDetail.EventTypeCategory)}
+		return append(interruptionEventWrappers, InterruptionEventWrapper{nil, err})
 	}
 
 	for _, affectedEntity := range scheduledChangeEventDetail.AffectedEntities {

--- a/pkg/monitor/sqsevent/scheduled-change-event.go
+++ b/pkg/monitor/sqsevent/scheduled-change-event.go
@@ -76,13 +76,13 @@ func (m SQSMonitor) scheduledEventToInterruptionEvents(event *EventBridgeEvent, 
 	}
 
 	if scheduledChangeEventDetail.Service != "EC2" {
-		err := fmt.Errorf("events from Amazon EventBridge for service (%s) are not supported", scheduledChangeEventDetail.Service)
-		return append(interruptionEventWrappers, InterruptionEventWrapper{nil, err})
+		log.Warn().Msgf("events from Amazon EventBridge for service (%s) are not supported", scheduledChangeEventDetail.Service)
+		return append(interruptionEventWrappers, InterruptionEventWrapper{nil, nil})
 	}
 
 	if scheduledChangeEventDetail.EventTypeCategory != "scheduledChange" {
-		err := fmt.Errorf("events from Amazon EventBridge with EventTypeCategory (%s) are not supported", scheduledChangeEventDetail.EventTypeCategory)
-		return append(interruptionEventWrappers, InterruptionEventWrapper{nil, err})
+		log.Warn().Msgf("events from Amazon EventBridge with EventTypeCategory (%s) are not supported", scheduledChangeEventDetail.EventTypeCategory)
+		return append(interruptionEventWrappers, InterruptionEventWrapper{nil, nil})
 	}
 
 	for _, affectedEntity := range scheduledChangeEventDetail.AffectedEntities {


### PR DESCRIPTION
**Issue #, if available:** https://github.com/aws/aws-node-termination-handler/issues/550

**Description of changes:**  
- Modified the Event Bridge Rule for "MyK8sScheduledChangeRule" in README document to consider the detail-type for the AWS Health Events.
- Modified the conditions in "scheduled-change-event" file for checking service and event type category for AWS Health Events. Instead of returning an error, now it returns a warning message and deletes the messages that are not handled by NTH.

- For testing the changes, followed the below steps:
                       - Ran the e2e tests to check whether the modified changes are affecting any  other functionalities.
                       - Tried to send an AWS health event from different service other than EC2 from SQS service.
                       - Verified if the sent message has been deleted and a warning message is returned.
                       - Tried to send an AWS Health Event with EC2 service and verified if the output for that Event is as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
