### PR TITLE
update release workflow trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "v1.*.*"
 
 permissions:
   contents: write # required for uploading releases


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Restrict `main` branch's release workflow to only trigger on tags `v1.*.*` to avoid unintended run when a `v2.*.*` tag is created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
