### PR TITLE
Created the Kubernetes Compatibility Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ Must be deployed as a Kubernetes **Deployment**. Also requires some **additional
 |        ASG Termination Lifecycle Hooks        |       ❌        |        ✅        |
 |         Instance State Change Events          |       ❌        |        ✅        |
 
+### Kubernetes Compatibility
+
+|  NTH Release  | K8s v1.26 | K8s v1.25 | K8s v1.24 | K8s v1.23 | K8s v1.22 | K8s v1.21 | 
+| :-----------: | :-------: | :-------: | :-------: | :-------: | :-------: | :-------: | 
+|    v1.20.0    |     ✅    |    ✅     |    ✅     |    ✅     |    ✅     |    ❌    |
+|    v1.19.0    |     ❌    |    ❌     |    ❌     |    ✅     |    ✅     |    ✅    |
+|    v1.18.3    |     ❌    |    ❌     |    ❌     |    ✅     |    ✅     |    ✅    |
+|    v1.18.2    |     ❌    |    ❌     |    ❌     |    ✅     |    ✅     |    ✅    | 
+|    v1.18.1    |     ❌    |    ❌     |    ❌     |    ✅     |    ✅     |    ✅    |   
+|    v1.18.0    |     ❌    |    ❌     |    ❌     |    ✅     |    ✅     |    ✅    |
+
 
 ## Installation and Configuration
 

--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ Must be deployed as a Kubernetes **Deployment**. Also requires some **additional
 
 ### Kubernetes Compatibility
 
-|  NTH Release  | K8s v1.26 | K8s v1.25 | K8s v1.24 | K8s v1.23 | K8s v1.22 | K8s v1.21 | 
-| :-----------: | :-------: | :-------: | :-------: | :-------: | :-------: | :-------: | 
-|    v1.20.0    |     ✅    |    ✅     |    ✅     |    ✅     |    ✅     |    ❌    |
-|    v1.19.0    |     ❌    |    ❌     |    ❌     |    ✅     |    ✅     |    ✅    |
-|    v1.18.3    |     ❌    |    ❌     |    ❌     |    ✅     |    ✅     |    ✅    |
-|    v1.18.2    |     ❌    |    ❌     |    ❌     |    ✅     |    ✅     |    ✅    | 
-|    v1.18.1    |     ❌    |    ❌     |    ❌     |    ✅     |    ✅     |    ✅    |   
-|    v1.18.0    |     ❌    |    ❌     |    ❌     |    ✅     |    ✅     |    ✅    |
+|                                      NTH Release                                      | K8s v1.26 | K8s v1.25 | K8s v1.24 | K8s v1.23 | K8s v1.22 | K8s v1.21 | 
+| :-----------------------------------------------------------------------------------: | :-------: | :-------: | :-------: | :-------: | :-------: | :-------: | 
+|  [v1.20.0](https://github.com/aws/aws-node-termination-handler/releases/tag/v1.20.0)  |     ✅    |    ✅     |    ✅     |    ✅     |    ✅     |    ❌    |
+|  [v1.19.0](https://github.com/aws/aws-node-termination-handler/releases/tag/v1.19.0)  |     ❌    |    ❌     |    ❌     |    ✅     |    ✅     |    ✅    |
+|  [v1.18.3](https://github.com/aws/aws-node-termination-handler/releases/tag/v1.18.3)  |     ❌    |    ❌     |    ❌     |    ✅     |    ✅     |    ✅    |
+|  [v1.18.2](https://github.com/aws/aws-node-termination-handler/releases/tag/v1.18.2)  |     ❌    |    ❌     |    ❌     |    ✅     |    ✅     |    ✅    | 
+|  [v1.18.1](https://github.com/aws/aws-node-termination-handler/releases/tag/v1.18.1)  |     ❌    |    ❌     |    ❌     |    ✅     |    ✅     |    ✅    |   
+|  [v1.18.0](https://github.com/aws/aws-node-termination-handler/releases/tag/v1.18.0)  |     ❌    |    ❌     |    ❌     |    ✅     |    ✅     |    ✅    |
 
 
 ## Installation and Configuration


### PR DESCRIPTION
**Issue #, if available:**
#823 

**Description of changes:**
Created a matrix/table that details the compatibility of recent NTH release with recent Kubernetes versions. A green checkmark indicates that a NTH release is compatible with a K8s version, and a red X indicates incompatibility. This table is located in the ReadMe.md file in the "Major Features" section. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
