### PR TITLE
fix ECR credentials for Windows release workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ BINARY_NAME ?= "node-termination-handler"
 THIRD_PARTY_LICENSES = "${MAKEFILE_PATH}/THIRD_PARTY_LICENSES.md"
 GOLICENSES = $(BIN_DIR)/go-licenses
 K8S_1_25_ASSET_SUFFIX = "_k8s-1-25-or-newer"
+AMAZON_ECR_CREDENTIAL_HELPER_VERSION = 0.7.1
 
 $(shell mkdir -p ${BUILD_DIR_PATH} && touch ${BUILD_DIR_PATH}/_go.mod)
 
@@ -57,7 +58,7 @@ push-docker-images:
 
 push-docker-images-windows:
 	${MAKEFILE_PATH}/scripts/retag-docker-images -p ${SUPPORTED_PLATFORMS_WINDOWS} -v ${VERSION} -o ${IMG} -n ${ECR_REPO}
-	@ECR_REGISTRY=${ECR_REGISTRY} ${MAKEFILE_PATH}/scripts/ecr-public-login
+	${MAKEFILE_PATH}/scripts/install-amazon-ecr-credential-helper $(AMAZON_ECR_CREDENTIAL_HELPER_VERSION)
 	${MAKEFILE_PATH}/scripts/push-docker-images -p ${SUPPORTED_PLATFORMS_WINDOWS} -r ${ECR_REPO} -v ${VERSION} -m
 
 push-helm-chart:

--- a/scripts/install-amazon-ecr-credential-helper
+++ b/scripts/install-amazon-ecr-credential-helper
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage=$(cat << EOM
+  Download and install amazon-ecr-credential-helper for Docker client.
+
+  usage: $(basename $0) [-h] VERSION
+
+  Options:
+    -h  Print help message then exit
+
+  Arguments:
+    VERSION Version number of amazon-ecr-login-helper to download and install (e.g. 0.7.1)
+
+EOM
+)
+
+function display_help {
+    echo "${usage}" 1<&2
+}
+
+while getopts "h" arg; do
+    case "${arg}" in
+        h ) display_help
+            exit 0
+            ;;
+
+        * ) display_help
+            exit 1
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+version="${1:-}"
+if [[ -z "${version}" ]]; then
+    echo "❌ no version given"
+    display_help
+    exit 1
+fi
+
+install_path="$(dirname "$(which docker-credential-wincred.exe)")"
+curl -Lo "${install_path}/docker-credential-ecr-login.exe" "https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/${version}/windows-amd64/docker-credential-ecr-login.exe"
+
+# Update Docker to use ecr-login instead of wincred.
+modified_config="$(mktemp)"
+jq '.credsStore="ecr-login"' ~/.docker/config.json > "${modified_config}"
+mv -f "${modified_config}" ~/.docker/config.json


### PR DESCRIPTION
**Issue #, if available:**

#954 

Same error message was reported in https://github.com/aws/aws-cli/issues/5636 which is caused by https://github.com/danieljoos/wincred/issues/18 which is because of a limitation in a Windows API.

**Description of changes:**

Use [amazon-ecr-credential-helper](https://github.com/awslabs/amazon-ecr-credential-helper) instead of pre-installed WinCred credentials helper.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
