### PR TITLE
Allow using kube-apiserver cache for pod list requests

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -52,6 +52,7 @@ func TestParseCliArgsEnvSuccess(t *testing.T) {
 	t.Setenv("WEBHOOK_TEMPLATE", "WEBHOOK_TEMPLATE")
 	t.Setenv("METADATA_TRIES", "100")
 	t.Setenv("CORDON_ONLY", "false")
+	t.Setenv("USE_APISERVER_CACHE", "true")
 	nthConfig, err := config.ParseCliArgs()
 	h.Ok(t, err)
 
@@ -76,6 +77,7 @@ func TestParseCliArgsEnvSuccess(t *testing.T) {
 	h.Equals(t, "WEBHOOK_TEMPLATE", nthConfig.WebhookTemplate)
 	h.Equals(t, 100, nthConfig.MetadataTries)
 	h.Equals(t, false, nthConfig.CordonOnly)
+	h.Equals(t, true, nthConfig.UseAPIServerCacheToListPods)
 
 	// Check that env vars were set
 	value, ok := os.LookupEnv("KUBERNETES_SERVICE_HOST")
@@ -111,6 +113,7 @@ func TestParseCliArgsSuccess(t *testing.T) {
 		"--webhook-template=WEBHOOK_TEMPLATE",
 		"--metadata-tries=100",
 		"--cordon-only=false",
+		"--use-apiserver-cache=true",
 	}
 	nthConfig, err := config.ParseCliArgs()
 	h.Ok(t, err)
@@ -137,6 +140,7 @@ func TestParseCliArgsSuccess(t *testing.T) {
 	h.Equals(t, 100, nthConfig.MetadataTries)
 	h.Equals(t, false, nthConfig.CordonOnly)
 	h.Equals(t, false, nthConfig.EnablePrometheus)
+	h.Equals(t, true, nthConfig.UseAPIServerCacheToListPods)
 
 	// Check that env vars were set
 	value, ok := os.LookupEnv("KUBERNETES_SERVICE_HOST")

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -628,9 +628,13 @@ func (n Node) fetchAllPods(nodeName string) (*corev1.PodList, error) {
 		log.Info().Msgf("Would have retrieved running pod list on node %s, but dry-run flag was set", nodeName)
 		return &corev1.PodList{}, nil
 	}
-	return n.drainHelper.Client.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{
+	listOptions := metav1.ListOptions{
 		FieldSelector: "spec.nodeName=" + nodeName,
-	})
+	}
+	if n.nthConfig.UseAPIServerCacheToListPods {
+		listOptions.ResourceVersion = "0"
+	}
+	return n.drainHelper.Client.CoreV1().Pods("").List(context.TODO(), listOptions)
 }
 
 func getDrainHelper(nthConfig config.Config, clientset *kubernetes.Clientset) (*drain.Helper, error) {


### PR DESCRIPTION
**Issue #, if available:** https://github.com/aws/aws-node-termination-handler/issues/1017

**Description of changes:** Exposes the configuration `use_apiserver_cache`, which sets `ResourceVersion: "0"` when listing pods on a node.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
