### PR TITLE
Update workflow linter version

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -61,9 +61,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up golangci-lint
-        uses: golangci/golangci-lint-action@v3.2.0
+        uses: golangci/golangci-lint-action@v3.4.0
         with:
-          version: v1.45.2
+          version: v1.51.1
           args: --timeout=5m
           skip-cache: true
     


### PR DESCRIPTION
**Issue #, if available:**

Current linter version (golangci-lint-action v3.2.0, golangci-lint v1.45.2) raises what appear to be false positives.

**Description of changes:**

* Updated golangci-lint-action to latest (v3.4.0)
* Updated golangci-lint to latest (v1.51.1)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
