### PR TITLE
Added k8s 1.27 version

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        k8sVersion: ["1.22", "1.23", "1.24", "1.25", "1.26"]
+        k8sVersion: ["1.23", "1.24", "1.25", "1.26", "1.27"]
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p>
   <a href="https://github.com/kubernetes/kubernetes/releases">
-    <img src="https://img.shields.io/badge/Kubernetes-%3E%3D%201.22-brightgreen" alt="kubernetes">
+    <img src="https://img.shields.io/badge/Kubernetes-%3E%3D%201.23-brightgreen" alt="kubernetes">
   </a>
   <a href="https://golang.org/doc/go1.20">
     <img src="https://img.shields.io/github/go-mod/go-version/aws/aws-node-termination-handler?color=blueviolet" alt="go-version">

--- a/test/eks-cluster-test/cluster-spec.yaml
+++ b/test/eks-cluster-test/cluster-spec.yaml
@@ -4,7 +4,7 @@ kind: ClusterConfig
 metadata:
   name: nth-eks-cluster-test
   region: us-west-2
-  version: '1.22'
+  version: '1.23'
 cloudWatch:
   clusterLogging:
     enableTypes: ["*"]

--- a/test/k8s-compatibility-test/run-k8s-compatibility-test.sh
+++ b/test/k8s-compatibility-test/run-k8s-compatibility-test.sh
@@ -2,14 +2,14 @@
 set -euo pipefail 
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-versions=("1.26" "1.25" "1.24" "1.23" "1.22")
+versions=("1.27""1.26" "1.25" "1.24" "1.23")
 E_CODE=0
 AFTER_FIRST_RUN_ARGS=""
 PASS_THRU_ARGS=""
 
 USAGE=$(cat << 'EOM'
   Usage: run-k8s-compatability-test [-h]
-  Executes the spot termination integration test for each version of kubernetes (k8s 1.22 - 1.26 supported)
+  Executes the spot termination integration test for each version of kubernetes (k8s 1.23 - 1.27 supported)
 
   Examples:
           # run test with direct download of go modules

--- a/test/k8s-local-cluster-test/provision-cluster
+++ b/test/k8s-local-cluster-test/provision-cluster
@@ -10,7 +10,7 @@ KIND_CONFIG_FILE=$SCRIPTPATH/kind-three-node-cluster.yaml
 use_psp=false
 
 # shellcheck disable=SC2034
-k8_1_27="kindest/node:v1.27.3@sha256:9dd3392d79af1b084671b05bcf65b21de476256ad1dcc853d9f3b10b4ac52dde"
+K8_1_27="kindest/node:v1.27.3@sha256:9dd3392d79af1b084671b05bcf65b21de476256ad1dcc853d9f3b10b4ac52dde"
 # shellcheck disable=SC2034
 K8_1_26="kindest/node:v1.26.3@sha256:94eb63275ad6305210041cdb5aca87c8562cc50fa152dbec3fef8c58479db4ff"
 # shellcheck disable=SC2034

--- a/test/k8s-local-cluster-test/provision-cluster
+++ b/test/k8s-local-cluster-test/provision-cluster
@@ -10,6 +10,8 @@ KIND_CONFIG_FILE=$SCRIPTPATH/kind-three-node-cluster.yaml
 use_psp=false
 
 # shellcheck disable=SC2034
+k8_1_27="kindest/node:v1.27.3@sha256:9dd3392d79af1b084671b05bcf65b21de476256ad1dcc853d9f3b10b4ac52dde"
+# shellcheck disable=SC2034
 K8_1_26="kindest/node:v1.26.3@sha256:94eb63275ad6305210041cdb5aca87c8562cc50fa152dbec3fef8c58479db4ff"
 # shellcheck disable=SC2034
 K8_1_25="kindest/node:v1.25.3@sha256:f1de3b0670462f43280114eccceab8bf1b9576d2afe0582f8f74529da6fd0365"
@@ -17,10 +19,8 @@ K8_1_25="kindest/node:v1.25.3@sha256:f1de3b0670462f43280114eccceab8bf1b9576d2afe
 K8_1_24="kindest/node:v1.24.7@sha256:5c015142d9b60a0f6c45573f809957076514e38ec973565e2b2fe828b91597f5"
 # shellcheck disable=SC2034
 K8_1_23="kindest/node:v1.23.5@sha256:1a72748086bc24ed6163de1d1e33cc0e2eb5a1eb5ebffdb15b53c3bcd5376a6f"
-# shellcheck disable=SC2034
-K8_1_22="kindest/node:v1.22.2@sha256:f638a08c1f68fe2a99e724ace6df233a546eaf6713019a0b310130a4f91ebe7f"
 
-K8_VERSION="$K8_1_22"
+K8_VERSION="$K8_1_23"
 KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 KIND_VERSION="0.17.0"
 HELM_VERSION="3.10.0"

--- a/test/k8s-local-cluster-test/run-test
+++ b/test/k8s-local-cluster-test/run-test
@@ -16,7 +16,7 @@ NODE_TERMINATION_HANDLER_DOCKER_IMG=""
 DEFAULT_WEBHOOK_DOCKER_IMG="webhook-test-proxy:customtest"
 WEBHOOK_DOCKER_IMG=""
 OVERRIDE_PATH=0
-K8S_VERSION="1.22"
+K8S_VERSION="1.23"
 AEMM_URL="amazon-ec2-metadata-mock-service.default.svc.cluster.local"
 AEMM_VERSION="1.8.1"
 AEMM_DL_URL="https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v$AEMM_VERSION/amazon-ec2-metadata-mock-$AEMM_VERSION.tgz"
@@ -136,7 +136,7 @@ USAGE=$(cat << 'EOM'
             -n          Node Termination Handler Docker Image
             -d          use GOPROXY=direct to bypass proxy.golang.org
             -o          Override path w/ your own kubectl and kind binaries
-            -v          Kubernetes Version (Default: 1.22) [1.22, 1.23, 1.24, 1.25, and 1.26]
+            -v          Kubernetes Version (Default: 1.23) [1.23, 1.24, 1.25, 1.26 and 1.27]
             -w          Webhook Docker Image
 
 EOM


### PR DESCRIPTION
**Issue #, if available:** https://github.com/aws/aws-node-termination-handler/pull/871

**Description of changes:**

Added k8s `1.27` version in e2e tests and removed the older versions that are not supported by EKS.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
