### PR TITLE
Remove runAsUser in helm template for windows node

### DIFF
--- a/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -52,7 +52,7 @@ spec:
       {{- end }}
       containers:
         - name: aws-node-termination-handler
-          {{- with .Values.securityContext }}
+          {{- with unset .Values.securityContext "runAsUser" }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
**Issue #595**

**Description of changes:**

Remove `runAsUser` from `securityContext` map on Windows daemonset.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
