### PR TITLE
Changed drainHelper output stream to Stdout

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -644,7 +645,7 @@ func getDrainHelper(nthConfig config.Config) (*drain.Helper, error) {
 		AdditionalFilters:   []drain.PodFilter{filterPodForDeletion(nthConfig.PodName, nthConfig.PodNamespace)},
 		DeleteEmptyDirData:  nthConfig.DeleteLocalData,
 		Timeout:             time.Duration(nthConfig.NodeTerminationGracePeriod) * time.Second,
-		Out:                 log.Logger,
+		Out:                 zerolog.New(os.Stdout).With().Timestamp().Logger(),
 		ErrOut:              log.Logger,
 	}
 


### PR DESCRIPTION
**Issue #, if available:**
#841 

**Description of changes:**
Changed the standard output that DrainHelper uses for logging to Stdout, instead of its current state as Stderr. This reflects that output logs are application output and not error messages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
