### PR TITLE
Handle scheduled events immediately in IMDS mode, the same as queue processor mode

### DIFF
--- a/pkg/monitor/scheduledevent/scheduled-event-monitor.go
+++ b/pkg/monitor/scheduledevent/scheduled-event-monitor.go
@@ -105,7 +105,7 @@ func (m ScheduledEventMonitor) checkForScheduledEvents() ([]monitor.Interruption
 			Description:  fmt.Sprintf("%s will occur between %s and %s because %s\n", scheduledEvent.Code, scheduledEvent.NotBefore, scheduledEvent.NotAfter, scheduledEvent.Description),
 			State:        scheduledEvent.State,
 			NodeName:     m.NodeName,
-			StartTime:    notBefore,
+			StartTime:    time.Now(),
 			EndTime:      notAfter,
 			PreDrainTask: preDrainFunc,
 		})

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
+	"time"
 )
 
 // Assert fails the test if the condition is false.
@@ -56,4 +57,13 @@ func Equals(tb testing.TB, exp, act interface{}) {
 		tb.FailNow()
 	}
 
+}
+
+// TimeWithinRange fails the test if act is not after lowerBound or not before upperBound
+func TimeWithinRange(tb testing.TB, act time.Time, lowerBound time.Time, upperBound time.Time) {
+	if !(act.After(lowerBound) && act.Before(upperBound)) {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d:\n\n\tlower bound: %#v\n\n\tgot: %#v\n\n\tupper bound: %#v\033[39m\n\n", filepath.Base(file), line, lowerBound, act, upperBound)
+		tb.FailNow()
+	}
 }


### PR DESCRIPTION
**Issue #, if available:** #361

**Description of changes:**
Update the IMDS mode handling of scheduled events to start immediately, the same as how queue processor mode currently works:

https://github.com/aws/aws-node-termination-handler/blob/814bccc507967f582867e065d4be916ab74fa5c0/pkg/monitor/sqsevent/scheduled-change-event.go#L100

We could probably remove  the date parsing altogether and get rid of `EndTime` (lines 90-101), since the SQS version does not set it at all and it does not appear to be used. But in the interest of making a small change, I'm leaving that code for now.

**Testing:**

Inside the NTH repo folder on my local machine, I ran the following commands:

```
# Create the kind cluster with two worker nodes
kind create cluster --config test/k8s-local-cluster-test/kind-three-node-cluster.yaml

# Install AEMM with a scheduled event starting a few hours in the future
helm template amazon-ec2-metadata-mock eks/amazon-ec2-metadata-mock \
  --set aemm.events.code="instance-reboot" \
  --set aemm.events.notAfter="2022-07-19T23:00:00Z" \
  --set aemm.events.notBefore="2022-07-19T22:25:00Z" \
  --set aemm.events.notBeforeDeadline="2022-07-19T22:30:00Z" \
  --set aemm.events.state="active" \
| kubectl apply -f -

# Verify that AEMM is serving the scheduled event with the correct times per our configuration
kubectl port-forward pod/<AEMM_pod_name> 1338:1338
open http://localhost:1338/latest/meta-data/events/maintenance/scheduled

# Install the latest release of NTH, instruct it to use AEMM, and have it listen for scheduled events but not Spot ITNs
helm template aws-node-termination-handler eks/aws-node-termination-handler \
  --namespace kube-system \
  --set instanceMetadataURL="http://amazon-ec2-metadata-mock-service.default.svc.cluster.local:1338" \
  --set enableSpotInterruptionDraining="false" \
  --set enableScheduledEventDraining="true" \
| kubectl apply -f -

# Verify that NTH received the scheduled event, but that it's in the future
kubectl logs <NTH_pod_name> --namespace kube-system

# Wait a few minutes and verify that no pods have been cordoned or drained
kubectl get nodes

# Build NTH with the changes in this PR
make build-binaries

# Find the repo name and tag of the image just built
docker images

# Import that image into the kind cluster
kind load docker-image bin-build:v1.16.4-10-g8297c93-linux-amd64

# Install the local build of NTH with the same options as before
helm template aws-node-termination-handler ./config/helm/aws-node-termination-handler \
  --namespace kube-system \
  --set image.repository="bin-build" \
  --set image.tag="v1.16.4-10-g8297c93-linux-amd64" \
  --set instanceMetadataURL="http://amazon-ec2-metadata-mock-service.default.svc.cluster.local:1338" \
  --set enableSpotInterruptionDraining="false" \
  --set enableScheduledEventDraining="true" \
| kubectl apply -f -

# Verify that NTH received the scheduled event, and that its StartTime is now
kubectl logs <NTH_pod_name> --namespace kube-system

# Wait a few minutes and verify that the worker nodes get cordoned and drained
# This will show SchedulingDisabled, and k9s will show pods getting restarted
kubectl get nodes
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
