### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/pkg/config/config_internal_test.go
+++ b/pkg/config/config_internal_test.go
@@ -15,7 +15,6 @@ package config
 
 import (
 	"flag"
-	"os"
 	"strconv"
 	"testing"
 
@@ -37,7 +36,7 @@ func TestGetEnv(t *testing.T) {
 	var successVal = "success"
 	var failVal = "failure"
 
-	os.Setenv(key, successVal)
+	t.Setenv(key, successVal)
 
 	result := getEnv(key+"bla", failVal)
 	h.Equals(t, failVal, result)
@@ -51,7 +50,7 @@ func TestGetIntEnv(t *testing.T) {
 	var successVal = 1
 	var failVal = 0
 
-	os.Setenv(key, strconv.Itoa(successVal))
+	t.Setenv(key, strconv.Itoa(successVal))
 
 	result := getIntEnv(key+"bla", failVal)
 	h.Equals(t, failVal, result)
@@ -64,7 +63,7 @@ func TestGetIntEnv(t *testing.T) {
 			t.Errorf("getIntEnv did not panic")
 		}
 	}()
-	os.Setenv(key, "hi")
+	t.Setenv(key, "hi")
 	getIntEnv(key, 0)
 }
 
@@ -73,7 +72,7 @@ func TestGetBoolEnv(t *testing.T) {
 	var successVal = true
 	var failVal = false
 
-	os.Setenv(key, strconv.FormatBool(successVal))
+	t.Setenv(key, strconv.FormatBool(successVal))
 
 	result := getBoolEnv(key+"bla", failVal)
 	h.Equals(t, failVal, result)
@@ -86,7 +85,7 @@ func TestGetBoolEnv(t *testing.T) {
 			t.Errorf("getBoolEnv did not panic")
 		}
 	}()
-	os.Setenv(key, "hi")
+	t.Setenv(key, "hi")
 	getBoolEnv(key, false)
 }
 
@@ -99,7 +98,7 @@ func TestIsConfigProvided(t *testing.T) {
 	result = isConfigProvided(cliArgName, envVarName)
 	h.Equals(t, true, result)
 
-	os.Setenv(envVarName, value)
+	t.Setenv(envVarName, value)
 	result = isConfigProvided(cliArgName, envVarName)
 	h.Equals(t, true, result)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -25,44 +25,33 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-var envForTest = map[string]string{}
-
 func resetFlagsForTest() {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	os.Args = []string{"cmd"}
-	for key := range envForTest {
-		os.Unsetenv(key)
-	}
-}
-
-func setEnvForTest(key string, val string) {
-	os.Setenv(key, val)
-	envForTest[key] = val
 }
 
 func TestParseCliArgsEnvSuccess(t *testing.T) {
-	resetFlagsForTest()
-	setEnvForTest("USE_PROVIDER_ID", "true")
-	setEnvForTest("DELETE_LOCAL_DATA", "false")
-	setEnvForTest("DRY_RUN", "true")
-	setEnvForTest("ENABLE_SCHEDULED_EVENT_DRAINING", "true")
-	setEnvForTest("ENABLE_SPOT_INTERRUPTION_DRAINING", "false")
-	setEnvForTest("ENABLE_SQS_TERMINATION_DRAINING", "false")
-	setEnvForTest("ENABLE_REBALANCE_MONITORING", "true")
-	setEnvForTest("ENABLE_REBALANCE_DRAINING", "true")
-	setEnvForTest("GRACE_PERIOD", "12345")
-	setEnvForTest("IGNORE_DAEMON_SETS", "false")
-	setEnvForTest("KUBERNETES_SERVICE_HOST", "KUBERNETES_SERVICE_HOST")
-	setEnvForTest("KUBERNETES_SERVICE_PORT", "KUBERNETES_SERVICE_PORT")
-	setEnvForTest("NODE_NAME", "NODE_NAME")
-	setEnvForTest("NODE_TERMINATION_GRACE_PERIOD", "12345")
-	setEnvForTest("INSTANCE_METADATA_URL", "INSTANCE_METADATA_URL")
-	setEnvForTest("POD_TERMINATION_GRACE_PERIOD", "12345")
-	setEnvForTest("WEBHOOK_URL", "WEBHOOK_URL")
-	setEnvForTest("WEBHOOK_HEADERS", "WEBHOOK_HEADERS")
-	setEnvForTest("WEBHOOK_TEMPLATE", "WEBHOOK_TEMPLATE")
-	setEnvForTest("METADATA_TRIES", "100")
-	setEnvForTest("CORDON_ONLY", "false")
+	t.Setenv("USE_PROVIDER_ID", "true")
+	t.Setenv("DELETE_LOCAL_DATA", "false")
+	t.Setenv("DRY_RUN", "true")
+	t.Setenv("ENABLE_SCHEDULED_EVENT_DRAINING", "true")
+	t.Setenv("ENABLE_SPOT_INTERRUPTION_DRAINING", "false")
+	t.Setenv("ENABLE_SQS_TERMINATION_DRAINING", "false")
+	t.Setenv("ENABLE_REBALANCE_MONITORING", "true")
+	t.Setenv("ENABLE_REBALANCE_DRAINING", "true")
+	t.Setenv("GRACE_PERIOD", "12345")
+	t.Setenv("IGNORE_DAEMON_SETS", "false")
+	t.Setenv("KUBERNETES_SERVICE_HOST", "KUBERNETES_SERVICE_HOST")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "KUBERNETES_SERVICE_PORT")
+	t.Setenv("NODE_NAME", "NODE_NAME")
+	t.Setenv("NODE_TERMINATION_GRACE_PERIOD", "12345")
+	t.Setenv("INSTANCE_METADATA_URL", "INSTANCE_METADATA_URL")
+	t.Setenv("POD_TERMINATION_GRACE_PERIOD", "12345")
+	t.Setenv("WEBHOOK_URL", "WEBHOOK_URL")
+	t.Setenv("WEBHOOK_HEADERS", "WEBHOOK_HEADERS")
+	t.Setenv("WEBHOOK_TEMPLATE", "WEBHOOK_TEMPLATE")
+	t.Setenv("METADATA_TRIES", "100")
+	t.Setenv("CORDON_ONLY", "false")
 	nthConfig, err := config.ParseCliArgs()
 	h.Ok(t, err)
 
@@ -157,27 +146,27 @@ func TestParseCliArgsSuccess(t *testing.T) {
 
 func TestParseCliArgsOverrides(t *testing.T) {
 	resetFlagsForTest()
-	setEnvForTest("USE_PROVIDER_ID", "true")
-	setEnvForTest("DELETE_LOCAL_DATA", "true")
-	setEnvForTest("DRY_RUN", "false")
-	setEnvForTest("ENABLE_SCHEDULED_EVENT_DRAINING", "false")
-	setEnvForTest("ENABLE_SPOT_INTERRUPTION_DRAINING", "true")
-	setEnvForTest("ENABLE_SQS_TERMINATION_DRAINING", "false")
-	setEnvForTest("ENABLE_REBALANCE_MONITORING", "true")
-	setEnvForTest("ENABLE_REBALANCE_DRAINING", "true")
-	setEnvForTest("GRACE_PERIOD", "99999")
-	setEnvForTest("IGNORE_DAEMON_SETS", "true")
-	setEnvForTest("KUBERNETES_SERVICE_HOST", "no")
-	setEnvForTest("KUBERNETES_SERVICE_PORT", "no")
-	setEnvForTest("NODE_NAME", "no")
-	setEnvForTest("NODE_TERMINATION_GRACE_PERIOD", "99999")
-	setEnvForTest("INSTANCE_METADATA_URL", "no")
-	setEnvForTest("POD_TERMINATION_GRACE_PERIOD", "99999")
-	setEnvForTest("WEBHOOK_URL", "no")
-	setEnvForTest("WEBHOOK_HEADERS", "no")
-	setEnvForTest("WEBHOOK_TEMPLATE", "no")
-	setEnvForTest("METADATA_TRIES", "100")
-	setEnvForTest("CORDON_ONLY", "true")
+	t.Setenv("USE_PROVIDER_ID", "true")
+	t.Setenv("DELETE_LOCAL_DATA", "true")
+	t.Setenv("DRY_RUN", "false")
+	t.Setenv("ENABLE_SCHEDULED_EVENT_DRAINING", "false")
+	t.Setenv("ENABLE_SPOT_INTERRUPTION_DRAINING", "true")
+	t.Setenv("ENABLE_SQS_TERMINATION_DRAINING", "false")
+	t.Setenv("ENABLE_REBALANCE_MONITORING", "true")
+	t.Setenv("ENABLE_REBALANCE_DRAINING", "true")
+	t.Setenv("GRACE_PERIOD", "99999")
+	t.Setenv("IGNORE_DAEMON_SETS", "true")
+	t.Setenv("KUBERNETES_SERVICE_HOST", "no")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "no")
+	t.Setenv("NODE_NAME", "no")
+	t.Setenv("NODE_TERMINATION_GRACE_PERIOD", "99999")
+	t.Setenv("INSTANCE_METADATA_URL", "no")
+	t.Setenv("POD_TERMINATION_GRACE_PERIOD", "99999")
+	t.Setenv("WEBHOOK_URL", "no")
+	t.Setenv("WEBHOOK_HEADERS", "no")
+	t.Setenv("WEBHOOK_TEMPLATE", "no")
+	t.Setenv("METADATA_TRIES", "100")
+	t.Setenv("CORDON_ONLY", "true")
 	os.Args = []string{
 		"cmd",
 		"--use-provider-id=false",
@@ -238,9 +227,9 @@ func TestParseCliArgsOverrides(t *testing.T) {
 
 func TestParseCliArgsWithGracePeriodSuccess(t *testing.T) {
 	resetFlagsForTest()
-	setEnvForTest("POD_TERMINATION_GRACE_PERIOD", "")
-	setEnvForTest("NODE_NAME", "bla")
-	setEnvForTest("GRACE_PERIOD", "12")
+	t.Setenv("POD_TERMINATION_GRACE_PERIOD", "")
+	t.Setenv("NODE_NAME", "bla")
+	t.Setenv("GRACE_PERIOD", "12")
 
 	nthConfig, err := config.ParseCliArgs()
 	h.Ok(t, err)
@@ -249,23 +238,23 @@ func TestParseCliArgsWithGracePeriodSuccess(t *testing.T) {
 
 func TestParseCliArgsMissingNodeNameFailure(t *testing.T) {
 	resetFlagsForTest()
-	setEnvForTest("NODE_NAME", "")
+	t.Setenv("NODE_NAME", "")
 	_, err := config.ParseCliArgs()
 	h.Assert(t, err != nil, "Failed to return error when node-name not provided")
 }
 
 func TestParseCliArgsCreateFlagsFailure(t *testing.T) {
 	resetFlagsForTest()
-	setEnvForTest("DELETE_LOCAL_DATA", "something not true or false")
+	t.Setenv("DELETE_LOCAL_DATA", "something not true or false")
 	_, err := config.ParseCliArgs()
 	h.Assert(t, err != nil, "Failed to return error when creating flags")
 }
 
 func TestParseCliArgsAWSSession(t *testing.T) {
 	resetFlagsForTest()
-	setEnvForTest("ENABLE_SQS_TERMINATION_DRAINING", "true")
-	setEnvForTest("AWS_REGION", "us-weast-1")
-	setEnvForTest("NODE_NAME", "node")
+	t.Setenv("ENABLE_SQS_TERMINATION_DRAINING", "true")
+	t.Setenv("AWS_REGION", "us-weast-1")
+	t.Setenv("NODE_NAME", "node")
 	nthConfig, err := config.ParseCliArgs()
 	h.Ok(t, err)
 	h.Assert(t, nthConfig.AWSRegion == "us-weast-1", "Should find region as us-weast-1")
@@ -273,8 +262,8 @@ func TestParseCliArgsAWSSession(t *testing.T) {
 
 func TestPrint_Human(t *testing.T) {
 	resetFlagsForTest()
-	setEnvForTest("NODE_NAME", "node")
-	setEnvForTest("JSON_LOGGING", "false")
+	t.Setenv("NODE_NAME", "node")
+	t.Setenv("JSON_LOGGING", "false")
 	nthConfig, err := config.ParseCliArgs()
 	h.Ok(t, err)
 	var printBuf bytes.Buffer
@@ -288,8 +277,8 @@ func TestPrint_Human(t *testing.T) {
 
 func TestPrint_JSON(t *testing.T) {
 	resetFlagsForTest()
-	setEnvForTest("NODE_NAME", "node")
-	setEnvForTest("JSON_LOGGING", "true")
+	t.Setenv("NODE_NAME", "node")
+	t.Setenv("JSON_LOGGING", "true")
 	nthConfig, err := config.ParseCliArgs()
 	h.Ok(t, err)
 	var printBuf bytes.Buffer


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
A testing cleanup.

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

```go
func TestFoo(t *testing.T) {
	// before
	key := "ENV"
	originalEnv := os.Getenv(key)
	
	if err := os.Setenv(key, "new value"); err != nil {
		t.Fatal(err)
	}
	defer func() {
		if err := os.Setenv(key, originalEnv); err != nil {
			t.Logf("failed to set env %s back to original value: %v", key, err)
		}
	}()
	
	// after
	t.Setenv(key, "new value")
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
