### PR TITLE
divide log output between stdout and stderr

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-node-termination-handler/pkg/config"
 	"github.com/aws/aws-node-termination-handler/pkg/ec2metadata"
 	"github.com/aws/aws-node-termination-handler/pkg/interruptioneventstore"
+	"github.com/aws/aws-node-termination-handler/pkg/logging"
 	"github.com/aws/aws-node-termination-handler/pkg/monitor"
 	"github.com/aws/aws-node-termination-handler/pkg/monitor/rebalancerecommendation"
 	"github.com/aws/aws-node-termination-handler/pkg/monitor/scheduledevent"
@@ -56,7 +57,10 @@ const (
 
 func main() {
 	// Zerolog uses json formatting by default, so change that to a human-readable format instead
-	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: timeFormat, NoColor: true})
+	log.Logger = log.Output(logging.RoutingLevelWriter{
+		Writer:    &zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: timeFormat, NoColor: true},
+		ErrWriter: &zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: timeFormat, NoColor: true},
+	})
 
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGTERM)

--- a/pkg/logging/routing-integration_test.go
+++ b/pkg/logging/routing-integration_test.go
@@ -1,0 +1,69 @@
+// Copyright 2016-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logging_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-node-termination-handler/pkg/logging"
+	h "github.com/aws/aws-node-termination-handler/pkg/test"
+
+	"github.com/rs/zerolog/log"
+)
+
+func TestIntegration_zerologInfo(t *testing.T) {
+	buf := &strings.Builder{}
+	errBuf := &strings.Builder{}
+
+	l := log.Output(logging.RoutingLevelWriter{Writer: buf, ErrWriter: errBuf})
+
+	const s = "this is a test"
+	l.Info().Msg(s)
+
+	h.Equals(t, errBuf.Len(), 0)
+
+	h.Assert(t, buf.Len() > 0, "no message was written to the default location")
+	h.Assert(t, strings.Contains(buf.String(), s), "expected message not found in default location")
+}
+
+func TestIntegration_zerologWarn(t *testing.T) {
+	buf := &strings.Builder{}
+	errBuf := &strings.Builder{}
+
+	l := log.Output(logging.RoutingLevelWriter{Writer: buf, ErrWriter: errBuf})
+
+	const s = "this is a test"
+	l.Warn().Msg(s)
+
+	h.Equals(t, buf.Len(), 0)
+
+	h.Assert(t, errBuf.Len() > 0, "no message was written to the error location")
+	h.Assert(t, strings.Contains(errBuf.String(), s), "expected message not found in error location")
+}
+
+func TestIntegration_zerologError(t *testing.T) {
+	buf := &strings.Builder{}
+	errBuf := &strings.Builder{}
+
+	l := log.Output(logging.RoutingLevelWriter{Writer: buf, ErrWriter: errBuf})
+
+	const s = "this is a test"
+	l.Error().Msg(s)
+
+	h.Equals(t, buf.Len(), 0)
+
+	h.Assert(t, errBuf.Len() > 0, "no message was written to the error location")
+	h.Assert(t, strings.Contains(errBuf.String(), s), "expected message not found in error location")
+}

--- a/pkg/logging/routing.go
+++ b/pkg/logging/routing.go
@@ -1,0 +1,36 @@
+// Copyright 2016-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logging
+
+import (
+	"io"
+
+	"github.com/rs/zerolog"
+)
+
+// RoutingLevelWriter writes data to one of two locations based on an
+// associated level value.
+type RoutingLevelWriter struct {
+	io.Writer
+	ErrWriter io.Writer
+}
+
+// WriteLevel if *l* is warning or higher then *b* is written to the error
+// location, otherwise it is written to the default location.
+func (r RoutingLevelWriter) WriteLevel(l zerolog.Level, b []byte) (int, error) {
+	if l < zerolog.WarnLevel {
+		return r.Write(b)
+	}
+	return r.ErrWriter.Write(b)
+}

--- a/pkg/logging/routing_test.go
+++ b/pkg/logging/routing_test.go
@@ -1,0 +1,100 @@
+// Copyright 2016-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package logging_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-node-termination-handler/pkg/logging"
+	h "github.com/aws/aws-node-termination-handler/pkg/test"
+
+	"github.com/rs/zerolog"
+)
+
+func TestWrite(t *testing.T) {
+	buf := &strings.Builder{}
+	errBuf := &strings.Builder{}
+
+	r := logging.RoutingLevelWriter{Writer: buf, ErrWriter: errBuf}
+
+	const s = "this is a test"
+	p := []byte(s)
+	n, err := r.Write(p)
+
+	h.Ok(t, err)
+	h.Equals(t, len(p), n)
+
+	h.Equals(t, errBuf.Len(), 0)
+
+	h.Assert(t, buf.Len() > 0, "no message was written to the default location")
+	h.Assert(t, strings.Contains(buf.String(), s), "expected message not found in default location")
+}
+
+func TestWriteLevel_lessThanWarning(t *testing.T) {
+	buf := &strings.Builder{}
+	errBuf := &strings.Builder{}
+
+	r := logging.RoutingLevelWriter{Writer: buf, ErrWriter: errBuf}
+
+	const s = "this is a test"
+	p := []byte(s)
+	n, err := r.WriteLevel(zerolog.InfoLevel, p)
+
+	h.Ok(t, err)
+	h.Equals(t, len(p), n)
+
+	h.Equals(t, errBuf.Len(), 0)
+
+	h.Assert(t, buf.Len() > 0, "no message was written to the default location")
+	h.Assert(t, strings.Contains(buf.String(), s), "expected message not found in default location")
+}
+
+func TestWriteLevel_warning(t *testing.T) {
+	buf := &strings.Builder{}
+	errBuf := &strings.Builder{}
+
+	r := logging.RoutingLevelWriter{Writer: buf, ErrWriter: errBuf}
+
+	const s = "this is a test"
+	p := []byte(s)
+	n, err := r.WriteLevel(zerolog.WarnLevel, p)
+
+	h.Ok(t, err)
+	h.Equals(t, len(p), n)
+
+	h.Equals(t, buf.Len(), 0)
+
+	h.Assert(t, errBuf.Len() > 0, "no message was written to the error location")
+	h.Assert(t, strings.Contains(errBuf.String(), s), "expected message not found in error location")
+}
+
+func TestWriteLevel_greaterThanWarning(t *testing.T) {
+	buf := &strings.Builder{}
+	errBuf := &strings.Builder{}
+
+	r := logging.RoutingLevelWriter{Writer: buf, ErrWriter: errBuf}
+
+	const s = "this is a test"
+	p := []byte(s)
+	n, err := r.WriteLevel(zerolog.ErrorLevel, p)
+
+	h.Ok(t, err)
+	h.Equals(t, len(p), n)
+
+	h.Equals(t, buf.Len(), 0)
+
+	h.Assert(t, errBuf.Len() > 0, "no message was written to the error location")
+	h.Assert(t, strings.Contains(errBuf.String(), s), "expected message not found in error location")
+}


### PR DESCRIPTION
**Issue #, if available:**

#667 Node Termination Handler only logs to stderr

**Description of changes:**

Route messages of warning or higher to stderr, everything else to stdout.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
