### PR TITLE
Fix misleading launch event log message

### DIFF
--- a/pkg/monitor/sqsevent/asg-lifecycle-event.go
+++ b/pkg/monitor/sqsevent/asg-lifecycle-event.go
@@ -163,7 +163,7 @@ func (m SQSMonitor) createAsgInstanceLaunchEvent(event *EventBridgeEvent, messag
 		IsManaged:            nodeInfo.IsManaged,
 		InstanceID:           lifecycleDetail.EC2InstanceID,
 		ProviderID:           nodeInfo.ProviderID,
-		Description:          fmt.Sprintf("ASG Lifecycle Launch event received. Instance will be interrupted at %s \n", event.getTime()),
+		Description:          fmt.Sprintf("ASG Lifecycle Launch event received. Instance was started at %s \n", event.getTime()),
 	}
 
 	interruptionEvent.PostDrainTask = func(interruptionEvent monitor.InterruptionEvent, _ node.Node) error {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
The description was probably copied from the old interruption event in #940, I was pretty confused when I read the logs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
