### PR TITLE
Log IMDS response full text when status code not in 200 range

### DIFF
--- a/pkg/ec2metadata/ec2metadata.go
+++ b/pkg/ec2metadata/ec2metadata.go
@@ -195,20 +195,24 @@ func (e *Service) GetRebalanceRecommendationEvent() (rebalanceRec *RebalanceReco
 
 // GetMetadataInfo generic function for retrieving ec2 metadata
 func (e *Service) GetMetadataInfo(path string) (info string, err error) {
+	metadataInfo := ""
 	resp, err := e.Request(path)
-	if err != nil || resp == nil {
+	if err != nil {
 		return "", fmt.Errorf("Unable to parse metadata response: %w", err)
 	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("Unable to parse http response. Status code: %d. %w", resp.StatusCode, err)
+	if resp != nil {
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return "", fmt.Errorf("Unable to parse http response. Status code: %d. %w", resp.StatusCode, err)
+		}
+		metadataInfo = string(body)
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			log.Info().Msgf("Metadata response status code: %d. Body: %s", resp.StatusCode, metadataInfo)
+			return "", fmt.Errorf("Metadata request received http status code: %d", resp.StatusCode)
+		}
 	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		log.Debug().Msgf("Metadata response status code: %d. Body: %s", resp.StatusCode, string(body))
-		return "", fmt.Errorf("Metadata request received http status code: %d", resp.StatusCode)
-	}
-	return string(body), nil
+	return metadataInfo, nil
 }
 
 // Request sends an http request to IMDSv1 or v2 at the specified path

--- a/pkg/ec2metadata/ec2metadata.go
+++ b/pkg/ec2metadata/ec2metadata.go
@@ -196,16 +196,17 @@ func (e *Service) GetRebalanceRecommendationEvent() (rebalanceRec *RebalanceReco
 // GetMetadataInfo generic function for retrieving ec2 metadata
 func (e *Service) GetMetadataInfo(path string) (info string, err error) {
 	resp, err := e.Request(path)
-	if resp != nil && (resp.StatusCode < 200 || resp.StatusCode >= 300) {
-		return "", fmt.Errorf("Metadata request received http status code: %d", resp.StatusCode)
-	}
-	if err != nil {
+	if err != nil || resp == nil {
 		return "", fmt.Errorf("Unable to parse metadata response: %w", err)
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("Unable to parse http response: %w", err)
+		return "", fmt.Errorf("Unable to parse http response. Status code: %d. %w", resp.StatusCode, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		log.Debug().Msgf("Metadata response status code: %d. Body: %s", resp.StatusCode, string(body))
+		return "", fmt.Errorf("Metadata request received http status code: %d", resp.StatusCode)
 	}
 	return string(body), nil
 }


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

Sometimes IMDS may return non-200 status codes. We'd like to see the body of the response in those scenarios, in case there may be useful debugging data there.

Restructured the `GetMetadataInfo()` function to print response body with debug-level logging.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
