### PR TITLE
Remove unit test functions that mock ASG managed tag

### DIFF
--- a/pkg/monitor/sqsevent/sqs-monitor_test.go
+++ b/pkg/monitor/sqsevent/sqs-monitor_test.go
@@ -148,7 +148,7 @@ func TestMonitor_EventBridgeSuccess(t *testing.T) {
 			SQS:              sqsMock,
 			EC2:              ec2Mock,
 			ManagedTag:       "aws-node-termination-handler/managed",
-			ASG:              mockIsManagedTrue(nil),
+			ASG:              &h.MockedASG{},
 			CheckIfManaged:   true,
 			QueueURL:         "https://test-queue",
 			InterruptionChan: drainChan,
@@ -192,7 +192,6 @@ func TestMonitor_EventBridgeTestNotification(t *testing.T) {
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
 		ManagedTag:       "aws-node-termination-handler/managed",
-		ASG:              mockIsManagedFalse(nil),
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
 		InterruptionChan: drainChan,
@@ -233,7 +232,7 @@ func TestMonitor_AsgDirectToSqsSuccess(t *testing.T) {
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
 		ManagedTag:       "aws-node-termination-handler/managed",
-		ASG:              mockIsManagedTrue(nil),
+		ASG:              &h.MockedASG{},
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
 		InterruptionChan: drainChan,
@@ -279,7 +278,6 @@ func TestMonitor_AsgDirectToSqsTestNotification(t *testing.T) {
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
 		ManagedTag:       "aws-node-termination-handler/managed",
-		ASG:              mockIsManagedFalse(nil),
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
 		InterruptionChan: drainChan,
@@ -323,7 +321,7 @@ func TestMonitor_DrainTasks(t *testing.T) {
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
 		ManagedTag:       "aws-node-termination-handler/managed",
-		ASG:              mockIsManagedTrue(&asgMock),
+		ASG:              asgMock,
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
 		InterruptionChan: drainChan,
@@ -368,7 +366,7 @@ func TestMonitor_DrainTasks_Delay(t *testing.T) {
 		SQS:                           sqsMock,
 		EC2:                           ec2Mock,
 		ManagedTag:                    "aws-node-termination-handler/managed",
-		ASG:                           mockIsManagedTrue(&asgMock),
+		ASG:                           asgMock,
 		CheckIfManaged:                true,
 		QueueURL:                      "https://test-queue",
 		InterruptionChan:              drainChan,
@@ -417,7 +415,7 @@ func TestMonitor_DrainTasks_Errors(t *testing.T) {
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
 		ManagedTag:       "aws-node-termination-handler/managed",
-		ASG:              mockIsManagedTrue(&asgMock),
+		ASG:              asgMock,
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
 		InterruptionChan: drainChan,
@@ -470,7 +468,7 @@ func TestMonitor_DrainTasksASGFailure(t *testing.T) {
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
 		ManagedTag:       "aws-node-termination-handler/managed",
-		ASG:              mockIsManagedTrue(&asgMock),
+		ASG:              asgMock,
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
 		InterruptionChan: drainChan,
@@ -748,7 +746,6 @@ func TestMonitor_EC2NoDNSName(t *testing.T) {
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
 		ManagedTag:       "aws-node-termination-handler/managed",
-		ASG:              mockIsManagedTrue(nil),
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
 		InterruptionChan: drainChan,
@@ -788,7 +785,6 @@ func TestMonitor_EC2NoDNSNameOnTerminatedInstance(t *testing.T) {
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
 		ManagedTag:       "aws-node-termination-handler/managed",
-		ASG:              mockIsManagedTrue(nil),
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
 		InterruptionChan: drainChan,
@@ -826,7 +822,6 @@ func TestMonitor_SQSDeleteFailure(t *testing.T) {
 		SQS:              sqsMock,
 		EC2:              ec2Mock,
 		ManagedTag:       "aws-node-termination-handler/managed",
-		ASG:              mockIsManagedTrue(nil),
 		CheckIfManaged:   true,
 		QueueURL:         "https://test-queue",
 		InterruptionChan: drainChan,
@@ -864,7 +859,6 @@ func TestMonitor_InstanceNotManaged(t *testing.T) {
 		sqsMonitor := sqsevent.SQSMonitor{
 			SQS:              sqsMock,
 			EC2:              ec2Mock,
-			ASG:              mockIsManagedFalse(nil),
 			CheckIfManaged:   true,
 			QueueURL:         "https://test-queue",
 			InterruptionChan: drainChan,
@@ -919,31 +913,4 @@ func getSQSMessageFromEvent(event sqsevent.EventBridgeEvent) (sqs.Message, error
 	}
 	eventStr := string(eventBytes)
 	return sqs.Message{Body: &eventStr}, nil
-}
-
-func mockIsManagedTrue(asg *h.MockedASG) h.MockedASG {
-	if asg == nil {
-		asg = &h.MockedASG{}
-	}
-	asg.DescribeAutoScalingInstancesResp = autoscaling.DescribeAutoScalingInstancesOutput{
-		AutoScalingInstances: []*autoscaling.InstanceDetails{
-			{AutoScalingGroupName: aws.String("test-asg")},
-		},
-	}
-	asg.DescribeTagsPagesResp = autoscaling.DescribeTagsOutput{
-		Tags: []*autoscaling.TagDescription{
-			{Key: aws.String("aws-node-termination-handler/managed")},
-		},
-	}
-	return *asg
-}
-
-func mockIsManagedFalse(asg *h.MockedASG) h.MockedASG {
-	if asg == nil {
-		asg = &h.MockedASG{}
-	}
-	asg.DescribeAutoScalingInstancesResp = autoscaling.DescribeAutoScalingInstancesOutput{
-		AutoScalingInstances: []*autoscaling.InstanceDetails{},
-	}
-	return *asg
 }


### PR DESCRIPTION
**Issue #, if available:** #654

**Description of changes:**

PR #669 removed calls to ASG APIs when checking for the "managed" tag on EC2 instances. Some of the unit tests were still testing that behavior, which is no longer necessary. This PR removes those functions.

A few of the unit tests do not need to set an `ASG` parameter at all, so I removed those lines entirely. In tests that do need the ASG parameter, I left it but passed in a default ASG mock object.

**Testing:**

Verified that unit tests pass after these changes. No changes made to functional production code, only unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
