### PR TITLE
synchronize the linux and windows release process to avoid overwriting the manifest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,7 @@ jobs:
   releaseWindows:
     name: Release Windows
     runs-on: windows-2019
+    needs: [releaseLinux]
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
- Synchronize the linux and windows release process to avoid a timing issue where the manifest gets overwritten. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
