### PR TITLE
Removing adding windows binaries to release assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ eks-cluster-test:
 
 release: build-binaries build-docker-images push-docker-images generate-k8s-yaml upload-resources-to-github
 
-release-windows: build-binaries-windows build-docker-images-windows push-docker-images-windows upload-resources-to-github-windows
+release-windows: build-binaries-windows build-docker-images-windows push-docker-images-windows
 
 test: spellcheck shellcheck unit-test e2e-test compatibility-test license-test go-linter helm-version-sync-test helm-lint
 


### PR DESCRIPTION
**Issue #, if available:**

Adding windows binaries to release assets is failing when we are doing a new NTH release. We fixed this earlier and able to view windows binaries uploaded successfully in our local forks. We will fix this in next release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
