### PR TITLE
chore(README): add hint about EKS managed node groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The aws-node-termination-handler **[Instance Metadata Service](https://docs.aws.
 
 The aws-node-termination-handler **Queue Processor** will monitor an SQS queue of events from Amazon EventBridge for ASG lifecycle events, EC2 status change events, Spot Interruption Termination Notice events, and Spot Rebalance Recommendation events. When NTH detects an instance is going down, we use the Kubernetes API to cordon the node to ensure no new work is scheduled there, then drain it, removing any existing work. The termination handler **Queue Processor** requires AWS IAM permissions to monitor and manage the SQS queue and to query the EC2 API.
 
-You can run the termination handler on any Kubernetes cluster running on AWS, including self-managed clusters and those created with Amazon [Elastic Kubernetes Service](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html).
+You can run the termination handler on any Kubernetes cluster running on AWS, including self-managed clusters and those created with Amazon [Elastic Kubernetes Service](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html). If you're using [EKS managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html), you don't need the aws-node-termination-handler.
 
 ## Major Features
 


### PR DESCRIPTION
**Issue:**

The Investigation if NTH is mandatory on EKS managed node groups took me few days. README.md is missing when it's recommended to deploy NTH - according to [issue](https://github.com/aws/aws-node-termination-handler/issues/186), it's pointless to deploy it on managed node groups. 

**Description of changes:**


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
