### PR TITLE
Docs: Terraform Node Termination Handler with SQS

### DIFF
--- a/docs/terraform/.gitignore
+++ b/docs/terraform/.gitignore
@@ -1,0 +1,5 @@
+terraform.tf*
+.terraform/**
+.terraform.tfstate*
+.terraform.lock*
+.terraform

--- a/docs/terraform/README.md
+++ b/docs/terraform/README.md
@@ -1,0 +1,49 @@
+# Setup Node Termination Handler with Terraform Providers
+
+## Helm chart provider example
+
+```hcl
+resource "helm_release" "node_termination_handler" {
+  name      = "aws-node-termination-handler"
+  namespace = "kube-system"
+
+  chart      = "aws-node-termination-handler"
+  repository = "https://aws.github.io/eks-charts/"
+  version    = "0.21.0"
+
+  set {
+    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+    value = aws_iam_role.aws_node_termination_handler_role.arn
+  }
+
+  set {
+    name  = "awsRegion"
+    value = var.aws_region
+  }
+
+  set {
+    name  = "queueURL"
+    value = aws_sqs_queue.main.url
+  }
+
+  set {
+    name  = "checkTagBeforeDraining"
+    value = false
+  }
+
+  set {
+    name  = "enableSqsTerminationDraining"
+    value = true
+  }
+}
+```
+
+## Apply Terraform  
+
+```bash
+terraform init 
+```
+
+```bash
+terraform apply --auto-approve 
+```

--- a/docs/terraform/data.tf
+++ b/docs/terraform/data.tf
@@ -1,0 +1,9 @@
+data "aws_eks_cluster" "main" {
+  name = var.cluster_name
+}
+
+data "aws_eks_cluster_auth" "main" {
+  name = var.cluster_name
+}
+
+data "aws_caller_identity" "current" {}

--- a/docs/terraform/event_rules.tf
+++ b/docs/terraform/event_rules.tf
@@ -1,0 +1,100 @@
+resource "aws_cloudwatch_event_rule" "node_termination_handler_instance_terminate" {
+  name        = format("%s-node-termination-handler-instance-terminate", var.cluster_name)
+  description = var.cluster_name
+
+  event_pattern = jsonencode({
+    source = ["aws.autoscaling"]
+    detail-type = [
+      "EC2 Instance-terminate Lifecycle Action"
+    ]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "node_termination_handler_instance_terminate" {
+  rule      = aws_cloudwatch_event_rule.node_termination_handler_instance_terminate.name
+  target_id = "SendToSQS"
+  arn       = aws_sqs_queue.main.arn
+}
+
+
+resource "aws_cloudwatch_event_rule" "node_termination_handler_scheduled_change" {
+  name        = format("%s-node-termination-handler-scheduled-change", var.cluster_name)
+  description = var.cluster_name
+
+  event_pattern = jsonencode({
+    source = ["aws.health"]
+    detail-type = [
+      "AWS Health Event"
+    ]
+    detail = {
+      service = [
+        "EC2"
+      ]
+      eventTypeCategory = [
+        "scheduledChange"
+      ]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "node_termination_handler_scheduled_change" {
+  rule      = aws_cloudwatch_event_rule.node_termination_handler_scheduled_change.name
+  target_id = "SendToSQS"
+  arn       = aws_sqs_queue.main.arn
+}
+
+resource "aws_cloudwatch_event_rule" "node_termination_handler_spot_termination" {
+  name        = format("%s-node-termination-handler-spot-termination", var.cluster_name)
+  description = var.cluster_name
+
+  event_pattern = jsonencode({
+    source = ["aws.ec2"]
+    detail-type = [
+      "EC2 Spot Instance Interruption Warning"
+    ]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "node_termination_handler_spot_termination" {
+  rule      = aws_cloudwatch_event_rule.node_termination_handler_spot_termination.name
+  target_id = "SendToSQS"
+  arn       = aws_sqs_queue.main.arn
+}
+
+
+resource "aws_cloudwatch_event_rule" "node_termination_handler_rebalance" {
+  name        = format("%s-node-termination-handler-rebalance", var.cluster_name)
+  description = var.cluster_name
+
+  event_pattern = jsonencode({
+    source = ["aws.ec2"]
+    detail-type = [
+      "EC2 Instance Rebalance Recommendation"
+    ]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "node_termination_handler_rebalance" {
+  rule      = aws_cloudwatch_event_rule.node_termination_handler_rebalance.name
+  target_id = "SendToSQS"
+  arn       = aws_sqs_queue.main.arn
+}
+
+
+resource "aws_cloudwatch_event_rule" "node_termination_handler_state_change" {
+  name        = format("%s-node-termination-handler-state-change", var.cluster_name)
+  description = var.cluster_name
+
+  event_pattern = jsonencode({
+    source = ["aws.ec2"]
+    detail-type = [
+      "EC2 Instance State-change Notification"
+    ]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "node_termination_handler_state_change" {
+  rule      = aws_cloudwatch_event_rule.node_termination_handler_state_change.name
+  target_id = "SendToSQS"
+  arn       = aws_sqs_queue.main.arn
+}

--- a/docs/terraform/helm_node_termination_handler.tf
+++ b/docs/terraform/helm_node_termination_handler.tf
@@ -1,0 +1,33 @@
+resource "helm_release" "node_termination_handler" {
+  name      = "aws-node-termination-handler"
+  namespace = "kube-system"
+
+  chart      = "aws-node-termination-handler"
+  repository = "https://aws.github.io/eks-charts/"
+  version    = "0.21.0"
+
+  set {
+    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+    value = aws_iam_role.aws_node_termination_handler_role.arn
+  }
+
+  set {
+    name  = "awsRegion"
+    value = var.aws_region
+  }
+
+  set {
+    name  = "queueURL"
+    value = aws_sqs_queue.main.url
+  }
+
+  set {
+    name  = "checkTagBeforeDraining"
+    value = false
+  }
+
+  set {
+    name  = "enableSqsTerminationDraining"
+    value = true
+  }
+}

--- a/docs/terraform/iam.tf
+++ b/docs/terraform/iam.tf
@@ -1,0 +1,58 @@
+data "aws_iam_policy_document" "aws_node_termination_handler_role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    principals {
+      identifiers = [
+        format("arn:aws:iam::%s:oidc-provider/%s", data.aws_caller_identity.current.account_id, replace(data.aws_eks_cluster.main.identity[0].oidc[0].issuer, "https://", ""))
+      ]
+      type = "Federated"
+    }
+  }
+}
+
+resource "aws_iam_role" "aws_node_termination_handler_role" {
+  assume_role_policy = data.aws_iam_policy_document.aws_node_termination_handler_role.json
+  name               = format("%s-aws-node-termination-handler", var.cluster_name)
+}
+
+
+data "aws_iam_policy_document" "aws_node_termination_handler_policy" {
+  version = "2012-10-17"
+
+  statement {
+
+    effect = "Allow"
+    actions = [
+      "autoscaling:CompleteLifecycleAction",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeTags",
+      "ec2:DescribeInstances",
+      "sqs:DeleteMessage",
+      "sqs:ReceiveMessage"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+  }
+}
+
+resource "aws_iam_policy" "aws_node_termination_handler_policy" {
+  name        = format("%s-aws_node_termination_handler", var.cluster_name)
+  path        = "/"
+  description = var.cluster_name
+
+  policy = data.aws_iam_policy_document.aws_node_termination_handler_policy.json
+}
+
+resource "aws_iam_policy_attachment" "aws_node_termination_handler_policy" {
+  name = "aws_node_termination_handler"
+  roles = [
+    aws_iam_role.aws_node_termination_handler_role.name
+  ]
+
+  policy_arn = aws_iam_policy.aws_node_termination_handler_policy.arn
+}

--- a/docs/terraform/providers.tf
+++ b/docs/terraform/providers.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.main.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.main.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.main.token
+  }
+}

--- a/docs/terraform/sqs.tf
+++ b/docs/terraform/sqs.tf
@@ -1,0 +1,29 @@
+resource "aws_sqs_queue" "main" {
+  name                       = format("%s-aws-node-termination-handler", var.cluster_name)
+  delay_seconds              = 0
+  max_message_size           = 2048
+  message_retention_seconds  = 86400
+  receive_wait_time_seconds  = 10
+  visibility_timeout_seconds = 60
+}
+
+resource "aws_sqs_queue_policy" "main" {
+  queue_url = aws_sqs_queue.main.id
+  policy    = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": [
+        "sqs:SendMessage"
+      ],
+      "Resource": [
+        "${aws_sqs_queue.main.arn}"
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/docs/terraform/variables.tf
+++ b/docs/terraform/variables.tf
@@ -1,0 +1,7 @@
+variable "cluster_name" {
+  default = "eks-cluster"
+}
+
+variable "aws_region" {
+  default = "us-east-1"
+}


### PR DESCRIPTION
Sending this PR with a quick Terraform example showing how to setup `aws-node-termination-handler` with `Helm Provider` and SQS.

### This example cover:
* Terraform setup 
* Helm provider setup
* SQS Queue 
* IAM Permissions 
* Event Bridge Rules 

I hope it helps someone