### PR TITLE
ASG Launch Lifecycle Hooks

### DIFF
--- a/pkg/monitor/sqsevent/sqs-monitor.go
+++ b/pkg/monitor/sqsevent/sqs-monitor.go
@@ -148,7 +148,8 @@ func (m SQSMonitor) processLifecycleEventFromASG(message *sqs.Message) (EventBri
 		}
 		return eventBridgeEvent, skip{err}
 
-	case lifecycleEvent.LifecycleTransition != "autoscaling:EC2_INSTANCE_TERMINATING":
+	case lifecycleEvent.LifecycleTransition != "autoscaling:EC2_INSTANCE_TERMINATING" &&
+		lifecycleEvent.LifecycleTransition != "autoscaling:EC2_INSTANCE_LAUNCHING":
 		log.Err(err).Msg("only lifecycle termination events from ASG to SQS are supported outside EventBridge")
 		err = fmt.Errorf("unsupported message type (%s)", message.String())
 		return eventBridgeEvent, err
@@ -157,10 +158,47 @@ func (m SQSMonitor) processLifecycleEventFromASG(message *sqs.Message) (EventBri
 	eventBridgeEvent.Source = "aws.autoscaling"
 	eventBridgeEvent.Time = lifecycleEvent.Time
 	eventBridgeEvent.ID = lifecycleEvent.RequestID
+	eventBridgeEvent.DetailType = lifecycleEvent.LifecycleTransition
 	eventBridgeEvent.Detail, err = json.Marshal(lifecycleEvent)
 
 	log.Debug().Msg("processing lifecycle termination event from ASG")
 	return eventBridgeEvent, err
+}
+
+// Receives and processes SQS messages to check for ASG lifecycle hook informing of an EC2 instance launch
+func (m SQSMonitor) newASGInstanceLifeCycleReceived() (bool, error) {
+	newInstanceCreated := false
+	messages, err := m.receiveQueueMessages(m.QueueURL)
+	if err != nil {
+		log.Err(err).Msg("Error receiveing SQS queue messages.")
+		return false, err
+	}
+
+	failedEventBridgeEvents := 0
+	for _, message := range messages {
+		eventBridgeEvent, err := m.processSQSMessage(message)
+		if err != nil {
+			var s skip
+			if errors.As(err, &s) {
+				log.Warn().Err(s).Msg("skip processing SQS message")
+			} else {
+				log.Err(err).Msg("error processing SQS message")
+			}
+			continue
+		}
+
+		if eventBridgeEvent.DetailType == "autoscaling:EC2_INSTANCE_LAUNCHING" {
+			log.Info().Msg("New EC2 instance created by ASG")
+			newInstanceCreated = true
+			break
+		}
+	}
+
+	if len(messages) > 0 && failedEventBridgeEvents == len(messages) {
+		err = fmt.Errorf("none of the waiting queue events could be processed")
+	}
+
+	return newInstanceCreated, err
 }
 
 // processEventBridgeEvent processes an EventBridge event and returns interruption event wrappers
@@ -171,6 +209,14 @@ func (m SQSMonitor) processEventBridgeEvent(eventBridgeEvent *EventBridgeEvent, 
 
 	switch eventBridgeEvent.Source {
 	case "aws.autoscaling":
+		newInstanceCreated, err := m.newASGInstanceLifeCycleReceived()
+		for !newInstanceCreated {
+			if err != nil {
+				log.Err(err)
+				break
+			}
+			newInstanceCreated, err = m.newASGInstanceLifeCycleReceived()
+		}
 		interruptionEvent, err = m.asgTerminationToInterruptionEvent(eventBridgeEvent, message)
 		return append(interruptionEventWrappers, InterruptionEventWrapper{interruptionEvent, err})
 

--- a/pkg/monitor/sqsevent/sqs-monitor.go
+++ b/pkg/monitor/sqsevent/sqs-monitor.go
@@ -175,6 +175,7 @@ func (m SQSMonitor) processEventBridgeEvent(eventBridgeEvent *EventBridgeEvent, 
 	case "aws.autoscaling":
 		if eventBridgeEvent.DetailType == "autoscaling:EC2_INSTANCE_LAUNCHING" {
 			err = m.asgCompleteLaunchLifecycle(eventBridgeEvent)
+			interruptionEvent = nil
 		} else if eventBridgeEvent.DetailType == "autoscaling:EC2_INSTANCE_TERMINATING" {
 			interruptionEvent, err = m.asgTerminationToInterruptionEvent(eventBridgeEvent, message)
 		}


### PR DESCRIPTION
**Issue #, if available:**
#292 

**Description of changes:**
NTH now completes ASG lifecycle hooks for launched instances. This allows for instances to be launched before or during termination to avoid Node downtime, with the setting of the Capacity Rebalance feature for ASG. NTH catches ASG Launch lifecycle hooks while monitoring the SQS queue for events. The hook is then completed if the launched Node has a Ready status in the K8s cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
