### PR TITLE
Deduping duplicate webhooks sent for the same Node

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -370,7 +370,9 @@ func drainOrCordonIfNecessary(interruptionEventStore *interruptioneventstore.Sto
 		err = cordonAndDrainNode(node, nodeName, drainEvent, metrics, recorder, nthConfig.EnableSQSTerminationDraining)
 	}
 
-	webhook.SinglePost(nodeMetadata, drainEvent, nthConfig, webhook.Post)
+	if nthConfig.WebhookURL != "" {
+		webhook.SinglePost(webhook.Post)(nodeMetadata, drainEvent, nthConfig)
+	}
 
 	if err != nil {
 		interruptionEventStore.CancelInterruptionEvent(drainEvent.EventID)

--- a/pkg/interruptioneventstore/interruption-event-store.go
+++ b/pkg/interruptioneventstore/interruption-event-store.go
@@ -204,12 +204,3 @@ func (s *Store) logPeriodically() {
 		Msg("event store statistics")
 	s.callsSinceLastLog = 0
 }
-
-func (s *Store) IsEventProcessed(eventID string) bool {
-	for id, event := range s.interruptionEventStore {
-		if id == eventID {
-			return event.NodeProcessed
-		}
-	}
-	return true
-}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -42,8 +42,11 @@ var m sync.RWMutex
 
 type PostDecorator func(additionalInfo ec2metadata.NodeMetadata, event *monitor.InterruptionEvent, nthConfig config.Config)
 
-func SinglePost(additionalInfo ec2metadata.NodeMetadata, event *monitor.InterruptionEvent, nthConfig config.Config, postFn PostDecorator) PostDecorator {
+func SinglePost(postFn PostDecorator) PostDecorator {
 	return func(additionalInfo ec2metadata.NodeMetadata, event *monitor.InterruptionEvent, nthConfig config.Config) {
+		m.Lock()
+		defer m.Unlock()
+
 		if previousEvent, ok := instanceEventMap[event.InstanceID]; !ok || (previousEvent.Kind == monitor.RebalanceRecommendationKind && event.Kind == monitor.SpotITNKind) {
 			postFn(additionalInfo, event, nthConfig)
 			instanceEventMap[event.InstanceID] = event


### PR DESCRIPTION
**Issue #, if available:**
#297 

**Description of changes:**
Checks to see if the node doesn't exist, if it has already been marked as unschedulable, and if has already been processed in order to prevent duplicate webhooks from being sent. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
