### PR TITLE
fix(sqs): log itn event messageid correctly

### DIFF
--- a/pkg/monitor/sqsevent/sqs-monitor.go
+++ b/pkg/monitor/sqsevent/sqs-monitor.go
@@ -241,7 +241,7 @@ func (m SQSMonitor) processInterruptionEvents(interruptionEventWrappers []Interr
 	}
 
 	if failedInterruptionEventsCount != 0 {
-		return fmt.Errorf("some interruption events for message Id %b could not be processed", message.MessageId)
+		return fmt.Errorf("some interruption events for message Id %s could not be processed", *message.MessageId)
 	}
 
 	return nil

--- a/pkg/monitor/sqsevent/sqs-monitor_test.go
+++ b/pkg/monitor/sqsevent/sqs-monitor_test.go
@@ -918,7 +918,8 @@ func getSQSMessageFromEvent(event sqsevent.EventBridgeEvent) (sqs.Message, error
 		return sqs.Message{}, err
 	}
 	eventStr := string(eventBytes)
-	return sqs.Message{Body: &eventStr}, nil
+	messageId := "d7de6634-f672-ce5c-d87e-ae0b1b5b2510"
+	return sqs.Message{Body: &eventStr, MessageId: &messageId}, nil
 }
 
 func mockIsManagedTrue(asg *h.MockedASG) h.MockedASG {


### PR DESCRIPTION
**Description of changes:**

This fixes the logging so we log the MessageId, not a binary representation of the pointer. Otherwise we get messages like:

`2022/09/06 19:22:45 ERR error processing interruption events error="some interruption events for message Id 1100000000000000001111000101100011101000 could not be processed"`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
