### PR TITLE
set git identity in sync-to-aws-eks-charts.sh

### DIFF
--- a/scripts/sync-to-aws-eks-charts.sh
+++ b/scripts/sync-to-aws-eks-charts.sh
@@ -153,13 +153,16 @@ cp -R "${helm_chart_path}/" "${eks_charts_nth_path}/"
 
 echo -e "🥑 Commit updates"
 
+git config --local user.name "ec2-bot 🤖"
+git config --local user.email "ec2-bot@users.noreply.github.com"
+
 helm_chart_version="$(cat "${helm_chart_path}/Chart.yaml" | grep "version:" | cut -d ' ' -f2 | tr -d '"')"
 pr_id="$(uuidgen | cut -d '-' -f1)"
 git_release_branch="${helm_chart_name}-${helm_chart_version}-${pr_id}"
 git checkout -b "${git_release_branch}"
 
 git add --all
-git commit --author="ec2-bot 🤖 <ec2-bot@users.noreply.github.com>" -m "${helm_chart_name}: ${helm_chart_version}"
+git commit -m "${helm_chart_name}: ${helm_chart_version}"
 git push -u origin "${git_release_branch}"
 
 #################################################


### PR DESCRIPTION
**Issue #, if available:**

Git user identity was not set in the sync-to-aws-eks-charts.sh script.

**Description of changes:**

Set the user identity for the local repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
