### PR TITLE
Temporarily removed uploading windows binaries to release assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ eks-cluster-test:
 
 release: build-binaries build-docker-images push-docker-images generate-k8s-yaml upload-resources-to-github
 
-release-windows: build-binaries-windows build-docker-images-windows push-docker-images-windows upload-resources-to-github-windows
+release-windows: build-binaries-windows build-docker-images-windows push-docker-images-windows
 
 test: spellcheck shellcheck unit-test e2e-test compatibility-test license-test go-linter helm-version-sync-test helm-lint
 


### PR DESCRIPTION
**Description of changes:**

We are currently having issues adding windows binaries to release assets. We are planning to mitigate this as soon as possible. Due to these issues, we are unable to push helm charts to ecr-public causing inconvenience to customers. Temporarily removing uploading resources for windows to have smooth release process.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
