### PR TITLE
fix: exit when recv sig

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -243,11 +243,14 @@ func main() {
 
 	var wg sync.WaitGroup
 
+loop:
 	for range time.NewTicker(1 * time.Second).C {
 		select {
 		case <-signalChan:
 			// Exit interruption loop if a SIGTERM is received or the channel is closed
-			break
+			// exit = true
+			wg.Done()
+			break loop
 		default:
 		EventLoop:
 			for event, ok := interruptionEventStore.GetActiveEvent(); ok; event, ok = interruptionEventStore.GetActiveEvent() {

--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -248,8 +248,6 @@ loop:
 		select {
 		case <-signalChan:
 			// Exit interruption loop if a SIGTERM is received or the channel is closed
-			// exit = true
-			wg.Done()
 			break loop
 		default:
 		EventLoop:


### PR DESCRIPTION
### summary

process exit when recv signal. exit 2 level loop, otherwise `wg.wait` will block ? 😁

```
	for range time.NewTicker(1 * time.Second).C {
		select {
		case <-signalChan:
			break  // 😅 the `break` only break select-loop, but don't break for-loop outside.
                 }
                 ...
}
```