### PR TITLE
invoke bash directly on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ push-docker-images:
 
 push-docker-images-windows:
 	${MAKEFILE_PATH}/scripts/retag-docker-images -p ${SUPPORTED_PLATFORMS_WINDOWS} -v ${VERSION} -o ${IMG} -n ${ECR_REPO}
-	${MAKEFILE_PATH}/scripts/install-amazon-ecr-credential-helper $(AMAZON_ECR_CREDENTIAL_HELPER_VERSION)
+	bash ${MAKEFILE_PATH}/scripts/install-amazon-ecr-credential-helper $(AMAZON_ECR_CREDENTIAL_HELPER_VERSION)
 	${MAKEFILE_PATH}/scripts/push-docker-images -p ${SUPPORTED_PLATFORMS_WINDOWS} -r ${ECR_REPO} -v ${VERSION} -m
 
 push-helm-chart:


### PR DESCRIPTION
**Description of changes:**

* Invoke bash directly to run `scripts/install-amazon-ecr-credential-helper` on Windows


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
