### PR TITLE
helm: Apply extraEnv to daemonsets

### DIFF
--- a/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -151,6 +151,9 @@ spec:
               value: "false"
             - name: UPTIME_FROM_FILE
               value: {{ .Values.procUptimeFile | quote }}
+            {{- with .Values.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- if or .Values.enablePrometheusServer .Values.enableProbesServer }}
           ports:
           {{- if .Values.enableProbesServer }}

--- a/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.windows.yaml
@@ -149,6 +149,9 @@ spec:
               value: {{ .Values.enableRebalanceDraining | quote }}
             - name: ENABLE_SQS_TERMINATION_DRAINING
               value: "false"
+            {{- with .Values.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- if or .Values.enablePrometheusServer .Values.enableProbesServer }}
           ports:
           {{- if .Values.enableProbesServer }}


### PR DESCRIPTION
Looks like this was (accidentally I presume) removed in #540 

I *think* helm changes are made here and not on the eks-charts repo?
If that's not correct I'm happy to open this there instead!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
