### PR TITLE
Add back deprecated flags for checking whether an instance is managed by NTH

### DIFF
--- a/config/helm/aws-node-termination-handler/templates/deployment.yaml
+++ b/config/helm/aws-node-termination-handler/templates/deployment.yaml
@@ -82,8 +82,14 @@ spec:
               value: {{ .Values.enablePrometheusServer | quote }}
             - name: PROMETHEUS_SERVER_PORT
               value: {{ .Values.prometheusServerPort | quote }}
+            # [DEPRECATED] Use CHECK_TAG_BEFORE_DRAINING instead
+            - name: CHECK_ASG_TAG_BEFORE_DRAINING
+              value: {{ .Values.checkASGTagBeforeDraining | quote }}
             - name: CHECK_TAG_BEFORE_DRAINING
               value: {{ .Values.checkTagBeforeDraining | quote }}
+            # [DEPRECATED] Use MANAGED_TAG instead
+            - name: MANAGED_ASG_TAG
+              value: {{ .Values.managedAsgTag | quote }}
             - name: MANAGED_TAG
               value: {{ .Values.managedTag | quote }}
             - name: USE_PROVIDER_ID

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -173,8 +173,14 @@ queueURL: ""
 # The maximum amount of parallel event processors to handle concurrent events
 workers: 10
 
+# [DEPRECATED] Use checkTagBeforeDraining instead
+checkASGTagBeforeDraining: true
+
 # If true, check that the instance is tagged with "aws-node-termination-handler/managed" as the key before draining the node
 checkTagBeforeDraining: true
+
+# [DEPRECATED] Use managedTag instead
+managedAsgTag: "aws-node-termination-handler/managed"
 
 # The tag to ensure is on a node if checkTagBeforeDraining is true
 managedTag: "aws-node-termination-handler/managed"


### PR DESCRIPTION
**Issue #, if available:** #682

**Description of changes:**
We removed these flags in NTH release `v1.17.0`, but they are still supported for now. The Helm chart should allow both in the mean time.

If the Helm chart includes one of the deprecated flags at install time, NTH will issue a warning, such as the following ([source](https://github.com/aws/aws-node-termination-handler/blob/main/pkg/config/config.go#L223-L235)):

> Deprecated argument "managed-asg-tag" was provided. This argument will eventually be removed. Please switch to "managed-tag" instead.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
