### PR TITLE
Fixed kubernetes version in test file

### DIFF
--- a/test/eks-cluster-test/cluster-spec.yaml
+++ b/test/eks-cluster-test/cluster-spec.yaml
@@ -4,7 +4,7 @@ kind: ClusterConfig
 metadata:
   name: nth-eks-cluster-test
   region: us-west-2
-  version: '1.20'
+  version: '1.22'
 cloudWatch:
   clusterLogging:
     enableTypes: ["*"]


### PR DESCRIPTION
**Description of changes:**

Updated Kubernetes version in `cluster-spec.yaml` , we are using older version leading to test failures. Kubernetes supported versions start from `1.22`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
