### PR TITLE
add make target explore-test-coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,12 @@ jobs:
           ~/go/bin/
         key: gocache
 
+    - name: Upgrade Make
+      run: |
+        sudo apt-get update
+        wget -c http://archive.ubuntu.com/ubuntu/pool/main/m/make-dfsg/make_4.3-4ubuntu1_amd64.deb
+        sudo apt-get install ./make_4.3-4ubuntu1_amd64.deb
+
     - name: make test
       run: make test
       working-directory: ./src

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,3 +1,8 @@
+# The "grouped targets" feature requires Make 4.3.
+ifneq (4.3,$(firstword $(sort $(or $(MAKE_VERSION),00-unknown) 4.3)))
+    $(error using make version $(MAKE_VERSION), please use version 4.3 or newer)
+endif
+
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 CONTROLLER_GEN = $(PROJECT_DIR)/bin/controller-gen
 KO = $(PROJECT_DIR)/bin/ko
@@ -15,6 +20,7 @@ KODATA = \
 	cmd/controller/kodata/refs \
 	cmd/webhook/kodata/HEAD \
 	cmd/webhook/kodata/refs
+CODECOVERAGE_OUT = $(PROJECT_DIR)/coverprofile.out
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
@@ -66,9 +72,13 @@ verify: ## Run go fmt and go vet against code.
 	go vet $(PROJECT_DIR)/...
 
 .PHONY: test
-test: $(GINKGO) ## Run tests.
+test $(CODECOVERAGE_OUT) &: $(GINKGO) ## Run tests.
 	go vet $(PROJECT_DIR)/...
 	$(GINKGO) run $(GINKGO_BASE_OPTS) $(GINKGO_OPTS) $(PROJECT_DIR)/test/
+
+.PHONY: explore-test-coverage
+explore-test-coverage: $(CODECOVERAGE_OUT) ## Display test coverage report in default web browser.
+	go tool cover -html=$<
 
 ##@ Build
 


### PR DESCRIPTION
**Issue #, if available:**

The "grouped targets" feature requires Make 4.3 or newer.

**Description of changes:**

* Added check for Make 4.3 or newer in `Makefile`
* Updated test workflow
* Added shortcut make target `explore-test-coverage`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
