### PR TITLE
Update golangci linter to v1.48 for go 1.19 support

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: v1.45.2
+          version: v1.48.0
           args: --timeout=5m
     
   buildLinux:


### PR DESCRIPTION
**Issue #, if available:** 

**Description of changes:**
golangci/lint added support for go 1.19 in [v1.48](https://github.com/golangci/golangci-lint/releases/tag/v1.48.0). 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
