### PR TITLE
update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
 
     - name: Check out code
       uses: actions/checkout@v2
+      with:
+        ref: v2  # repo branch
+        fetch-depth: 0  # fetch all history
 
     - name: Release assets
       run: make release

--- a/scripts/sync-readme-to-ecr-public.sh
+++ b/scripts/sync-readme-to-ecr-public.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 repo_root_path="$(cd "$(dirname "$0")"; cd ..; pwd -P)"
 makefile_path="${repo_root_path}/Makefile"
 
-if ! command -v jq; then
+if ! command -v jq >/dev/null; then
     echo "command not found: jq" >&2
     exit 1
 fi


### PR DESCRIPTION
**Issue #, if available:**

By default actions/checkout@v2 does not fetch git history.  Release script then fails when it attempts to look through the git history.

**Description of changes:**

* Configure actions/checkout@v2 to fetch git history
* Silence unnecessary script output

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
