### PR TITLE
ignore test notification Event

### DIFF
--- a/pkg/monitor/sqsevent/asg-lifecycle-event.go
+++ b/pkg/monitor/sqsevent/asg-lifecycle-event.go
@@ -48,6 +48,8 @@ import (
 }
 */
 
+const TEST_NOTIFICATION = "autoscaling:TEST_NOTIFICATION"
+
 // LifecycleDetail provides the ASG lifecycle event details
 type LifecycleDetail struct {
 	LifecycleActionToken string `json:"LifecycleActionToken"`
@@ -67,8 +69,7 @@ func (m SQSMonitor) asgTerminationToInterruptionEvent(event *EventBridgeEvent, m
 		return nil, err
 	}
 
-	if lifecycleDetail.Event == "autoscaling:TEST_NOTIFICATION" ||
-		lifecycleDetail.LifecycleTransition == "autoscaling:TEST_NOTIFICATION" {
+	if lifecycleDetail.Event == TEST_NOTIFICATION || lifecycleDetail.LifecycleTransition == TEST_NOTIFICATION {
 		return nil, skip{fmt.Errorf("message is an ASG test notification")}
 	}
 

--- a/pkg/monitor/sqsevent/asg-lifecycle-event.go
+++ b/pkg/monitor/sqsevent/asg-lifecycle-event.go
@@ -55,6 +55,7 @@ type LifecycleDetail struct {
 	LifecycleHookName    string `json:"LifecycleHookName"`
 	EC2InstanceID        string `json:"EC2InstanceId"`
 	LifecycleTransition  string `json:"LifecycleTransition"`
+	Event                string `json:"Event"`
 	RequestID            string `json:"RequestId"`
 	Time                 string `json:"Time"`
 }
@@ -66,7 +67,8 @@ func (m SQSMonitor) asgTerminationToInterruptionEvent(event *EventBridgeEvent, m
 		return nil, err
 	}
 
-	if lifecycleDetail.LifecycleTransition == "autoscaling:TEST_NOTIFICATION" {
+	if lifecycleDetail.Event == "autoscaling:TEST_NOTIFICATION" ||
+		lifecycleDetail.LifecycleTransition == "autoscaling:TEST_NOTIFICATION" {
 		return nil, skip{fmt.Errorf("message is an ASG test notification")}
 	}
 

--- a/pkg/monitor/sqsevent/sqs-monitor.go
+++ b/pkg/monitor/sqsevent/sqs-monitor.go
@@ -136,7 +136,8 @@ func (m SQSMonitor) processLifecycleEventFromASG(message *sqs.Message) (EventBri
 		log.Err(err).Msg("only lifecycle events from ASG to SQS are supported outside EventBridge")
 		return eventBridgeEvent, err
 
-	case lifecycleEvent.LifecycleTransition == "autoscaling:TEST_NOTIFICATION":
+	case lifecycleEvent.Event == "autoscaling:TEST_NOTIFICATION" ||
+		lifecycleEvent.LifecycleTransition == "autoscaling:TEST_NOTIFICATION":
 		log.Warn().Msg("ignoring ASG test notification")
 		return eventBridgeEvent, skip{fmt.Errorf("message is a test notification")}
 

--- a/pkg/monitor/sqsevent/sqs-monitor.go
+++ b/pkg/monitor/sqsevent/sqs-monitor.go
@@ -136,8 +136,7 @@ func (m SQSMonitor) processLifecycleEventFromASG(message *sqs.Message) (EventBri
 		log.Err(err).Msg("only lifecycle events from ASG to SQS are supported outside EventBridge")
 		return eventBridgeEvent, err
 
-	case lifecycleEvent.Event == "autoscaling:TEST_NOTIFICATION" ||
-		lifecycleEvent.LifecycleTransition == "autoscaling:TEST_NOTIFICATION":
+	case lifecycleEvent.Event == TEST_NOTIFICATION || lifecycleEvent.LifecycleTransition == TEST_NOTIFICATION:
 		log.Warn().Msg("ignoring ASG test notification")
 		return eventBridgeEvent, skip{fmt.Errorf("message is a test notification")}
 

--- a/pkg/monitor/sqsevent/sqs-monitor_test.go
+++ b/pkg/monitor/sqsevent/sqs-monitor_test.go
@@ -89,6 +89,7 @@ var asgLifecycleTestNotification = sqsevent.EventBridgeEvent{
 		"arn:aws:autoscaling:us-east-1:123456789012:autoScalingGroup:26e7234b-03a4-47fb-b0a9-2b241662774e:autoScalingGroupName/nth-test1",
 	},
 	Detail: []byte(`{
+		"Event": "autoscaling:TEST_NOTIFICATION",
 		"LifecycleTransition": "autoscaling:TEST_NOTIFICATION"
 	  }`),
 }
@@ -96,6 +97,7 @@ var asgLifecycleTestNotification = sqsevent.EventBridgeEvent{
 var asgLifecycleTestNotificationFromSQS = sqsevent.LifecycleDetail{
 	LifecycleHookName:    "test-nth-asg-to-sqs",
 	RequestID:            "3775fac9-93c3-7ead-8713-159816566000",
+	Event:                "autoscaling:TEST_NOTIFICATION",
 	LifecycleTransition:  "autoscaling:TEST_NOTIFICATION",
 	AutoScalingGroupName: "my-asg",
 	Time:                 "2022-01-31T23:07:47.872Z",


### PR DESCRIPTION
**Issue #, if available:**

#619 TEST_NOTIFICATION event sent to newly added ASG lifecycle hook w/o Event Bridge triggers NTH panic

**Description of changes:**

Now also checks the `Event` field when determining whether the message is a test notification.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
