### PR TITLE
remove extra double quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,14 +126,14 @@ build-binaries-windows:
 
 upload-resources-to-github:
 	${MAKEFILE_PATH}/scripts/upload-resources-to-github
-	${MAKEFILE_PATH}/scripts/upload-resources-to-github -s "${K8S_1_25_ASSET_SUFFIX}"
+	${MAKEFILE_PATH}/scripts/upload-resources-to-github -s ${K8S_1_25_ASSET_SUFFIX}
 
 upload-resources-to-github-windows:
 	${MAKEFILE_PATH}/scripts/upload-resources-to-github -b
 
 generate-k8s-yaml:
 	${MAKEFILE_PATH}/scripts/generate-k8s-yaml
-	${MAKEFILE_PATH}/scripts/generate-k8s-yaml -k "1.25.0" -s "${K8S_1_25_ASSET_SUFFIX}"
+	${MAKEFILE_PATH}/scripts/generate-k8s-yaml -k "1.25.0" -s ${K8S_1_25_ASSET_SUFFIX}
 
 sync-readme-to-ecr-public:
 	@ECR_REGISTRY=${ECR_REGISTRY} ${MAKEFILE_PATH}/scripts/ecr-public-login


### PR DESCRIPTION
Release script fails on the extra double quotes - https://github.com/aws/aws-node-termination-handler/actions/runs/5291868437/jobs/9619737977#step:4:660 