### PR TITLE
CICD improvements: update golangci-lint & go proxy fallback

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -13,7 +13,7 @@ on:
     - cron: '0 19 * * 1-5'
 
 env:
-  DEFAULT_GO_VERSION: ^1.16
+  DEFAULT_GO_VERSION: 1.16
   GITHUB_USERNAME: ${{ secrets.EC2_BOT_GITHUB_USERNAME }}
   GITHUB_TOKEN: ${{ secrets.EC2_BOT_GITHUB_TOKEN }}
   WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
@@ -61,10 +61,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.2
+        uses: golangci/golangci-lint-action@v3.2.0
         with:
           version: v1.45.2
           args: --timeout=5m
+          skip-cache: true
     
   buildLinux:
     name: Build Linux Binaries

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ fmt:
 	goimports -w ./ && gofmt -s -w ./
 
 docker-build:
-	${MAKEFILE_PATH}/scripts/build-docker-images -d -p ${GOOS}/${GOARCH} -r ${IMG} -v ${VERSION}
+	${MAKEFILE_PATH}/scripts/build-docker-images -p ${GOOS}/${GOARCH} -r ${IMG} -v ${VERSION}
 
 docker-run:
 	docker run ${IMG_W_TAG}
@@ -93,10 +93,10 @@ helm-validate-eks-versions:
 	${MAKEFILE_PATH}/test/helm/validate-chart-versions
 
 build-binaries:
-	${MAKEFILE_PATH}/scripts/build-binaries -p ${SUPPORTED_PLATFORMS_LINUX} -v ${VERSION} -d
+	${MAKEFILE_PATH}/scripts/build-binaries -p ${SUPPORTED_PLATFORMS_LINUX} -v ${VERSION}
 
 build-binaries-windows:
-	${MAKEFILE_PATH}/scripts/build-binaries -p ${SUPPORTED_PLATFORMS_WINDOWS} -v ${VERSION} -d
+	${MAKEFILE_PATH}/scripts/build-binaries -p ${SUPPORTED_PLATFORMS_WINDOWS} -v ${VERSION}
 
 upload-resources-to-github:
 	${MAKEFILE_PATH}/scripts/upload-resources-to-github

--- a/scripts/build-binaries
+++ b/scripts/build-binaries
@@ -11,7 +11,6 @@ mkdir -p $BIN_DIR
 VERSION=$(make -s -f $MAKE_FILE_PATH version)
 BASE_BIN_NAME=$(make -s -f $MAKE_FILE_PATH binary-name)
 PLATFORMS=("linux/amd64")
-PASS_THRU_ARGS=""
 
 USAGE=$(cat << 'EOM'
   Usage: build-binaries  [-p <platform pairs>]
@@ -21,19 +20,15 @@ USAGE=$(cat << 'EOM'
           Optional:
             -b          Base bin name [DEFAULT: output of "make binary-name"]
             -p          Platform pair list (os/architecture) [DEFAULT: linux/amd64]
-            -d          DIRECT: Set GOPROXY=direct to bypass go proxies
             -v          VERSION: The application version of the docker image [DEFAULT: output of `make version`]
 EOM
 )
 
 # Process our input arguments
-while getopts "dp:v:b:" opt; do
+while getopts "p:v:b:" opt; do
   case ${opt} in
     p ) # Platform Pairs
         IFS=',' read -ra PLATFORMS <<< "$OPTARG"
-      ;;
-    d ) # sets GOPROXY=direct
-        PASS_THRU_ARGS="$PASS_THRU_ARGS -d"
       ;;
     v ) # Image Version
         VERSION="$OPTARG"
@@ -61,7 +56,7 @@ for os_arch in "${PLATFORMS[@]}"; do
     fi
 
     docker container rm $container_name || :
-    $SCRIPTPATH/build-docker-images -p $os_arch -v $VERSION -r $repo_name $PASS_THRU_ARGS
+    $SCRIPTPATH/build-docker-images -p $os_arch -v $VERSION -r $repo_name
     docker container create --rm --name $container_name "$repo_name:$VERSION-$os-$arch"
     docker container cp $container_name:/${BASE_BIN_NAME} $BIN_DIR/$bin_name
 

--- a/scripts/build-docker-images
+++ b/scripts/build-docker-images
@@ -9,7 +9,7 @@ DOCKERFILE_PATH=$REPO_ROOT_PATH/Dockerfile
 
 VERSION=$(make -s -f $MAKE_FILE_PATH version)
 PLATFORMS=("linux/amd64")
-GOPROXY="https://proxy.golang.org,direct"
+GOPROXY="direct|https://proxy.golang.org"
 
 
 USAGE=$(cat << 'EOM'

--- a/scripts/build-docker-images
+++ b/scripts/build-docker-images
@@ -19,20 +19,16 @@ USAGE=$(cat << 'EOM'
   Example: build-docker-images -p "linux/amd64,linux/arm"
           Optional:
             -p          Platform pair list (os/architecture) [DEFAULT: linux/amd64]
-            -d          DIRECT: Set GOPROXY=direct to bypass go proxies
             -r          IMAGE REPO: set the docker image repo
             -v          VERSION: The application version of the docker image [DEFAULT: output of `make version`]
 EOM
 )
 
 # Process our input arguments
-while getopts "dp:r:v:" opt; do
+while getopts "p:r:v:" opt; do
   case ${opt} in
     p ) # Platform Pairs
         IFS=',' read -ra PLATFORMS <<< "$OPTARG"
-      ;;
-    d ) # GOPROXY=direct
-        GOPROXY="direct"
       ;;
     r ) # Image Repo
         IMAGE_REPO="$OPTARG"

--- a/test/license-test/run-license-test.sh
+++ b/test/license-test/run-license-test.sh
@@ -8,8 +8,9 @@ BUILD_BIN="$BUILD_PATH/bin"
 BINARY_NAME="node-termination-handler-linux-amd64"
 LICENSE_TEST_TAG="nth-license-test"
 LICENSE_REPORT_FILE="$BUILD_PATH/license-report"
+GOPROXY="direct|https://proxy.golang.org"
 
 SUPPORTED_PLATFORMS_LINUX="linux/amd64" make -s -f $SCRIPTPATH/../../Makefile build-binaries
-docker buildx build --load --build-arg=GOPROXY=direct -t $LICENSE_TEST_TAG $SCRIPTPATH/
+docker buildx build --load --build-arg=GOPROXY=${GOPROXY} -t $LICENSE_TEST_TAG $SCRIPTPATH/
 docker run -i -e GITHUB_TOKEN --rm -v $SCRIPTPATH/:/test -v $BUILD_BIN/:/nth-bin $LICENSE_TEST_TAG golicense /test/license-config.hcl /nth-bin/$BINARY_NAME | tee $LICENSE_REPORT_FILE
 $SCRIPTPATH/check-licenses.sh $LICENSE_REPORT_FILE


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:** Fix issues with linter job. fall back to go proxy (use direct first) so developers can start building immediately

**Related:**
* https://github.com/aws/aws-node-termination-handler/pull/672
* https://github.com/aws/amazon-ec2-instance-selector/commit/184e939e47216dfb0907b35030e3c12306fb1708


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
