### PR TITLE
Metric zero

### DIFF
--- a/pkg/observability/opentelemetry.go
+++ b/pkg/observability/opentelemetry.go
@@ -106,6 +106,7 @@ func registerMetricsWith(provider *metric.MeterProvider) (Metrics, error) {
 	if err != nil {
 		return Metrics{}, fmt.Errorf("failed to create Prometheus counter %q: %w", name, err)
 	}
+	actionsCounter.Add(context.Background(), 0)
 
 	name = "events.error"
 	errorEventsCounter, err := meter.Int64Counter(name, instrument.WithDescription("Number of errors in events processing"))

--- a/pkg/observability/opentelemetry.go
+++ b/pkg/observability/opentelemetry.go
@@ -112,7 +112,7 @@ func registerMetricsWith(provider *metric.MeterProvider) (Metrics, error) {
 	if err != nil {
 		return Metrics{}, fmt.Errorf("failed to create Prometheus counter %q: %w", name, err)
 	}
-
+	errorEventsCounter.Add(context.Background(), 0)
 	return Metrics{
 		meter:              meter,
 		errorEventsCounter: errorEventsCounter,


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws/aws-node-termination-handler/issues/374


**Description of changes:**
 - zeros metrics when registered


```
> ec2-metadata-mock -d 100000 &
> go run cmd/node-termination-handler.go -enable-prometheus-server --dry-run --node-name test --metadata-url http://localhost:1338 -enable-scheduled-event-draining=false
> curl http://localhost:9092/metrics

# HELP actions_node_total Number of actions per node
# TYPE actions_node_total counter
actions_node_total{otel_scope_name="aws.node.termination.handler",otel_scope_version=""} 0
# HELP events_error_total Number of errors in events processing
# TYPE events_error_total counter
events_error_total{otel_scope_name="aws.node.termination.handler",otel_scope_version=""} 0
...
```


```
> ec2-metadata-mock &
> go run cmd/node-termination-handler.go -enable-prometheus-server --dry-run --node-name test --metadata-url http://localhost:1338 -enable-scheduled-event-draining=false
> curl http://localhost:9092/metrics

# HELP actions_node_total Number of actions per node
# TYPE actions_node_total counter
actions_node_total{otel_scope_name="aws.node.termination.handler",otel_scope_version=""} 0
actions_node_total{node_action="cordon-and-drain",node_event_id="spot-itn-044b4639ef3811e75ffa8748538727f6ee75486fd7ac74e9ccd3a8185a8062b5",node_name="test",node_status="success",otel_scope_name="aws.node.termination.handler",otel_scope_version=""} 1
actions_node_total{node_action="pre-drain",node_event_id="spot-itn-044b4639ef3811e75ffa8748538727f6ee75486fd7ac74e9ccd3a8185a8062b5",node_name="test",node_status="success",otel_scope_name="aws.node.termination.handler",otel_scope_version=""} 1
# HELP events_error_total Number of errors in events processing
# TYPE events_error_total counter
events_error_total{otel_scope_name="aws.node.termination.handler",otel_scope_version=""} 0
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
