### PR TITLE
proceed lifecycle when node is not a part of the k8s cluster

### DIFF
--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -110,11 +110,12 @@ The configuration in this table applies to AWS Node Termination Handler in queue
 | `priorityClassName`          | Name of the PriorityClass to use for the Deployment.                                                                                                                      | `system-cluster-critical`              |
 | `awsRegion`                  | If specified, use the AWS region for AWS API calls, else NTH will try to find the region through the `AWS_REGION` environment variable, IMDS, or the specified queue URL. | `""`                                   |
 | `queueURL`                   | Listens for messages on the specified SQS queue URL.                                                                                                                      | `""`                                   |
+| `handleFailedInstances`      | Proceed with lifecycle (PostDrainTasks) even if the terminated node isn't part of the cluster (issue #575)                                                                                                                   | `false`                                |
 | `workers`                    | The maximum amount of parallel event processors to handle concurrent events.                                                                                              | `10`                                   |
 | `checkTagBeforeDraining`     | If `true`, check that the instance is tagged with the `managedTag` before draining the node.                                                                              | `true`                                 |
 | `managedTag`                 | The node tag to check if `checkTagBeforeDraining` is `true`.                                                                                                              | `aws-node-termination-handler/managed` |
 | `checkASGTagBeforeDraining`  | [DEPRECATED](Use `checkTagBeforeDraining` instead) If `true`, check that the instance is tagged with the `managedAsgTag` before draining the node. If `false`, disables calls ASG API.                                                                          | `true`                                 |
-| `managedAsgTag`              | [DEPRECATED](Use `managedTag` instead) The node tag to check if `checkASGTagBeforeDraining` is `true`.     
+| `managedAsgTag`              | [DEPRECATED](Use `managedTag` instead) The node tag to check if `checkASGTagBeforeDraining` is `true`.
 | `useProviderId`              | If `true`, fetch node name through Kubernetes node spec ProviderID instead of AWS event PrivateDnsHostname.                                                               | `false`                                |
 
 ### IMDS Mode Configuration

--- a/config/helm/aws-node-termination-handler/templates/deployment.yaml
+++ b/config/helm/aws-node-termination-handler/templates/deployment.yaml
@@ -170,6 +170,8 @@ spec:
             {{- end }}
             - name: QUEUE_URL
               value: {{ .Values.queueURL | quote }}
+            - name: HANDLE_FAILED_INSTANCES
+              value: {{ .Values.handleFailedInstances | quote }}
             - name: WORKERS
               value: {{ .Values.workers | quote }}
             {{- with .Values.extraEnv }}

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -170,6 +170,9 @@ awsRegion: ""
 # Listens for messages on the specified SQS queue URL
 queueURL: ""
 
+# Proceed with lifecycle (PostDrainTasks) even if the terminated node isn't part of the cluster (issue #575)
+handleFailedInstances: false
+
 # The maximum amount of parallel event processors to handle concurrent events
 workers: 10
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -102,6 +102,8 @@ const (
 	awsRegionConfigKey                        = "AWS_REGION"
 	awsEndpointConfigKey                      = "AWS_ENDPOINT"
 	queueURLConfigKey                         = "QUEUE_URL"
+	handleFailedInstancesConfigKey            = "HANDLE_FAILED_INSTANCES"
+	handleFailedInstanceDefault               = false
 	completeLifecycleActionDelaySecondsKey    = "COMPLETE_LIFECYCLE_ACTION_DELAY_SECONDS"
 )
 
@@ -149,6 +151,7 @@ type Config struct {
 	AWSRegion                           string
 	AWSEndpoint                         string
 	QueueURL                            string
+	HandleFailedInstances               bool
 	Workers                             int
 	UseProviderId                       bool
 	CompleteLifecycleActionDelaySeconds int
@@ -208,6 +211,7 @@ func ParseCliArgs() (config Config, err error) {
 	flag.StringVar(&config.AWSRegion, "aws-region", getEnv(awsRegionConfigKey, ""), "If specified, use the AWS region for AWS API calls")
 	flag.StringVar(&config.AWSEndpoint, "aws-endpoint", getEnv(awsEndpointConfigKey, ""), "[testing] If specified, use the AWS endpoint to make API calls")
 	flag.StringVar(&config.QueueURL, "queue-url", getEnv(queueURLConfigKey, ""), "Listens for messages on the specified SQS queue URL")
+	flag.BoolVar(&config.HandleFailedInstances, "handle-failed-instances", getBoolEnv(handleFailedInstancesConfigKey, handleFailedInstanceDefault), "Proceed with lifecycle (PostDrainTasks) even if the terminated node isn't part of the cluster")
 	flag.IntVar(&config.Workers, "workers", getIntEnv(workersConfigKey, workersDefault), "The amount of parallel event processors.")
 	flag.BoolVar(&config.UseProviderId, "use-provider-id", getBoolEnv(useProviderIdConfigKey, useProviderIdDefault), "If true, fetch node name through Kubernetes node spec ProviderID instead of AWS event PrivateDnsHostname.")
 	flag.IntVar(&config.CompleteLifecycleActionDelaySeconds, "complete-lifecycle-action-delay-seconds", getIntEnv(completeLifecycleActionDelaySecondsKey, -1), "Delay completing the Autoscaling lifecycle action after a node has been drained.")
@@ -298,6 +302,7 @@ func (c Config) PrintJsonConfigArgs() {
 		Str("aws_region", c.AWSRegion).
 		Str("aws_endpoint", c.AWSEndpoint).
 		Str("queue_url", c.QueueURL).
+		Bool("handle_failed_instances", c.HandleFailedInstances).
 		Bool("check_tag_before_draining", c.CheckTagBeforeDraining).
 		Str("ManagedTag", c.ManagedTag).
 		Bool("use_provider_id", c.UseProviderId).


### PR DESCRIPTION
**Issue #575**

**Description of changes:**
Possible way to solve the mentioned issue terminating instances which are not part of the k8s cluster.
Added flag `handleFailedInstances` to change the behaviour when the node which got the termination signal is not a cluster member. If set to `true` we proceed as the node is cordoned (and drained, depending on the arguments).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.