### PR TITLE
Pass `CHECK_ASG_TAG_BEFORE_DRAINING`-variable in daemonsets

### DIFF
--- a/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -77,6 +77,8 @@ spec:
               value: {{ .Values.probes.httpGet.port | quote }}
             - name: PROBES_SERVER_ENDPOINT
               value: {{ .Values.probes.httpGet.path | quote }}
+            - name: CHECK_ASG_TAG_BEFORE_DRAINING
+              value: {{ .Values.checkASGTagBeforeDraining | quote }}
             - name: LOG_LEVEL
               value: {{ .Values.logLevel | quote }}
             - name: JSON_LOGGING

--- a/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -77,6 +77,8 @@ spec:
               value: {{ .Values.probes.httpGet.port | quote }}
             - name: PROBES_SERVER_ENDPOINT
               value: {{ .Values.probes.httpGet.path | quote }}
+            - name: CHECK_ASG_TAG_BEFORE_DRAINING
+              value: {{ .Values.checkASGTagBeforeDraining | quote }}
             - name: LOG_LEVEL
               value: {{ .Values.logLevel | quote }}
             - name: JSON_LOGGING


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
`CHECK_ASG_TAG_BEFORE_DRAINING`-env-var is not passed to daemonset but it is to deployment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
