### PR TITLE
Replicas

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,12 @@ helm upgrade --install aws-node-termination-handler \
 
 For a full list of configuration options see our [Helm readme](https://github.com/aws/aws-node-termination-handler/blob/v1.20.0/config/helm/aws-node-termination-handler#readme).
 
+#### Replica Usage
+- Using a **single** replica can delay message processing as only one message is processed at a time.
+- Using **multiple** replicas allows for the simultaneous processing of messages.
+  - Replicas may attempt to process the same message. This is avoided by the `visibilityTimeout`, however, draining a Node may take longer than the set visibilityTimeout, default of 20s. Increasing the visibilityTimeout to coincide with the maximum drainage time can mitigate this issue.
+    - `visibilityTimeout` can be increased up to 12 hours. An increase can lead to other replicas waiting longer to process the message upon failure. This can result in the Node not being cordoned or drained.
+
 #### Kubectl Apply
 
 Queue Processor needs an **SQS queue URL** to function; therefore, manifest changes are **REQUIRED** before using kubectl to directly add all of the above resources into your cluster.

--- a/README.md
+++ b/README.md
@@ -447,11 +447,22 @@ helm upgrade --install aws-node-termination-handler \
 
 For a full list of configuration options see our [Helm readme](https://github.com/aws/aws-node-termination-handler/blob/v1.20.0/config/helm/aws-node-termination-handler#readme).
 
-#### Replica Usage
-- Using a **single** replica can delay message processing as only one message is processed at a time.
-- Using **multiple** replicas allows for the simultaneous processing of messages.
-  - Replicas may attempt to process the same message. This is avoided by the `visibilityTimeout`, however, draining a Node may take longer than the set visibilityTimeout, default of 20s. Increasing the visibilityTimeout to coincide with the maximum drainage time can mitigate this issue.
-    - `visibilityTimeout` can be increased up to 12 hours. An increase can lead to other replicas waiting longer to process the message upon failure. This can result in the Node not being cordoned or drained.
+#### Single vs Multiple Replicas
+**Single** replica usage, by default, can process up to 10 messages at a time. Provides less throughput than **multiple** replica usage, but uses less resources.
+
+Example use cases for using a single replica:
+- Working with a relitively small (not large) cluster.
+- Node drainage that doesn't take significant time.
+- Limitted resources (memory or monetary) for allocation of NTH Pods on a cluster.
+
+**Multiple** replica usage allows for increased throughput and increased availability.
+
+Example use cases for using multiple replicas:
+- Working with a large scale cluster that can make use of the larger throughput from more NTH instances.
+- Node drainage that takes a significant time. Additional replicas increase throughput allowing for other messages to be processed.
+- A Node running an NTH instance is terminated, leaving downtime until K8s deploys another Pod to take its place. Replicas provide  mitigation with increased availabilty, allowing for NTH to still be operational.
+
+With **multiple** replicas, drainage times longer than the set visibility timeout of 20s may result in multiple NTH instances processing the same message. This will still result in a successful cordon/drainage, but will waste resources.
 
 #### Kubectl Apply
 

--- a/README.md
+++ b/README.md
@@ -449,19 +449,19 @@ For a full list of configuration options see our [Helm readme](https://github.co
 
 #### Single Instance vs Multiple Replicas
 
-The Helm chart, by default, will deploy a single instance of Amazon Node Termination Handler. With minimal usage of resources, this still provides good responsiveness in processing SQS messages.
+The Helm chart, by default, will deploy a single instance of Amazon Node Termination Handler. With the minimizing of resource usage, a single instance still provides good responsiveness in processing SQS messages.
 
 **When should multiple instances of Amazon Node Termination Handler be used?**
 
-* Responsiveness: The deployment of multiple Amazon Node Termination Handler instances will increase the throughput of processing SQS messages. This can aid in Amazon Node Termination Handler not responding to events as quickly as needed -- potentially because of numerous concurrent events or drained Pods taking a long time to terminate.
+* Responsiveness: Amazon Node Termination Handler may be taking longer than desired to process certain events, potentially in processing numerous concurrent events or taking too long to drain Pods. The deployment of multiple Amazon Node Termination Handler instances may help.
 
-* Availability: The deployment of multiple Amazon Node Termination Handler instances will provide mitigation in the case that Amazon Node Termination Handler itself is drained. The replica Amazon Node Termination Handlers will process SQS messages, avoiding a delay until the Deployment can start another instance. 
+* Availability: The deployment of multiple Amazon Node Termination Handler instances provides mitigation in the case that Amazon Node Termination Handler itself is drained. Replica Amazon Node Termination Handlers will process SQS messages, avoiding a delay until the Deployment can start another instance. 
 
 **Notes**
 
 * Running multiple instances of Amazon Node Termination Handler will not load balance responding to events. Each instance will greedily consume and respond to events.
 * Logs from multiple instances of Amazon Node Termination Handler are not aggregated.
-* Multiple instances of Amazon Node Termination Handler will respond to the same event, if the event takes longer than 20s to process. This will not result in any errors, with the first response having any effect.
+* Multiple instances of Amazon Node Termination Handler may respond to the same event, if it takes longer than 20s to process. This is not an error case, only the first response will have an affect.
 
 #### Kubectl Apply
 

--- a/README.md
+++ b/README.md
@@ -449,11 +449,11 @@ For a full list of configuration options see our [Helm readme](https://github.co
 
 #### Single Instance vs Multiple Replicas
 
-The Helm chart, by default, will deploy a single instance of Amazon Node Termination Handler. With minimal usage of resources this still provides good responsiveness in processing SQS messages.
+The Helm chart, by default, will deploy a single instance of Amazon Node Termination Handler. With minimal usage of resources, this still provides good responsiveness in processing SQS messages.
 
 **When should multiple instances of Amazon Node Termination Handler be used?**
 
-* Responsiveness: The deployment of multiple Amazon Node Termination Handler instances will increase the throughput of processing SQS messages. This can aide in Amazon Node Termination Handler not responding to events as quickly as needed -- potentially because of a large number of concurrent events or drained Pods taking a long time to terminate.
+* Responsiveness: The deployment of multiple Amazon Node Termination Handler instances will increase the throughput of processing SQS messages. This can aid in Amazon Node Termination Handler not responding to events as quickly as needed -- potentially because of numerous concurrent events or drained Pods taking a long time to terminate.
 
 * Availability: The deployment of multiple Amazon Node Termination Handler instances will provide mitigation in the case that Amazon Node Termination Handler itself is drained. The replica Amazon Node Termination Handlers will process SQS messages, avoiding a delay until the Deployment can start another instance. 
 
@@ -461,7 +461,7 @@ The Helm chart, by default, will deploy a single instance of Amazon Node Termina
 
 * Running multiple instances of Amazon Node Termination Handler will not load balance responding to events. Each instance will greedily consume and respond to events.
 * Logs from multiple instances of Amazon Node Termination Handler are not aggregated.
-* Multiple instances of Amazon Node Termination Handler will respond to the same event, if the event takes longer than 20s to process. This will not result in any errors, with the first responce having any affect.
+* Multiple instances of Amazon Node Termination Handler will respond to the same event, if the event takes longer than 20s to process. This will not result in any errors, with the first response having any effect.
 
 #### Kubectl Apply
 

--- a/README.md
+++ b/README.md
@@ -451,16 +451,16 @@ For a full list of configuration options see our [Helm readme](https://github.co
 **Single** replica usage, by default, can process up to 10 messages at a time. Provides less throughput than **multiple** replica usage, but uses less resources.
 
 Example use cases for using a single replica:
-- Working with a relitively small (not large) cluster.
+- Working with a relatively small (not large) cluster.
 - Node drainage that doesn't take significant time.
-- Limitted resources (memory or monetary) for allocation of NTH Pods on a cluster.
+- Limited resources (memory or monetary) for allocation of NTH Pods on a cluster.
 
 **Multiple** replica usage allows for increased throughput and increased availability.
 
 Example use cases for using multiple replicas:
 - Working with a large scale cluster that can make use of the larger throughput from more NTH instances.
-- Node drainage that takes a significant time. Additional replicas increase throughput allowing for other messages to be processed.
-- A Node running an NTH instance is terminated, leaving downtime until K8s deploys another Pod to take its place. Replicas provide  mitigation with increased availabilty, allowing for NTH to still be operational.
+- Node drainage that takes a significant time. Additional replicas increase throughput, allowing for other messages to be processed.
+- A Node running an NTH instance is terminated, leaving downtime until K8s deploys another Pod to take its place. Replicas provide  mitigation with increased availability, allowing for NTH to still be operational.
 
 With **multiple** replicas, drainage times longer than the set visibility timeout of 20s may result in multiple NTH instances processing the same message. This will still result in a successful cordon/drainage, but will waste resources.
 

--- a/README.md
+++ b/README.md
@@ -447,22 +447,21 @@ helm upgrade --install aws-node-termination-handler \
 
 For a full list of configuration options see our [Helm readme](https://github.com/aws/aws-node-termination-handler/blob/v1.20.0/config/helm/aws-node-termination-handler#readme).
 
-#### Single vs Multiple Replicas
-**Single** replica usage, by default, can process up to 10 messages at a time. Provides less throughput than **multiple** replica usage, but uses less resources.
+#### Single Instance vs Multiple Replicas
 
-Example use cases for using a single replica:
-- Working with a relatively small (not large) cluster.
-- Node drainage that doesn't take significant time.
-- Limited resources (memory or monetary) for allocation of NTH Pods on a cluster.
+The Helm chart, by default, will deploy a single instance of Amazon Node Termination Handler. With minimal usage of resources this still provides good responsiveness in processing SQS messages.
 
-**Multiple** replica usage allows for increased throughput and increased availability.
+**When should multiple instances of Amazon Node Termination Handler be used?**
 
-Example use cases for using multiple replicas:
-- Working with a large scale cluster that can make use of the larger throughput from more NTH instances.
-- Node drainage that takes a significant time. Additional replicas increase throughput, allowing for other messages to be processed.
-- A Node running an NTH instance is terminated, leaving downtime until K8s deploys another Pod to take its place. Replicas provide  mitigation with increased availability, allowing for NTH to still be operational.
+* Responsiveness: The deployment of multiple Amazon Node Termination Handler instances will increase the throughput of processing SQS messages. This can aide in Amazon Node Termination Handler not responding to events as quickly as needed -- potentially because of a large number of concurrent events or drained Pods taking a long time to terminate.
 
-With **multiple** replicas, drainage times longer than the set visibility timeout of 20s may result in multiple NTH instances processing the same message. This will still result in a successful cordon/drainage, but will waste resources.
+* Availability: The deployment of multiple Amazon Node Termination Handler instances will provide mitigation in the case that Amazon Node Termination Handler itself is drained. The replica Amazon Node Termination Handlers will process SQS messages, avoiding a delay until the Deployment can start another instance. 
+
+**Notes**
+
+* Running multiple instances of Amazon Node Termination Handler will not load balance responding to events. Each instance will greedily consume and respond to events.
+* Logs from multiple instances of Amazon Node Termination Handler are not aggregated.
+* Multiple instances of Amazon Node Termination Handler will respond to the same event, if the event takes longer than 20s to process. This will not result in any errors, with the first responce having any affect.
 
 #### Kubectl Apply
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -644,7 +645,7 @@ func getDrainHelper(nthConfig config.Config) (*drain.Helper, error) {
 		AdditionalFilters:   []drain.PodFilter{filterPodForDeletion(nthConfig.PodName, nthConfig.PodNamespace)},
 		DeleteEmptyDirData:  nthConfig.DeleteLocalData,
 		Timeout:             time.Duration(nthConfig.NodeTerminationGracePeriod) * time.Second,
-		Out:                 log.Logger,
+		Out:                 zerolog.New(os.Stdout).With().Timestamp().Logger(),
 		ErrOut:              log.Logger,
 	}
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -645,7 +644,7 @@ func getDrainHelper(nthConfig config.Config) (*drain.Helper, error) {
 		AdditionalFilters:   []drain.PodFilter{filterPodForDeletion(nthConfig.PodName, nthConfig.PodNamespace)},
 		DeleteEmptyDirData:  nthConfig.DeleteLocalData,
 		Timeout:             time.Duration(nthConfig.NodeTerminationGracePeriod) * time.Second,
-		Out:                 zerolog.New(os.Stdout).With().Timestamp().Logger(),
+		Out:                 log.Logger,
 		ErrOut:              log.Logger,
 	}
 


### PR DESCRIPTION
**Issue #, if available:**
#775 

**Description of changes:**
Added Replica Usage section to the main README.md under "AWS Node Termination Handler - Queue Processor". This provides information on the usage of single and multiple replicas in their handling of messages with SQS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
