### PR TITLE
fix release script to upload binaries once

### DIFF
--- a/scripts/upload-resources-to-github
+++ b/scripts/upload-resources-to-github
@@ -9,25 +9,30 @@ VERSION=$(make -s -f $SCRIPTPATH/../Makefile version)
 BUILD_DIR=$SCRIPTPATH/../build/k8s-resources/$VERSION
 BINARY_DIR=$SCRIPTPATH/../build/bin
 BINARIES_ONLY="false"
+K8s_ASSETS_ONLY="false"
 SUFFIX=""
 
 USAGE=$(cat << 'EOM'
   Usage: upload-resources-to-github  [-b]
-  Upload release assets to GitHub
+  Upload release assets to GitHub. Release assets include binaries for supported platforms and K8s resources for supported versions.
 
   Example: upload-resources-to-github -b
           Optional:
             -b          Upload binaries only [DEFAULT: upload all the assets]
+            -k          Upload K8s assets only
             -s SUFFIX   String appended to resource file names
 EOM
 )
 
 # Process our input arguments
-while getopts "bs:" opt; do
+while getopts "bks:" opt; do
   case ${opt} in
     b ) # Binaries only
         BINARIES_ONLY="true"
       ;;
+    k ) # K8s assets only
+        K8s_ASSETS_ONLY="true"
+        ;;
     s) # Suffix
         SUFFIX=$OPTARG
       ;;
@@ -70,9 +75,11 @@ handle_errors_and_cleanup() {
 
 gather_assets_to_upload() {
     local resources=()
-    for binary in $BINARY_DIR/*; do
-      resources+=("$binary")
-    done
+    if [ $K8s_ASSETS_ONLY != "true" ]; then
+      for binary in $BINARY_DIR/*; do
+        resources+=("$binary")
+      done
+    fi
     if [ $BINARIES_ONLY != "true" ]; then
       resources+=("$INDV_K8S_RESOURCES" "$AGG_RESOURCES_YAML" "$QP_INDV_K8S_RESOURCES" "$QP_AGG_RESOURCES_YAML")
     fi


### PR DESCRIPTION
Fix release script to upload binaries to Github only once. 

# Testing
```
$ ./upload-resources-to-github 

Uploading release assets for release id 'TEST' to Github

  1. *

  2. individual-resources.tar

  3. all-resources.yaml

  4. individual-resources-queue-processor.tar

  5. all-resources-queue-processor.yaml
----
$./upload-resources-to-github -s "-test"

Uploading release assets for release id 'TEST' to Github

  1. *

  2. individual-resources-test.tar

  3. all-resources-test.yaml

  4. individual-resources-queue-processor-test.tar

  5. all-resources-queue-processor-test.yaml

---
$./upload-resources-to-github -s "-test" -k

Uploading release assets for release id 'TEST' to Github

  1. individual-resources-test.tar

  2. all-resources-test.yaml

  3. individual-resources-queue-processor-test.tar

  4. all-resources-queue-processor-test.yaml



```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
