### PR TITLE
Completely ignore Instance Metadata when in SQS Queue mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The `enableSqsTerminationDraining` must be set to false for these configuration 
 The Queue Processor Mode does not allow for fine-grained configuration of which events are handled through helm configuration keys. Instead, you can modify your Amazon EventBridge rules to not send certain types of events to the SQS Queue so that NTH does not process those events. All events when operating in Queue Processor mode are Cordoned and Drained unless the `cordon-only` flag is set to true.
 
 
-The `enableSqsTerminationDraining` flag turns on Queue Processor Mode. When Queue Processor Mode is enabled, IMDS mode cannot be active. NTH cannot respond to queue events AND monitor IMDS paths. Queue Processor Mode still queries for node information on startup, but this information is not required for normal operation, so it is safe to disable IMDS for the NTH pod.
+The `enableSqsTerminationDraining` flag turns on Queue Processor Mode. When Queue Processor Mode is enabled, IMDS mode will be disabled, even if you explicitly enabled any of the IMDS configuration keys. NTH cannot respond to queue events AND monitor IMDS paths. In this case, it is safe to disable IMDS for the NTH pod.
 
 <details opened>
 <summary>AWS Node Termination Handler - IMDS Processor</summary>

--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -113,11 +113,12 @@ func main() {
 		nthConfig.Print()
 		log.Fatal().Err(err).Msg("Unable to instantiate probes service,")
 	}
+        imdsDisabled := nthConfig.EnableSQSTerminationDraining
 
 	imds := ec2metadata.New(nthConfig.MetadataURL, nthConfig.MetadataTries)
 
 	interruptionEventStore := interruptioneventstore.New(nthConfig)
-	nodeMetadata := imds.GetNodeMetadata()
+	nodeMetadata := imds.GetNodeMetadata(!imdsDisabled)
 	// Populate the aws region if available from node metadata and not already explicitly configured
 	if nthConfig.AWSRegion == "" && nodeMetadata.Region != "" {
 		nthConfig.AWSRegion = nodeMetadata.Region
@@ -163,17 +164,19 @@ func main() {
 	defer close(cancelChan)
 
 	monitoringFns := map[string]monitor.Monitor{}
-	if nthConfig.EnableSpotInterruptionDraining {
-		imdsSpotMonitor := spotitn.NewSpotInterruptionMonitor(imds, interruptionChan, cancelChan, nthConfig.NodeName)
-		monitoringFns[spotITN] = imdsSpotMonitor
-	}
-	if nthConfig.EnableScheduledEventDraining {
-		imdsScheduledEventMonitor := scheduledevent.NewScheduledEventMonitor(imds, interruptionChan, cancelChan, nthConfig.NodeName)
-		monitoringFns[scheduledMaintenance] = imdsScheduledEventMonitor
-	}
-	if nthConfig.EnableRebalanceMonitoring || nthConfig.EnableRebalanceDraining {
-		imdsRebalanceMonitor := rebalancerecommendation.NewRebalanceRecommendationMonitor(imds, interruptionChan, nthConfig.NodeName)
-		monitoringFns[rebalanceRecommendation] = imdsRebalanceMonitor
+        if !imdsDisabled {
+	        if nthConfig.EnableSpotInterruptionDraining {
+		        imdsSpotMonitor := spotitn.NewSpotInterruptionMonitor(imds, interruptionChan, cancelChan, nthConfig.NodeName)
+		        monitoringFns[spotITN] = imdsSpotMonitor
+	        }
+	        if nthConfig.EnableScheduledEventDraining {
+		        imdsScheduledEventMonitor := scheduledevent.NewScheduledEventMonitor(imds, interruptionChan, cancelChan, nthConfig.NodeName)
+		        monitoringFns[scheduledMaintenance] = imdsScheduledEventMonitor
+	        }
+	        if nthConfig.EnableRebalanceMonitoring || nthConfig.EnableRebalanceDraining {
+		        imdsRebalanceMonitor := rebalancerecommendation.NewRebalanceRecommendationMonitor(imds, interruptionChan, nthConfig.NodeName)
+		        monitoringFns[rebalanceRecommendation] = imdsRebalanceMonitor
+                }
 	}
 	if nthConfig.EnableSQSTerminationDraining {
 		cfg := aws.NewConfig().WithRegion(nthConfig.AWSRegion).WithEndpoint(nthConfig.AWSEndpoint).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint)

--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -118,7 +118,7 @@ func main() {
 	imds := ec2metadata.New(nthConfig.MetadataURL, nthConfig.MetadataTries)
 
 	interruptionEventStore := interruptioneventstore.New(nthConfig)
-	nodeMetadata := imds.GetNodeMetadata(!imdsDisabled)
+	nodeMetadata := imds.GetNodeMetadata(imdsDisabled)
 	// Populate the aws region if available from node metadata and not already explicitly configured
 	if nthConfig.AWSRegion == "" && nodeMetadata.Region != "" {
 		nthConfig.AWSRegion = nodeMetadata.Region

--- a/pkg/ec2metadata/ec2metadata.go
+++ b/pkg/ec2metadata/ec2metadata.go
@@ -326,42 +326,31 @@ func retry(attempts int, sleep time.Duration, httpReq func() (*http.Response, er
 
 // GetNodeMetadata attempts to gather additional ec2 instance information from the metadata service
 func (e *Service) GetNodeMetadata(imdsDisabled bool) NodeMetadata {
-	var metadata NodeMetadata
-        if (!imdsDisabled) {
-            identityDoc, err := e.GetMetadataInfo(IdentityDocPath)
-            if err != nil {
-	        log.Err(err).Msg("Unable to fetch metadata from IMDS")
-	        return metadata
-            }
-            err = json.NewDecoder(strings.NewReader(identityDoc)).Decode(&metadata)
-            if err != nil {
-                log.Warn().Msg("Unable to fetch instance identity document from ec2 metadata")
-                metadata.InstanceID, _ = e.GetMetadataInfo(InstanceIDPath)
-                metadata.InstanceType, _ = e.GetMetadataInfo(InstanceTypePath)
-	        metadata.LocalIP, _ = e.GetMetadataInfo(LocalIPPath)
-	        metadata.AvailabilityZone, _ = e.GetMetadataInfo(AZPlacementPath)
-		if len(metadata.AvailabilityZone) > 1 {
-		        metadata.Region = metadata.AvailabilityZone[0 : len(metadata.AvailabilityZone)-1]
+	metadata := NodeMetadata{}
+	if !imdsDisabled {
+		identityDoc, err := e.GetMetadataInfo(IdentityDocPath)
+		if err != nil {
+			log.Err(err).Msg("Unable to fetch metadata from IMDS")
+			return metadata
 		}
-	    }
-            metadata.InstanceLifeCycle, _ = e.GetMetadataInfo(InstanceLifeCycle)
-	    metadata.LocalHostname, _ = e.GetMetadataInfo(LocalHostnamePath)
-	    metadata.PublicHostname, _ = e.GetMetadataInfo(PublicHostnamePath)
-	    metadata.PublicIP, _ = e.GetMetadataInfo(PublicIPPath)
+		err = json.NewDecoder(strings.NewReader(identityDoc)).Decode(&metadata)
+		if err != nil {
+			log.Warn().Msg("Unable to fetch instance identity document from ec2 metadata")
+			metadata.InstanceID, _ = e.GetMetadataInfo(InstanceIDPath)
+			metadata.InstanceType, _ = e.GetMetadataInfo(InstanceTypePath)
+			metadata.LocalIP, _ = e.GetMetadataInfo(LocalIPPath)
+			metadata.AvailabilityZone, _ = e.GetMetadataInfo(AZPlacementPath)
+			if len(metadata.AvailabilityZone) > 1 {
+				metadata.Region = metadata.AvailabilityZone[0 : len(metadata.AvailabilityZone)-1]
+			}
+		}
+		metadata.InstanceLifeCycle, _ = e.GetMetadataInfo(InstanceLifeCycle)
+		metadata.LocalHostname, _ = e.GetMetadataInfo(LocalHostnamePath)
+		metadata.PublicHostname, _ = e.GetMetadataInfo(PublicHostnamePath)
+		metadata.PublicIP, _ = e.GetMetadataInfo(PublicIPPath)
 
-	    log.Info().Interface("metadata", metadata).Msg("Startup Metadata Retrieved")
-        } else {
-            metadata.AccountId         = ""
-	    metadata.InstanceID        = ""
-	    metadata.InstanceLifeCycle = ""
-	    metadata.InstanceType      = ""
-	    metadata.PublicHostname    = ""
-	    metadata.PublicIP          = ""
-	    metadata.LocalHostname     = ""
-	    metadata.LocalIP           = ""
-	    metadata.AvailabilityZone  = ""
-	    metadata.Region            = ""
-        }
+		log.Info().Interface("metadata", metadata).Msg("Startup Metadata Retrieved")
+	}
 
 	return metadata
 }

--- a/pkg/ec2metadata/ec2metadata.go
+++ b/pkg/ec2metadata/ec2metadata.go
@@ -325,30 +325,43 @@ func retry(attempts int, sleep time.Duration, httpReq func() (*http.Response, er
 }
 
 // GetNodeMetadata attempts to gather additional ec2 instance information from the metadata service
-func (e *Service) GetNodeMetadata() NodeMetadata {
+func (e *Service) GetNodeMetadata(imdsDisabled bool) NodeMetadata {
 	var metadata NodeMetadata
-	identityDoc, err := e.GetMetadataInfo(IdentityDocPath)
-	if err != nil {
-		log.Err(err).Msg("Unable to fetch metadata from IMDS")
-		return metadata
-	}
-	err = json.NewDecoder(strings.NewReader(identityDoc)).Decode(&metadata)
-	if err != nil {
-		log.Warn().Msg("Unable to fetch instance identity document from ec2 metadata")
-		metadata.InstanceID, _ = e.GetMetadataInfo(InstanceIDPath)
-		metadata.InstanceType, _ = e.GetMetadataInfo(InstanceTypePath)
-		metadata.LocalIP, _ = e.GetMetadataInfo(LocalIPPath)
-		metadata.AvailabilityZone, _ = e.GetMetadataInfo(AZPlacementPath)
+        if (!imdsDisabled) {
+            identityDoc, err := e.GetMetadataInfo(IdentityDocPath)
+            if err != nil {
+	        log.Err(err).Msg("Unable to fetch metadata from IMDS")
+	        return metadata
+            }
+            err = json.NewDecoder(strings.NewReader(identityDoc)).Decode(&metadata)
+            if err != nil {
+                log.Warn().Msg("Unable to fetch instance identity document from ec2 metadata")
+                metadata.InstanceID, _ = e.GetMetadataInfo(InstanceIDPath)
+                metadata.InstanceType, _ = e.GetMetadataInfo(InstanceTypePath)
+	        metadata.LocalIP, _ = e.GetMetadataInfo(LocalIPPath)
+	        metadata.AvailabilityZone, _ = e.GetMetadataInfo(AZPlacementPath)
 		if len(metadata.AvailabilityZone) > 1 {
-			metadata.Region = metadata.AvailabilityZone[0 : len(metadata.AvailabilityZone)-1]
+		        metadata.Region = metadata.AvailabilityZone[0 : len(metadata.AvailabilityZone)-1]
 		}
-	}
-	metadata.InstanceLifeCycle, _ = e.GetMetadataInfo(InstanceLifeCycle)
-	metadata.LocalHostname, _ = e.GetMetadataInfo(LocalHostnamePath)
-	metadata.PublicHostname, _ = e.GetMetadataInfo(PublicHostnamePath)
-	metadata.PublicIP, _ = e.GetMetadataInfo(PublicIPPath)
+	    }
+            metadata.InstanceLifeCycle, _ = e.GetMetadataInfo(InstanceLifeCycle)
+	    metadata.LocalHostname, _ = e.GetMetadataInfo(LocalHostnamePath)
+	    metadata.PublicHostname, _ = e.GetMetadataInfo(PublicHostnamePath)
+	    metadata.PublicIP, _ = e.GetMetadataInfo(PublicIPPath)
 
-	log.Info().Interface("metadata", metadata).Msg("Startup Metadata Retrieved")
+	    log.Info().Interface("metadata", metadata).Msg("Startup Metadata Retrieved")
+        } else {
+            metadata.AccountId         = ""
+	    metadata.InstanceID        = ""
+	    metadata.InstanceLifeCycle = ""
+	    metadata.InstanceType      = ""
+	    metadata.PublicHostname    = ""
+	    metadata.PublicIP          = ""
+	    metadata.LocalHostname     = ""
+	    metadata.LocalIP           = ""
+	    metadata.AvailabilityZone  = ""
+	    metadata.Region            = ""
+        }
 
 	return metadata
 }

--- a/pkg/ec2metadata/ec2metadata_test.go
+++ b/pkg/ec2metadata/ec2metadata_test.go
@@ -580,7 +580,7 @@ func TestGetNodeMetadata(t *testing.T) {
 
 	// Use URL from our local test server
 	imds := ec2metadata.New(server.URL, 1)
-	nodeMetadata := imds.GetNodeMetadata()
+	nodeMetadata := imds.GetNodeMetadata(false)
 
 	h.Assert(t, nodeMetadata.InstanceID == `metadata`, `Missing required NodeMetadata field InstanceID`)
 	h.Assert(t, nodeMetadata.InstanceType == `metadata`, `Missing required NodeMetadata field InstanceType`)


### PR DESCRIPTION
**Issue #, if available:**
Fixes https://github.com/aws/aws-node-termination-handler/issues/732

When IMDSv2 is enabled and aws-note-termination-handler is ran inside a container accessing IMDSv2 is not possible due to the IMDSv2 HTTP endpoint's default hop limit of 1. This makes the process exit.

**Description of changes:**
Completely disables the communication with the IMDS endpoint when in SQS queue mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
