### PR TITLE
Filter managed non-ASG nodes by tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,19 +269,26 @@ $ aws autoscaling put-lifecycle-hook \
   --role-arn <your SQS access role ARN here>
 ```
 
-#### 3. Tag the ASGs:
+#### 3. Tag the ASGs and Instances:
 
-By default the aws-node-termination-handler will only manage terminations for ASGs tagged w/ `key=aws-node-termination-handler/managed`
+By default the aws-node-termination-handler will only manage terminations for instances tagged with `key=aws-node-termination-handler/managed`.
+The value of the key does not matter.
 
+To tag ASGs and propagate the tags to your instances (recommended):
 ```
 $ aws autoscaling create-or-update-tags \
   --tags ResourceId=my-auto-scaling-group,ResourceType=auto-scaling-group,Key=aws-node-termination-handler/managed,Value=,PropagateAtLaunch=true
 ```
 
-The value of the key does not matter.
+To tag an EC2 instance:
+```
+aws ec2 create-tags \
+    --resources i-1234567890abcdef0 \
+    --tags 'Key="aws-node-termination-handler/managed",Value='
+```
 
 This functionality is helpful in accounts where there are ASGs that do not run kubernetes nodes or you do not want aws-node-termination-handler to manage their termination lifecycle.
-However, if your account is dedicated to ASGs for your kubernetes cluster, then you can turn off the ASG tag check by setting the flag `--check-asg-tag-before-draining=false` or environment variable `CHECK_ASG_TAG_BEFORE_DRAINING=false`.
+However, if your account is dedicated to ASGs for your kubernetes cluster, then you can turn off the ASG tag check by setting the flag `--check-tag-before-draining=false` or environment variable `CHECK_TAG_BEFORE_DRAINING=false`.
 
 You can also control what resources NTH manages by adding the resource ARNs to your Amazon EventBridge rules.
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ $ aws autoscaling put-lifecycle-hook \
   --role-arn <your SQS access role ARN here>
 ```
 
-#### 3. Tag the ASGs and Instances:
+#### 3. Tag the Instances:
 
 By default the aws-node-termination-handler will only manage terminations for instances tagged with `key=aws-node-termination-handler/managed`.
 The value of the key does not matter.

--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -176,8 +176,8 @@ func main() {
 		log.Debug().Msgf("AWS Credentials retrieved from provider: %s", creds.ProviderName)
 
 		sqsMonitor := sqsevent.SQSMonitor{
-			CheckIfManaged:   nthConfig.CheckASGTagBeforeDraining,
-			ManagedAsgTag:    nthConfig.ManagedAsgTag,
+			CheckIfManaged:   nthConfig.CheckTagBeforeDraining,
+			ManagedTag:       nthConfig.ManagedTag,
 			QueueURL:         nthConfig.QueueURL,
 			InterruptionChan: interruptionChan,
 			CancelChan:       cancelChan,

--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -110,9 +110,9 @@ The configuration in this table applies to AWS Node Termination Handler in queue
 | `awsRegion`                  | If specified, use the AWS region for AWS API calls, else NTH will try to find the region through the `AWS_REGION` environment variable, IMDS, or the specified queue URL. | `""`                                   |
 | `queueURL`                   | Listens for messages on the specified SQS queue URL.                                                                                                                      | `""`                                   |
 | `workers`                    | The maximum amount of parallel event processors to handle concurrent events.                                                                                              | `10`                                   |
-| `checkASGTagBeforeDraining`  | If `true`, check that the instance is tagged with the `managedAsgTag` before draining the node. If `false`, disables calls ASG API.                                                                          | `true`                                 |
-| `managedAsgTag`              | The node tag to check if `checkASGTagBeforeDraining` is `true`.                                                                                                           | `aws-node-termination-handler/managed` |
-| `useProviderId`    | If `true`, fetch node name through Kubernetes node spec ProviderID instead of AWS event PrivateDnsHostname.                                                                                                    | `false`                                |
+| `checkTagBeforeDraining`     | If `true`, check that the instance is tagged with the `managedTag` before draining the node.                                                                              | `true`                                 |
+| `managedTag`                 | The node tag to check if `checkTagBeforeDraining` is `true`.                                                                                                              | `aws-node-termination-handler/managed` |
+| `useProviderId`              | If `true`, fetch node name through Kubernetes node spec ProviderID instead of AWS event PrivateDnsHostname.                                                               | `false`                                |
 
 ### IMDS Mode Configuration
 

--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -112,6 +112,8 @@ The configuration in this table applies to AWS Node Termination Handler in queue
 | `workers`                    | The maximum amount of parallel event processors to handle concurrent events.                                                                                              | `10`                                   |
 | `checkTagBeforeDraining`     | If `true`, check that the instance is tagged with the `managedTag` before draining the node.                                                                              | `true`                                 |
 | `managedTag`                 | The node tag to check if `checkTagBeforeDraining` is `true`.                                                                                                              | `aws-node-termination-handler/managed` |
+| `checkASGTagBeforeDraining`  | [DEPRECATED](Use `checkTagBeforeDraining` instead) If `true`, check that the instance is tagged with the `managedAsgTag` before draining the node. If `false`, disables calls ASG API.                                                                          | `true`                                 |
+| `managedAsgTag`              | [DEPRECATED](Use `managedTag` instead) The node tag to check if `checkASGTagBeforeDraining` is `true`.     
 | `useProviderId`              | If `true`, fetch node name through Kubernetes node spec ProviderID instead of AWS event PrivateDnsHostname.                                                               | `false`                                |
 
 ### IMDS Mode Configuration

--- a/config/helm/aws-node-termination-handler/templates/deployment.yaml
+++ b/config/helm/aws-node-termination-handler/templates/deployment.yaml
@@ -82,10 +82,10 @@ spec:
               value: {{ .Values.enablePrometheusServer | quote }}
             - name: PROMETHEUS_SERVER_PORT
               value: {{ .Values.prometheusServerPort | quote }}
-            - name: CHECK_ASG_TAG_BEFORE_DRAINING
-              value: {{ .Values.checkASGTagBeforeDraining | quote }}
-            - name: MANAGED_ASG_TAG
-              value: {{ .Values.managedAsgTag | quote }}
+            - name: CHECK_TAG_BEFORE_DRAINING
+              value: {{ .Values.checkTagBeforeDraining | quote }}
+            - name: MANAGED_TAG
+              value: {{ .Values.managedTag | quote }}
             - name: USE_PROVIDER_ID
               value: {{ .Values.useProviderId | quote }}
             - name: DRY_RUN

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -171,11 +171,10 @@ queueURL: ""
 workers: 10
 
 # If true, check that the instance is tagged with "aws-node-termination-handler/managed" as the key before draining the node
-# If false, disables calls to ASG API.
-checkASGTagBeforeDraining: true
+checkTagBeforeDraining: true
 
-# The tag to ensure is on a node if checkASGTagBeforeDraining is true
-managedAsgTag: "aws-node-termination-handler/managed"
+# The tag to ensure is on a node if checkTagBeforeDraining is true
+managedTag: "aws-node-termination-handler/managed"
 
 # If true, fetch node name through Kubernetes node spec ProviderID instead of AWS event PrivateDnsHostname.
 useProviderId: false

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -184,9 +184,9 @@ func ParseCliArgs() (config Config, err error) {
 	flag.BoolVar(&config.EnableSQSTerminationDraining, "enable-sqs-termination-draining", getBoolEnv(enableSQSTerminationDrainingConfigKey, enableSQSTerminationDrainingDefault), "If true, drain nodes when an SQS termination event is received")
 	flag.BoolVar(&config.EnableRebalanceMonitoring, "enable-rebalance-monitoring", getBoolEnv(enableRebalanceMonitoringConfigKey, enableRebalanceMonitoringDefault), "If true, cordon nodes when the rebalance recommendation notice is received. If you'd like to drain the node in addition to cordoning, then also set \"enableRebalanceDraining\".")
 	flag.BoolVar(&config.EnableRebalanceDraining, "enable-rebalance-draining", getBoolEnv(enableRebalanceDrainingConfigKey, enableRebalanceDrainingDefault), "If true, drain nodes when the rebalance recommendation notice is received")
-	flag.BoolVar(&config.CheckASGTagBeforeDraining, "check-asg-tag-before-draining", getBoolEnv(checkASGTagBeforeDrainingConfigKey, checkASGTagBeforeDrainingDefault), "[DEPRECATED] * Use check-tag-before-draining instead * If true, check that the instance is tagged with \"aws-node-termination-handler/managed\" as the key before draining the node. If false, disables calls to ASG API.") // austin: mark as deprecated, same as grace-period
-	flag.BoolVar(&config.CheckTagBeforeDraining, "check-tag-before-draining", getBoolEnv(checkTagBeforeDrainingConfigKey, checkTagBeforeDrainingDefault), "If true, check that the instance is tagged with \"aws-node-termination-handler/managed\" as the key before draining the node.")                                                                                                          // austin: mark as deprecated, same as grace-period
-	flag.StringVar(&config.ManagedAsgTag, "managed-asg-tag", getEnv(managedAsgTagConfigKey, managedAsgTagDefault), "[DEPRECATED] * Use managed-tag instead * Sets the tag to check instances for that is propogated from the ASG before taking action, default to aws-node-termination-handler/managed")                                                                                            // austin: mark as deprecated, same as grace-period
+	flag.BoolVar(&config.CheckASGTagBeforeDraining, "check-asg-tag-before-draining", getBoolEnv(checkASGTagBeforeDrainingConfigKey, checkASGTagBeforeDrainingDefault), "[DEPRECATED] * Use check-tag-before-draining instead * If true, check that the instance is tagged with \"aws-node-termination-handler/managed\" as the key before draining the node. If false, disables calls to ASG API.")
+	flag.BoolVar(&config.CheckTagBeforeDraining, "check-tag-before-draining", getBoolEnv(checkTagBeforeDrainingConfigKey, checkTagBeforeDrainingDefault), "If true, check that the instance is tagged with \"aws-node-termination-handler/managed\" as the key before draining the node.")
+	flag.StringVar(&config.ManagedAsgTag, "managed-asg-tag", getEnv(managedAsgTagConfigKey, managedAsgTagDefault), "[DEPRECATED] * Use managed-tag instead * Sets the tag to check instances for that is propogated from the ASG before taking action, default to aws-node-termination-handler/managed")
 	flag.StringVar(&config.ManagedTag, "managed-tag", getEnv(managedTagConfigKey, managedTagDefault), "Sets the tag to check instances for before taking action, default to aws-node-termination-handler/managed")
 	flag.IntVar(&config.MetadataTries, "metadata-tries", getIntEnv(metadataTriesConfigKey, metadataTriesDefault), "The number of times to try requesting metadata. If you would like 2 retries, set metadata-tries to 3.")
 	flag.BoolVar(&config.CordonOnly, "cordon-only", getBoolEnv(cordonOnly, false), "If true, nodes will be cordoned but not drained when an interruption event occurs.")
@@ -218,14 +218,14 @@ func ParseCliArgs() (config Config, err error) {
 	}
 
 	if isConfigProvided("managed-asg-tag", managedAsgTagConfigKey) && isConfigProvided("managed-tag", managedTagConfigKey) {
-		log.Warn().Msg("Deprecated argument \"managed-asg-tag\" and the replacement argument \"managed-tag\" was provided. Using the newer argument \"managed-tag\"") // austin: check that user is expected to provide these similar to grace period
+		log.Warn().Msg("Deprecated argument \"managed-asg-tag\" and the replacement argument \"managed-tag\" was provided. Using the newer argument \"managed-tag\"")
 	} else if isConfigProvided("managed-asg-tag", managedAsgTagConfigKey) {
 		log.Warn().Msg("Deprecated argument \"managed-asg-tag\" was provided. This argument will eventually be removed. Please switch to \"managed-tag\" instead.")
 		config.ManagedTag = config.ManagedAsgTag
 	}
 
 	if isConfigProvided("check-asg-tag-before-draining", checkASGTagBeforeDrainingConfigKey) && isConfigProvided("check-tag-before-draining", checkTagBeforeDrainingConfigKey) {
-		log.Warn().Msg("Deprecated argument \"check-asg-tag-before-draining\" and the replacement argument \"check-tag-before-draining\" was provided. Using the newer argument \"check-tag-before-draining\"") // austin: check that user is expected to provide these similar to grace period
+		log.Warn().Msg("Deprecated argument \"check-asg-tag-before-draining\" and the replacement argument \"check-tag-before-draining\" was provided. Using the newer argument \"check-tag-before-draining\"")
 	} else if isConfigProvided("check-asg-tag-before-draining", checkASGTagBeforeDrainingConfigKey) {
 		log.Warn().Msg("Deprecated argument \"check-asg-tag-before-draining\" was provided. This argument will eventually be removed. Please switch to \"check-tag-before-draining\" instead.")
 		config.CheckTagBeforeDraining = config.CheckASGTagBeforeDraining

--- a/pkg/monitor/sqsevent/sqs-monitor.go
+++ b/pkg/monitor/sqsevent/sqs-monitor.go
@@ -353,7 +353,7 @@ func (m SQSMonitor) getNodeInfo(instanceID string) (*NodeInfo, error) {
 	}
 
 	if m.CheckIfManaged {
-		if _, ok := nodeInfo.Tags[m.ManagedTag]; !ok { // austin: wait, the presence of this should be a good sign...how did this ever work?
+		if _, ok := nodeInfo.Tags[m.ManagedTag]; !ok {
 			nodeInfo.IsManaged = false
 		}
 	}

--- a/pkg/monitor/sqsevent/sqs-monitor.go
+++ b/pkg/monitor/sqsevent/sqs-monitor.go
@@ -21,7 +21,6 @@ import (
 	"github.com/aws/aws-node-termination-handler/pkg/monitor"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
@@ -353,78 +352,12 @@ func (m SQSMonitor) getNodeInfo(instanceID string) (*NodeInfo, error) {
 		}
 	}
 
-	if m.CheckIfManaged {
-		if nodeInfo.AsgName == "" {
-			// If ASG tags are not propagated we might need to use the API
-			// to retrieve the ASG name
-			nodeInfo.AsgName, err = m.retrieveAutoScalingGroupName(nodeInfo.InstanceID)
-			if err != nil {
-				return nil, fmt.Errorf("unable to retrieve AutoScaling group: %w", err)
-			}
-		}
-		if nodeInfo.Tags[m.ManagedAsgTag] == "" {
-			// if ASG tags are not propagated we might have to check the ASG directly
-			nodeInfo.IsManaged, err = m.isASGManaged(nodeInfo.AsgName, nodeInfo.InstanceID)
-			if err != nil {
-				return nil, err
-			}
-		}
+	if m.CheckIfManaged && nodeInfo.Tags[m.ManagedAsgTag] == "" {
+		nodeInfo.IsManaged = false
 	}
 
 	infoJSON, _ := json.MarshalIndent(nodeInfo, " ", "    ")
 	log.Debug().Msgf("Got node info from AWS: %s", infoJSON)
 
 	return nodeInfo, nil
-}
-
-// isASGManaged returns whether the autoscaling group should be managed by node termination handler
-func (m SQSMonitor) isASGManaged(asgName string, instanceID string) (bool, error) {
-	if asgName == "" {
-		return false, nil
-	}
-	asgFilter := autoscaling.Filter{Name: aws.String("auto-scaling-group"), Values: []*string{aws.String(asgName)}}
-	asgDescribeTagsInput := autoscaling.DescribeTagsInput{
-		Filters: []*autoscaling.Filter{&asgFilter},
-	}
-	isManaged := false
-	err := m.ASG.DescribeTagsPages(&asgDescribeTagsInput, func(resp *autoscaling.DescribeTagsOutput, next bool) bool {
-		for _, tag := range resp.Tags {
-			if *tag.Key == m.ManagedAsgTag {
-				isManaged = true
-				// breaks paging loop
-				return false
-			}
-		}
-		// continue paging loop
-		return true
-	})
-
-	log.Debug().
-		Str("instance_id", instanceID).
-		Str("tag_key", m.ManagedAsgTag).
-		Bool("is_managed", isManaged).
-		Msg("directly checked if instance's Auto Scaling Group is managed")
-	return isManaged, err
-}
-
-// retrieveAutoScalingGroupName returns the autoscaling group name for a given instanceID
-func (m SQSMonitor) retrieveAutoScalingGroupName(instanceID string) (string, error) {
-	asgDescribeInstanceInput := autoscaling.DescribeAutoScalingInstancesInput{
-		InstanceIds: []*string{&instanceID},
-		MaxRecords:  aws.Int64(50),
-	}
-	asgs, err := m.ASG.DescribeAutoScalingInstances(&asgDescribeInstanceInput)
-	if err != nil {
-		return "", err
-	}
-	if len(asgs.AutoScalingInstances) == 0 {
-		log.Debug().Str("instance_id", instanceID).Msg("Did not find an Auto Scaling Group for the given instance id")
-		return "", nil
-	}
-	asgName := asgs.AutoScalingInstances[0].AutoScalingGroupName
-	log.Debug().
-		Str("instance_id", instanceID).
-		Str("asg_name", *asgName).
-		Msg("performed API lookup of instance ASG")
-	return *asgName, nil
 }

--- a/pkg/monitor/sqsevent/sqs-monitor_internal_test.go
+++ b/pkg/monitor/sqsevent/sqs-monitor_internal_test.go
@@ -134,7 +134,7 @@ func TestGetNodeInfo_ASG(t *testing.T) {
 	h.Equals(t, true, nodeInfo.IsManaged)
 }
 
-func TestGetNodeInfo_ASG_ASGManaged(t *testing.T) { // austin: may be root cause of failures
+func TestGetNodeInfo_ASG_ASGManaged(t *testing.T) {
 	asgName := "test-asg"
 	managedTag := "aws-nth/managed"
 	tags := map[string]string{managedTag: "", "aws:autoscaling:groupName": asgName}

--- a/pkg/monitor/sqsevent/sqs-monitor_internal_test.go
+++ b/pkg/monitor/sqsevent/sqs-monitor_internal_test.go
@@ -83,60 +83,6 @@ func TestGetNodeInfo_BothTags_Managed(t *testing.T) {
 	h.Equals(t, true, nodeInfo.IsManaged)
 }
 
-func TestGetNodeInfo_ASGTag_ASGNotManaged(t *testing.T) {
-	ec2Mock := h.MockedEC2{
-		DescribeInstancesResp: getDescribeInstancesResp(
-			"i-beebeebe",
-			"mydns.example.com",
-			map[string]string{
-				ASGTagName: "test-asg",
-			}),
-	}
-	asgMock := h.MockedASG{
-		DescribeTagsPagesResp: autoscaling.DescribeTagsOutput{
-			Tags: []*autoscaling.TagDescription{},
-		},
-	}
-	monitor := SQSMonitor{
-		EC2:            ec2Mock,
-		ASG:            asgMock,
-		CheckIfManaged: true,
-		ManagedTag:     "aws-nth/managed",
-	}
-	nodeInfo, err := monitor.getNodeInfo("i-0123456789")
-	h.Ok(t, err)
-	h.Equals(t, "test-asg", nodeInfo.AsgName)
-	h.Equals(t, false, nodeInfo.IsManaged)
-}
-
-func TestGetNodeInfo_ASGTag_ASGManaged(t *testing.T) {
-	ec2Mock := h.MockedEC2{
-		DescribeInstancesResp: getDescribeInstancesResp(
-			"i-beebeebe",
-			"mydns.example.com",
-			map[string]string{
-				ASGTagName: "test-asg",
-			}),
-	}
-	asgMock := h.MockedASG{
-		DescribeTagsPagesResp: autoscaling.DescribeTagsOutput{
-			Tags: []*autoscaling.TagDescription{
-				{Key: aws.String("aws-nth/managed")},
-			},
-		},
-	}
-	monitor := SQSMonitor{
-		EC2:            ec2Mock,
-		ASG:            asgMock,
-		CheckIfManaged: true,
-		ManagedTag:     "aws-nth/managed",
-	}
-	nodeInfo, err := monitor.getNodeInfo("i-0123456789")
-	h.Ok(t, err)
-	h.Equals(t, "test-asg", nodeInfo.AsgName)
-	h.Equals(t, true, nodeInfo.IsManaged)
-}
-
 func TestGetNodeInfo_NoASG_Managed(t *testing.T) {
 	ec2Mock := h.MockedEC2{
 		DescribeInstancesResp: getDescribeInstancesResp("i-beebeebe", "mydns.example.com", map[string]string{}),

--- a/pkg/monitor/sqsevent/sqs-monitor_test.go
+++ b/pkg/monitor/sqsevent/sqs-monitor_test.go
@@ -902,11 +902,3 @@ func mockIsManagedFalse(asg *h.MockedASG) h.MockedASG {
 	}
 	return *asg
 }
-
-func mockIsManagedErr(asg *h.MockedASG) h.MockedASG {
-	if asg == nil {
-		asg = &h.MockedASG{}
-	}
-	asg.DescribeAutoScalingInstancesErr = fmt.Errorf("error")
-	return *asg
-}

--- a/pkg/monitor/sqsevent/sqs-monitor_test.go
+++ b/pkg/monitor/sqsevent/sqs-monitor_test.go
@@ -147,7 +147,7 @@ func TestMonitor_EventBridgeSuccess(t *testing.T) {
 		sqsMonitor := sqsevent.SQSMonitor{
 			SQS:              sqsMock,
 			EC2:              ec2Mock,
-			ManagedAsgTag:    "aws-node-termination-handler/managed",
+			ManagedTag:       "aws-node-termination-handler/managed",
 			ASG:              mockIsManagedTrue(nil),
 			CheckIfManaged:   true,
 			QueueURL:         "https://test-queue",
@@ -191,7 +191,7 @@ func TestMonitor_EventBridgeTestNotification(t *testing.T) {
 	sqsMonitor := sqsevent.SQSMonitor{
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
-		ManagedAsgTag:    "aws-node-termination-handler/managed",
+		ManagedTag:       "aws-node-termination-handler/managed",
 		ASG:              mockIsManagedFalse(nil),
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
@@ -232,7 +232,7 @@ func TestMonitor_AsgDirectToSqsSuccess(t *testing.T) {
 	sqsMonitor := sqsevent.SQSMonitor{
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
-		ManagedAsgTag:    "aws-node-termination-handler/managed",
+		ManagedTag:       "aws-node-termination-handler/managed",
 		ASG:              mockIsManagedTrue(nil),
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
@@ -278,7 +278,7 @@ func TestMonitor_AsgDirectToSqsTestNotification(t *testing.T) {
 	sqsMonitor := sqsevent.SQSMonitor{
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
-		ManagedAsgTag:    "aws-node-termination-handler/managed",
+		ManagedTag:       "aws-node-termination-handler/managed",
 		ASG:              mockIsManagedFalse(nil),
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
@@ -322,7 +322,7 @@ func TestMonitor_DrainTasks(t *testing.T) {
 	sqsMonitor := sqsevent.SQSMonitor{
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
-		ManagedAsgTag:    "aws-node-termination-handler/managed",
+		ManagedTag:       "aws-node-termination-handler/managed",
 		ASG:              mockIsManagedTrue(&asgMock),
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
@@ -371,7 +371,7 @@ func TestMonitor_DrainTasks_Errors(t *testing.T) {
 	sqsMonitor := sqsevent.SQSMonitor{
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
-		ManagedAsgTag:    "aws-node-termination-handler/managed",
+		ManagedTag:       "aws-node-termination-handler/managed",
 		ASG:              mockIsManagedTrue(&asgMock),
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
@@ -424,7 +424,7 @@ func TestMonitor_DrainTasksASGFailure(t *testing.T) {
 	sqsMonitor := sqsevent.SQSMonitor{
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
-		ManagedAsgTag:    "aws-node-termination-handler/managed",
+		ManagedTag:       "aws-node-termination-handler/managed",
 		ASG:              mockIsManagedTrue(&asgMock),
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
@@ -702,7 +702,7 @@ func TestMonitor_EC2NoDNSName(t *testing.T) {
 	sqsMonitor := sqsevent.SQSMonitor{
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
-		ManagedAsgTag:    "aws-node-termination-handler/managed",
+		ManagedTag:       "aws-node-termination-handler/managed",
 		ASG:              mockIsManagedTrue(nil),
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
@@ -742,7 +742,7 @@ func TestMonitor_EC2NoDNSNameOnTerminatedInstance(t *testing.T) {
 	sqsMonitor := sqsevent.SQSMonitor{
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
-		ManagedAsgTag:    "aws-node-termination-handler/managed",
+		ManagedTag:       "aws-node-termination-handler/managed",
 		ASG:              mockIsManagedTrue(nil),
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
@@ -780,7 +780,7 @@ func TestMonitor_SQSDeleteFailure(t *testing.T) {
 	sqsMonitor := sqsevent.SQSMonitor{
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
-		ManagedAsgTag:    "aws-node-termination-handler/managed",
+		ManagedTag:       "aws-node-termination-handler/managed",
 		ASG:              mockIsManagedTrue(nil),
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
@@ -817,9 +817,10 @@ func TestMonitor_InstanceNotManaged(t *testing.T) {
 		drainChan := make(chan monitor.InterruptionEvent, 1)
 
 		sqsMonitor := sqsevent.SQSMonitor{
-			SQS:              sqsMock,
-			EC2:              ec2Mock,
-			ASG:              mockIsManagedFalse(nil),
+			SQS: sqsMock,
+			EC2: ec2Mock,
+			// ASG:              mockIsManagedFalse(nil), // austin: this may be a faulty test case, instance not managed should not check asg
+			ManagedTag:       "aws-node-termination-handler/managed",
 			CheckIfManaged:   true,
 			QueueURL:         "https://test-queue",
 			InterruptionChan: drainChan,
@@ -858,7 +859,7 @@ func TestMonitor_InstanceManagedErr(t *testing.T) {
 		sqsMonitor := sqsevent.SQSMonitor{
 			SQS:              sqsMock,
 			EC2:              ec2Mock,
-			ASG:              mockIsManagedErr(nil),
+			ASG:              mockIsManagedErr(nil), // austin: no longer a valid way to confirm not managed
 			CheckIfManaged:   true,
 			QueueURL:         "https://test-queue",
 			InterruptionChan: drainChan,

--- a/pkg/monitor/sqsevent/sqs-monitor_test.go
+++ b/pkg/monitor/sqsevent/sqs-monitor_test.go
@@ -817,10 +817,9 @@ func TestMonitor_InstanceNotManaged(t *testing.T) {
 		drainChan := make(chan monitor.InterruptionEvent, 1)
 
 		sqsMonitor := sqsevent.SQSMonitor{
-			SQS: sqsMock,
-			EC2: ec2Mock,
-			// ASG:              mockIsManagedFalse(nil), // austin: this may be a faulty test case, instance not managed should not check asg
-			ManagedTag:       "aws-node-termination-handler/managed",
+			SQS:              sqsMock,
+			EC2:              ec2Mock,
+			ASG:              mockIsManagedFalse(nil),
 			CheckIfManaged:   true,
 			QueueURL:         "https://test-queue",
 			InterruptionChan: drainChan,

--- a/test/e2e/asg-lifecycle-sqs-test
+++ b/test/e2e/asg-lifecycle-sqs-test
@@ -42,7 +42,7 @@ set +x
 
 sleep 10
 
-RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed,Value=}]'"
+RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed}]'"
 localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="status.phase=Running" \
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \
                                   | awk '$2 >= "'"${START_TIME//+0000/Z}"'" { print $1 }')

--- a/test/e2e/asg-lifecycle-sqs-test
+++ b/test/e2e/asg-lifecycle-sqs-test
@@ -42,7 +42,7 @@ set +x
 
 sleep 10
 
-RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test}]'"
+RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed,Value=}]'"
 localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="status.phase=Running" \
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \
                                   | awk '$2 >= "'"${START_TIME//+0000/Z}"'" { print $1 }')

--- a/test/e2e/asg-lifecycle-sqs-test
+++ b/test/e2e/asg-lifecycle-sqs-test
@@ -42,7 +42,7 @@ set +x
 
 sleep 10
 
-RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed}]'"
+RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed,Value=blah}]'"
 localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="status.phase=Running" \
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \
                                   | awk '$2 >= "'"${START_TIME//+0000/Z}"'" { print $1 }')

--- a/test/e2e/ec2-state-change-sqs-test
+++ b/test/e2e/ec2-state-change-sqs-test
@@ -42,7 +42,7 @@ set +x
 
 sleep 10
 
-RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed}]'"
+RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed,Value=blah}]'"
 set -x
 localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="status.phase=Running" \
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \

--- a/test/e2e/ec2-state-change-sqs-test
+++ b/test/e2e/ec2-state-change-sqs-test
@@ -42,7 +42,7 @@ set +x
 
 sleep 10
 
-RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test}]'"
+RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed,Value=}]'"
 set -x
 localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="status.phase=Running" \
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \

--- a/test/e2e/ec2-state-change-sqs-test
+++ b/test/e2e/ec2-state-change-sqs-test
@@ -42,7 +42,7 @@ set +x
 
 sleep 10
 
-RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed,Value=}]'"
+RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed}]'"
 set -x
 localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="status.phase=Running" \
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \

--- a/test/e2e/rebalance-recommendation-sqs-test
+++ b/test/e2e/rebalance-recommendation-sqs-test
@@ -42,7 +42,7 @@ set +x
 
 sleep 10
 
-RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed,Value=}]'"
+RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed}]'"
 localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="status.phase=Running" \
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \
                                   | awk '$2 >= "'"${START_TIME//+0000/Z}"'" { print $1 }')

--- a/test/e2e/rebalance-recommendation-sqs-test
+++ b/test/e2e/rebalance-recommendation-sqs-test
@@ -42,7 +42,7 @@ set +x
 
 sleep 10
 
-RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test}]'"
+RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed,Value=}]'"
 localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="status.phase=Running" \
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \
                                   | awk '$2 >= "'"${START_TIME//+0000/Z}"'" { print $1 }')

--- a/test/e2e/rebalance-recommendation-sqs-test
+++ b/test/e2e/rebalance-recommendation-sqs-test
@@ -42,7 +42,7 @@ set +x
 
 sleep 10
 
-RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed}]'"
+RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed,Value=blah}]'"
 localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="status.phase=Running" \
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \
                                   | awk '$2 >= "'"${START_TIME//+0000/Z}"'" { print $1 }')

--- a/test/e2e/scheduled-change-event-sqs-test
+++ b/test/e2e/scheduled-change-event-sqs-test
@@ -42,7 +42,7 @@ set +x
 
 sleep 10
 
-RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed,Value=}]'"
+RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed}]'"
 localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="status.phase=Running" \
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \
                                   | awk '$2 >= "'"${START_TIME//+0000/Z}"'" { print $1 }')

--- a/test/e2e/scheduled-change-event-sqs-test
+++ b/test/e2e/scheduled-change-event-sqs-test
@@ -42,7 +42,7 @@ set +x
 
 sleep 10
 
-RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test}]'"
+RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed,Value=}]'"
 localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="status.phase=Running" \
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \
                                   | awk '$2 >= "'"${START_TIME//+0000/Z}"'" { print $1 }')

--- a/test/e2e/scheduled-change-event-sqs-test
+++ b/test/e2e/scheduled-change-event-sqs-test
@@ -42,7 +42,7 @@ set +x
 
 sleep 10
 
-RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed}]'"
+RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed,Value=blah}]'"
 localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="status.phase=Running" \
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \
                                   | awk '$2 >= "'"${START_TIME//+0000/Z}"'" { print $1 }')

--- a/test/e2e/spot-interruption-sqs-test
+++ b/test/e2e/spot-interruption-sqs-test
@@ -42,7 +42,7 @@ set +x
 
 sleep 10
 
-RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed,Value=}]'"
+RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed}]'"
 localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="status.phase=Running" \
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \
                                   | awk '$2 >= "'"${START_TIME//+0000/Z}"'" { print $1 }')

--- a/test/e2e/spot-interruption-sqs-test
+++ b/test/e2e/spot-interruption-sqs-test
@@ -42,7 +42,7 @@ set +x
 
 sleep 10
 
-RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test}]'"
+RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed,Value=}]'"
 localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="status.phase=Running" \
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \
                                   | awk '$2 >= "'"${START_TIME//+0000/Z}"'" { print $1 }')

--- a/test/e2e/spot-interruption-sqs-test
+++ b/test/e2e/spot-interruption-sqs-test
@@ -42,7 +42,7 @@ set +x
 
 sleep 10
 
-RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed}]'"
+RUN_INSTANCE_CMD="awslocal ec2 run-instances --private-ip-address ${WORKER_IP} --region ${AWS_REGION} --tag-specifications 'ResourceType=instance,Tags=[{Key=aws:autoscaling:groupName,Value=nth-integ-test},{Key=aws-node-termination-handler/managed,Value=blah}]'"
 localstack_pod=$(kubectl get pods --selector app=localstack --field-selector="status.phase=Running" \
                                   -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' \
                                   | awk '$2 >= "'"${START_TIME//+0000/Z}"'" { print $1 }')


### PR DESCRIPTION
**Issue #, if available:** #654

**Description of changes:**
* Replaced fields `check-asg-tag-before-draining` and `managed-asg-tag` with `check-tag-before-draining` and `managed-tag`, updated docs to mark them as deprecated, and removed them from charts
* Removed ASG api calls to fetch ASG info when determining whether a node should be managed by NTH.
* Fixed bug where the presence of the `managedAsgTag/managedTag` on an instance wouldn't be checked correctly before deferring to ASG lookup

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
