### PR TITLE
Don't skip evicting pods with same name but in different namespace

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,6 +30,7 @@ const (
 	dryRunConfigKey                         = "DRY_RUN"
 	nodeNameConfigKey                       = "NODE_NAME"
 	podNameConfigKey                        = "POD_NAME"
+	podNamespaceConfigKey                   = "NAMESPACE"
 	kubernetesServiceHostConfigKey          = "KUBERNETES_SERVICE_HOST"
 	kubernetesServicePortConfigKey          = "KUBERNETES_SERVICE_PORT"
 	deleteLocalDataConfigKey                = "DELETE_LOCAL_DATA"
@@ -114,6 +115,7 @@ type Config struct {
 	DryRun                              bool
 	NodeName                            string
 	PodName                             string
+	PodNamespace                        string
 	MetadataURL                         string
 	IgnoreDaemonSets                    bool
 	DeleteLocalData                     bool
@@ -173,6 +175,7 @@ func ParseCliArgs() (config Config, err error) {
 	flag.BoolVar(&config.DryRun, "dry-run", getBoolEnv(dryRunConfigKey, false), "If true, only log if a node would be drained")
 	flag.StringVar(&config.NodeName, "node-name", getEnv(nodeNameConfigKey, ""), "The kubernetes node name")
 	flag.StringVar(&config.PodName, "pod-name", getEnv(podNameConfigKey, ""), "The kubernetes pod name")
+	flag.StringVar(&config.PodNamespace, "pod-namespace", getEnv(podNamespaceConfigKey, ""), "The kubernetes pod namespace")
 	flag.StringVar(&config.MetadataURL, "metadata-url", getEnv(instanceMetadataURLConfigKey, defaultInstanceMetadataURL), "The URL of EC2 instance metadata. This shouldn't need to be changed unless you are testing.")
 	flag.BoolVar(&config.IgnoreDaemonSets, "ignore-daemon-sets", getBoolEnv(ignoreDaemonSetsConfigKey, true), "If true, ignore daemon sets and drain other pods when a spot interrupt is received.")
 	flag.BoolVar(&config.DeleteLocalData, "delete-local-data", getBoolEnv(deleteLocalDataConfigKey, true), "If true, do not drain pods that are using local node storage in emptyDir")
@@ -285,6 +288,7 @@ func (c Config) PrintJsonConfigArgs() {
 		Bool("dry_run", c.DryRun).
 		Str("node_name", c.NodeName).
 		Str("pod_name", c.PodName).
+		Str("pod_namespace", c.PodNamespace).
 		Str("metadata_url", c.MetadataURL).
 		Str("kubernetes_service_host", c.KubernetesServiceHost).
 		Str("kubernetes_service_port", c.KubernetesServicePort).
@@ -331,6 +335,7 @@ func (c Config) PrintHumanConfigArgs() {
 			"\tdry-run: %t,\n"+
 			"\tnode-name: %s,\n"+
 			"\tpod-name: %s,\n"+
+			"\tpod-namespace: %s,\n"+
 			"\tmetadata-url: %s,\n"+
 			"\tkubernetes-service-host: %s,\n"+
 			"\tkubernetes-service-port: %s,\n"+
@@ -368,6 +373,7 @@ func (c Config) PrintHumanConfigArgs() {
 		c.DryRun,
 		c.NodeName,
 		c.PodName,
+		c.PodNamespace,
 		c.MetadataURL,
 		c.KubernetesServiceHost,
 		c.KubernetesServicePort,

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -821,7 +821,7 @@ func getUptimeFunc(uptimeFile string) uptime.UptimeFuncType {
 
 func filterPodForDeletion(podName, podNamespace string) func(pod corev1.Pod) drain.PodDeleteStatus {
 	return func(pod corev1.Pod) drain.PodDeleteStatus {
-		if pod.Name == podName && pod.Namespace == podNamespace {
+		if pod.Name == podName && (pod.Namespace == podNamespace || podNamespace == "") {
 			return drain.MakePodDeleteStatusSkip()
 		}
 		return drain.MakePodDeleteStatusOkay()

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -634,7 +634,7 @@ func getDrainHelper(nthConfig config.Config) (*drain.Helper, error) {
 		Force:               true,
 		GracePeriodSeconds:  nthConfig.PodTerminationGracePeriod,
 		IgnoreAllDaemonSets: nthConfig.IgnoreDaemonSets,
-		AdditionalFilters:   []drain.PodFilter{filterPodForDeletion(nthConfig.PodName)},
+		AdditionalFilters:   []drain.PodFilter{filterPodForDeletion(nthConfig.PodName, nthConfig.PodNamespace)},
 		DeleteEmptyDirData:  nthConfig.DeleteLocalData,
 		Timeout:             time.Duration(nthConfig.NodeTerminationGracePeriod) * time.Second,
 		Out:                 log.Logger,
@@ -819,9 +819,9 @@ func getUptimeFunc(uptimeFile string) uptime.UptimeFuncType {
 	return uptime.Uptime
 }
 
-func filterPodForDeletion(podName string) func(pod corev1.Pod) drain.PodDeleteStatus {
+func filterPodForDeletion(podName, podNamespace string) func(pod corev1.Pod) drain.PodDeleteStatus {
 	return func(pod corev1.Pod) drain.PodDeleteStatus {
-		if pod.Name == podName {
+		if pod.Name == podName && pod.Namespace == podNamespace {
 			return drain.MakePodDeleteStatusSkip()
 		}
 		return drain.MakePodDeleteStatusOkay()


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

When draining a node, NTH skips evicting itself. It incorrectly skipped evicting pods in other namespaces that happened to have the same name.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
