### PR TITLE
Error log fix

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -611,7 +611,7 @@ func (n Node) fetchKubernetesNode(nodeName string) (*corev1.Node, error) {
 	listOptions := metav1.ListOptions{LabelSelector: labels.Set(labelSelector.MatchLabels).String()}
 	matchingNodes, err := n.drainHelper.Client.CoreV1().Nodes().List(context.TODO(), listOptions)
 	if err != nil || len(matchingNodes.Items) == 0 {
-		log.Err(err).Msgf("Error when trying to list Nodes w/ label, falling back to direct Get lookup of node")
+		log.Warn().Msgf("Unable to list Nodes w/ label, falling back to direct Get lookup of node")
 		return n.drainHelper.Client.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 	}
 	return &matchingNodes.Items[0], nil


### PR DESCRIPTION
**Issue #, if available:** https://github.com/aws/aws-node-termination-handler/issues/685

**Description of changes:**

- As per the PR comments, modified log statement from Error to Warning as this doesn't affect any expected outcome.
- This error is mainly due to mismatch between Node labels as per the code and we already have a fallback mechanism.
-  Ran tests locally and all tests passed.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
