### PR TITLE
docs: Cleanup installation process for Queue Processor

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -27,7 +27,7 @@ docker buildx build --load --platform "linux/arm64" -t ${USER}/aws-node-terminat
 To push a multi-arch image, you can use the helper tool [manifest-tool](https://github.com/estesp/manifest-tool).
 
 ```
-$ cat << EOF > manifest.yaml
+cat << EOF > manifest.yaml
 image: ${USER}/aws-node-termination-handler:v1.0.0
 manifests:
   -
@@ -41,7 +41,7 @@ manifests:
       architecture: arm64
       os: linux
 EOF
-$ manifest-tool push from-spec manifest.yaml
+manifest-tool push from-spec manifest.yaml
 ```
 
 ### Building for Windows

--- a/BUILD.md
+++ b/BUILD.md
@@ -19,9 +19,9 @@ make build-docker-images
 
 Under the hood, this passes each architecture as the `--platform` argument to `docker buildx build`, like this:
 ```
-$ docker buildx create --use
-$ docker buildx build --load --platform "linux/amd64" -t ${USER}/aws-node-termination-handler-amd64:v1.0.0 .
-$ docker buildx build --load --platform "linux/arm64" -t ${USER}/aws-node-termination-handler-arm64:v1.0.0 .
+docker buildx create --use
+docker buildx build --load --platform "linux/amd64" -t ${USER}/aws-node-termination-handler-amd64:v1.0.0 .
+docker buildx build --load --platform "linux/arm64" -t ${USER}/aws-node-termination-handler-arm64:v1.0.0 .
 ```
 
 To push a multi-arch image, you can use the helper tool [manifest-tool](https://github.com/estesp/manifest-tool).

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Here is the AWS CLI command to create an SQS queue to hold termination events fr
 
 ```
 ## Queue Policy
-$ QUEUE_POLICY=$(cat <<EOF
+QUEUE_POLICY=$(cat <<EOF
 {
     "Version": "2012-10-17",
     "Id": "MyQueuePolicy",
@@ -235,18 +235,17 @@ EOF
 )
 
 ## make sure the queue policy is valid JSON
-$ echo "$QUEUE_POLICY" | jq .
+echo "$QUEUE_POLICY" | jq .
 
 ## Save queue attributes to a temp file
-$ cat << EOF > /tmp/queue-attributes.json
+cat << EOF > /tmp/queue-attributes.json
 {
   "MessageRetentionPeriod": "300",
   "Policy": "$(echo $QUEUE_POLICY | sed 's/\"/\\"/g' | tr -d -s '\n' " ")",
-  "SqsManagedSseEnabled": true
 }
 EOF
 
-$ aws sqs create-queue --queue-name "${SQS_QUEUE_NAME}" --attributes file:///tmp/queue-attributes.json
+aws sqs create-queue --queue-name "${SQS_QUEUE_NAME}" --attributes file:///tmp/queue-attributes.json
 ```
 
 If you are sending Lifecycle termination events from ASG directly to SQS, instead of through EventBridge, then you will also need to create an IAM service role to give Amazon EC2 Auto Scaling access to your SQS queue. Please follow [these linked instructions to create the IAM service role: link.](https://docs.aws.amazon.com/autoscaling/ec2/userguide/configuring-lifecycle-hook-notifications.html#sqs-notifications)
@@ -262,7 +261,7 @@ There are some caveats when using [server side encryption with SQS](https://docs
 Here is the AWS CLI command to create a termination lifecycle hook on an existing ASG when using EventBridge, although this should really be configured via your favorite infrastructure-as-code tool like CloudFormation or Terraform:
 
 ```
-$ aws autoscaling put-lifecycle-hook \
+aws autoscaling put-lifecycle-hook \
   --lifecycle-hook-name=my-k8s-term-hook \
   --auto-scaling-group-name=my-k8s-asg \
   --lifecycle-transition=autoscaling:EC2_INSTANCE_TERMINATING \
@@ -273,7 +272,7 @@ $ aws autoscaling put-lifecycle-hook \
 If you want to avoid using EventBridge and instead send ASG Lifecycle events directly to SQS, instead use the following command, using the ARNs from Step 1:
 
 ```
-$ aws autoscaling put-lifecycle-hook \
+aws autoscaling put-lifecycle-hook \
   --lifecycle-hook-name=my-k8s-term-hook \
   --auto-scaling-group-name=my-k8s-asg \
   --lifecycle-transition=autoscaling:EC2_INSTANCE_TERMINATING \
@@ -290,7 +289,7 @@ The value of the key does not matter.
 
 To tag ASGs and propagate the tags to your instances (recommended):
 ```
-$ aws autoscaling create-or-update-tags \
+aws autoscaling create-or-update-tags \
   --tags ResourceId=my-auto-scaling-group,ResourceType=auto-scaling-group,Key=aws-node-termination-handler/managed,Value=,PropagateAtLaunch=true
 ```
 
@@ -320,39 +319,39 @@ If we use ASG without capacity-rebalance enabled, then spot interruptions will c
 Here are AWS CLI commands to create Amazon EventBridge rules so that ASG termination events, Spot Interruptions, Instance state changes, Rebalance Recommendations, and AWS Health Scheduled Changes are sent to the SQS queue created in the previous step. This should really be configured via your favorite infrastructure-as-code tool like CloudFormation (template [here](docs/cfn-template.yaml)) or Terraform:
 
 ```
-$ aws events put-rule \
+aws events put-rule \
   --name MyK8sASGTermRule \
   --event-pattern "{\"source\":[\"aws.autoscaling\"],\"detail-type\":[\"EC2 Instance-terminate Lifecycle Action\"]}"
 
-$ aws events put-targets --rule MyK8sASGTermRule \
+aws events put-targets --rule MyK8sASGTermRule \
   --targets "Id"="1","Arn"="arn:aws:sqs:us-east-1:123456789012:MyK8sTermQueue"
 
-$ aws events put-rule \
+aws events put-rule \
   --name MyK8sSpotTermRule \
   --event-pattern "{\"source\": [\"aws.ec2\"],\"detail-type\": [\"EC2 Spot Instance Interruption Warning\"]}"
 
-$ aws events put-targets --rule MyK8sSpotTermRule \
+aws events put-targets --rule MyK8sSpotTermRule \
   --targets "Id"="1","Arn"="arn:aws:sqs:us-east-1:123456789012:MyK8sTermQueue"
 
-$ aws events put-rule \
+aws events put-rule \
   --name MyK8sRebalanceRule \
   --event-pattern "{\"source\": [\"aws.ec2\"],\"detail-type\": [\"EC2 Instance Rebalance Recommendation\"]}"
 
-$ aws events put-targets --rule MyK8sRebalanceRule \
+aws events put-targets --rule MyK8sRebalanceRule \
   --targets "Id"="1","Arn"="arn:aws:sqs:us-east-1:123456789012:MyK8sTermQueue"
 
-$ aws events put-rule \
+aws events put-rule \
   --name MyK8sInstanceStateChangeRule \
   --event-pattern "{\"source\": [\"aws.ec2\"],\"detail-type\": [\"EC2 Instance State-change Notification\"]}"
 
-$ aws events put-targets --rule MyK8sInstanceStateChangeRule \
+aws events put-targets --rule MyK8sInstanceStateChangeRule \
   --targets "Id"="1","Arn"="arn:aws:sqs:us-east-1:123456789012:MyK8sTermQueue"
 
-$ aws events put-rule \
+aws events put-rule \
   --name MyK8sScheduledChangeRule \
   --event-pattern "{\"source\": [\"aws.health\"],\"detail-type\": [\"AWS Health Event\"],\"detail\": {\"service\": [\"EC2\"],\"eventTypeCategory\": [\"scheduledChange\"]}}"
 
-$ aws events put-targets --rule MyK8sScheduledChangeRule \
+aws events put-targets --rule MyK8sScheduledChangeRule \
   --targets "Id"="1","Arn"="arn:aws:sqs:us-east-1:123456789012:MyK8sTermQueue"
 ```
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ cat << EOF > /tmp/queue-attributes.json
 {
   "MessageRetentionPeriod": "300",
   "Policy": "$(echo $QUEUE_POLICY | sed 's/\"/\\"/g' | tr -d -s '\n' " ")",
+  "SqsManagedSseEnabled": "true"
 }
 EOF
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
While going over the installation process for a test setup I noticed some small QoL changes.

* Remove the leading `$ ` for code blocks, makes them functional when copy pasting them to a terminal
* Remove invalid `"SqsManagedSseEnabled": true` from the queue attributes
  * When executing `sqs create-queue` this returns the error: `Invalid type for parameter Attributes.SqsManagedSseEnabled, value: True, type: <class 'bool'>, valid types: <class 'str'>`
  * According to https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-sse-existing-queue.html encryption is enabled by default anyway. Also details on SQS encryption are outlined below the code block.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
