### PR TITLE
Modified Spot ITN message

### DIFF
--- a/pkg/monitor/sqsevent/spot-itn-event.go
+++ b/pkg/monitor/sqsevent/spot-itn-event.go
@@ -29,7 +29,7 @@ import (
 	"id": "1e5527d7-bb36-4607-3370-4164db56a40e",
 	"detail-type": "EC2 Spot Instance Interruption Warning",
 	"source": "aws.ec2",
-	"account": "123456789012",
+	"account": "<account_number>",
 	"time": "1970-01-01T00:00:00Z",
 	"region": "us-east-1",
 	"resources": [
@@ -69,7 +69,7 @@ func (m SQSMonitor) spotITNTerminationToInterruptionEvent(event *EventBridgeEven
 		IsManaged:            nodeInfo.IsManaged,
 		InstanceID:           spotInterruptionDetail.InstanceID,
 		ProviderID:           nodeInfo.ProviderID,
-		Description:          fmt.Sprintf("Spot Interruption event received. Instance %s will be interrupted at %s \n", spotInterruptionDetail.InstanceID, event.getTime()),
+		Description:          fmt.Sprintf("Spot Interruption event received. Instance %s received interruption at %s \n", spotInterruptionDetail.InstanceID, event.getTime()),
 	}
 	interruptionEvent.PostDrainTask = func(interruptionEvent monitor.InterruptionEvent, n node.Node) error {
 		errs := m.deleteMessages([]*sqs.Message{message})

--- a/pkg/monitor/sqsevent/spot-itn-event.go
+++ b/pkg/monitor/sqsevent/spot-itn-event.go
@@ -69,7 +69,7 @@ func (m SQSMonitor) spotITNTerminationToInterruptionEvent(event *EventBridgeEven
 		IsManaged:            nodeInfo.IsManaged,
 		InstanceID:           spotInterruptionDetail.InstanceID,
 		ProviderID:           nodeInfo.ProviderID,
-		Description:          fmt.Sprintf("Spot Interruption event received. Instance %s received interruption at %s \n", spotInterruptionDetail.InstanceID, event.getTime()),
+		Description:          fmt.Sprintf("Spot Interruption notice for instance %s was sent at %s \n", spotInterruptionDetail.InstanceID, event.getTime()),
 	}
 	interruptionEvent.PostDrainTask = func(interruptionEvent monitor.InterruptionEvent, n node.Node) error {
 		errs := m.deleteMessages([]*sqs.Message{message})


### PR DESCRIPTION
**Issue #, if available:** https://github.com/aws/aws-node-termination-handler/issues/757

**Description of changes:**

We are returning the EventBridge event start time, in our case when instance received spot interruption. Current time is returned when we cannot parse the time in the specific format and we get a warning message that `Unable to parse time as RFC3339 from event, using current time instead`, we cannot hardcode the time for spot interruption as it might take 2 or minutes to terminate. Modified the Spot Interruption event message to make it more clear.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
