### PR TITLE
Upload k8s assets only on the second upload call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ build-binaries-windows:
 
 upload-resources-to-github:
 	${MAKEFILE_PATH}/scripts/upload-resources-to-github
-	${MAKEFILE_PATH}/scripts/upload-resources-to-github -s ${K8S_1_25_ASSET_SUFFIX}
+	${MAKEFILE_PATH}/scripts/upload-resources-to-github -k -s ${K8S_1_25_ASSET_SUFFIX}
 
 upload-resources-to-github-windows:
 	${MAKEFILE_PATH}/scripts/upload-resources-to-github -b


### PR DESCRIPTION
Upload k8s assets only on the second upload call


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
