### PR TITLE
Removed io/ioutil package as it is deprecated and used io and os package

### DIFF
--- a/pkg/ec2metadata/ec2metadata.go
+++ b/pkg/ec2metadata/ec2metadata.go
@@ -16,7 +16,7 @@ package ec2metadata
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"strconv"
@@ -202,7 +202,7 @@ func (e *Service) GetMetadataInfo(path string) (info string, err error) {
 	}
 	if resp != nil {
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", fmt.Errorf("Unable to parse http response. Status code: %d. %w", resp.StatusCode, err)
 		}
@@ -284,7 +284,7 @@ func (e *Service) getV2Token() (string, int, error) {
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return "", -1, fmt.Errorf("Received an http status code %d", resp.StatusCode)
 	}
-	token, err := ioutil.ReadAll(resp.Body)
+	token, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", -1, fmt.Errorf("Unable to read token response from IMDSv2: %w", err)
 	}

--- a/pkg/ec2metadata/ec2metadata_internal_test.go
+++ b/pkg/ec2metadata/ec2metadata_internal_test.go
@@ -16,7 +16,7 @@ package ec2metadata
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -35,7 +35,7 @@ func TestRetry(t *testing.T) {
 		requestCount++
 		return &http.Response{
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewBufferString(`OK`)),
+			Body:       io.NopCloser(bytes.NewBufferString(`OK`)),
 			Header:     make(http.Header),
 		}, errors.New(errorMsg)
 	}

--- a/pkg/ec2metadata/ec2metadata_test.go
+++ b/pkg/ec2metadata/ec2metadata_test.go
@@ -15,7 +15,7 @@ package ec2metadata_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -46,7 +46,7 @@ func TestRequestV1(t *testing.T) {
 	defer resp.Body.Close()
 	h.Equals(t, http.StatusOK, resp.StatusCode)
 
-	responseData, err := ioutil.ReadAll(resp.Body)
+	responseData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Error("Unable to parse response.")
 	}
@@ -80,7 +80,7 @@ func TestRequestV2(t *testing.T) {
 	defer resp.Body.Close()
 	h.Equals(t, http.StatusOK, resp.StatusCode)
 
-	responseData, err := ioutil.ReadAll(resp.Body)
+	responseData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Error("Unable to parse response.")
 	}

--- a/pkg/uptime/common.go
+++ b/pkg/uptime/common.go
@@ -15,7 +15,7 @@ package uptime
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -26,7 +26,7 @@ type UptimeFuncType func() (int64, error)
 // UptimeFromFile reads system uptime information from filepath and returns
 // the number of seconds since last system boot.
 func UptimeFromFile(filepath string) (int64, error) {
-	data, err := ioutil.ReadFile(filepath)
+	data, err := os.ReadFile(filepath)
 	if err != nil {
 		return 0, fmt.Errorf("Not able to read %s: %w", filepath, err)
 	}

--- a/pkg/uptime/common_test.go
+++ b/pkg/uptime/common_test.go
@@ -14,7 +14,6 @@
 package uptime
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -25,7 +24,7 @@ const testFile = "test.out"
 
 func TestUptimeFromFileSuccess(t *testing.T) {
 	d1 := []byte("350735.47 234388.90")
-	err := ioutil.WriteFile(testFile, d1, 0644)
+	err := os.WriteFile(testFile, d1, 0644)
 	h.Ok(t, err)
 
 	value, err := UptimeFromFile(testFile)
@@ -41,7 +40,7 @@ func TestUptimeFromFileReadFail(t *testing.T) {
 
 func TestUptimeFromFileBadData(t *testing.T) {
 	d1 := []byte("Something not time")
-	err := ioutil.WriteFile(testFile, d1, 0644)
+	err := os.WriteFile(testFile, d1, 0644)
 	h.Ok(t, err)
 
 	_, err = UptimeFromFile(testFile)

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -17,9 +17,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"text/template"
 	"time"
 
@@ -41,7 +41,7 @@ func Post(additionalInfo ec2metadata.NodeMetadata, event *monitor.InterruptionEv
 	var webhookTemplateContent string
 
 	if nthConfig.WebhookTemplateFile != "" {
-		content, err := ioutil.ReadFile(nthConfig.WebhookTemplateFile)
+		content, err := os.ReadFile(nthConfig.WebhookTemplateFile)
 		if err != nil {
 			log.Err(err).
 				Str("webhook_template_file", nthConfig.WebhookTemplateFile).
@@ -131,7 +131,7 @@ func ValidateWebhookConfig(nthConfig config.Config) error {
 	var webhookTemplateContent string
 
 	if nthConfig.WebhookTemplateFile != "" {
-		content, err := ioutil.ReadFile(nthConfig.WebhookTemplateFile)
+		content, err := os.ReadFile(nthConfig.WebhookTemplateFile)
 		if err != nil {
 			return fmt.Errorf("Webhook Error: Could not read template file %w", err)
 		}

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -88,7 +88,7 @@ func TestPostSuccess(t *testing.T) {
 		h.Equals(t, req.Header.Get("Content-type"), headerMap["Content-type"])
 
 		// Test request body
-		requestBody, err := ioutil.ReadAll(req.Body)
+		requestBody, err := io.ReadAll(req.Body)
 		if err != nil {
 			t.Error("Unable to read request body.")
 		}


### PR DESCRIPTION
**Issue #, if available:**

Lint Eastwood checks are failing in NTH Build and Test due to the deprecated `io/ioutil` package used in our code.

```
Error: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (staticcheck)
```

**Description of changes:**
Modified all the files that are using `io/ioutil` package and used `io` and  `os` packages to get the same result.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
