### PR TITLE
added windows 2022 support

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -122,8 +122,8 @@ jobs:
     - name: Build Linux Docker Images
       run: make build-docker-images
 
-  buildWindows:
-    name: Build Windows Binaries
+  buildWindows2019:
+    name: Build Windows 2019 Binaries
     runs-on: windows-2019
     steps:
     - name: Set up Go 1.x
@@ -149,10 +149,39 @@ jobs:
         Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
         refreshenv
 
-        choco install make && choco install zip && make build-binaries-windows
+        choco install make && choco install zip && make build-binaries-windows-2019
 
-  buildWindowsDocker:
-    name: Build Windows Docker Images
+  buildWindows2022:
+    name: Build Windows 2022 Binaries
+    runs-on: windows-2022
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.DEFAULT_GO_VERSION }}
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Restore go mod cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+          ~/go/bin/
+        key: gocache
+
+    - name: Build Windows Binaries
+      run: |
+        $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
+        Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+        refreshenv
+
+        choco install make && choco install zip && make build-binaries-windows-2022
+
+  buildWindows2019Docker:
+    name: Build Windows 2019 Docker Images
     runs-on: windows-2019
     steps:
     - name: Set up Go 1.x
@@ -178,7 +207,36 @@ jobs:
         Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
         refreshenv
 
-        choco install make && make build-docker-images-windows
+        choco install make && make build-docker-images-windows-2019
+
+  buildWindows2022Docker:
+    name: Build Windows 2022 Docker Images
+    runs-on: windows-2022
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.DEFAULT_GO_VERSION }}
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Restore go mod cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+          ~/go/bin/
+        key: gocache
+
+    - name: Build Windows Docker Images
+      run: |
+        $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
+        Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+        refreshenv
+
+        choco install make && make build-docker-images-windows-2022
 
   e2e:
     name: E2E Tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,8 +34,8 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
 
-  releaseWindows:
-    name: Release Windows
+  releaseWindows2019:
+    name: Release Windows 2019
     runs-on: windows-2019
     needs: [releaseLinux]
     steps:
@@ -53,7 +53,32 @@ jobs:
         Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
         refreshenv
 
-        choco install make && choco install zip && make release-windows
+        choco install make && choco install zip && make release-windows-2019
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+
+  releaseWindows2022:
+    name: Release Windows 2022
+    runs-on: windows-2022
+    needs: [releaseLinux]
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.DEFAULT_GO_VERSION }}
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Release Windows Assets
+      run: |
+        $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
+        Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+        refreshenv
+
+        choco install make && choco install zip && make release-windows-2022
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -62,7 +87,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-20.04
-    needs: [releaseLinux, releaseWindows]
+    needs: [releaseLinux, releaseWindows2019, releaseWindows2022]
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,16 @@ MAKEFILE_PATH = $(dir $(realpath -s $(firstword $(MAKEFILE_LIST))))
 BUILD_DIR_PATH = ${MAKEFILE_PATH}/build
 BIN_DIR = ${MAKEFILE_PATH}/bin
 SUPPORTED_PLATFORMS_LINUX ?= "linux/amd64,linux/arm64"
-SUPPORTED_PLATFORMS_WINDOWS ?= "windows/amd64"
+
+# Each windows version needs a separate make target because each build 
+# needs to happen on a separate GitHub runner
+# A windows version is specified by major-minor-build-revision. 
+# The build number of the OS must match the build number of the container image
+# The revision does not matter for windows 2019 and 2022.
+# Reference: https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility
+WINDOWS_2019 ?= "windows-10.0.17763.6189/amd64"
+WINDOWS_2022 ?= "windows-10.0.20348.2582/amd64"
+
 BINARY_NAME ?= "node-termination-handler"
 THIRD_PARTY_LICENSES = "${MAKEFILE_PATH}/THIRD_PARTY_LICENSES.md"
 GOLICENSES = $(BIN_DIR)/go-licenses
@@ -48,18 +57,32 @@ docker-run:
 build-docker-images:
 	${MAKEFILE_PATH}/scripts/build-docker-images -p ${SUPPORTED_PLATFORMS_LINUX} -r ${IMG} -v ${VERSION}
 
-build-docker-images-windows:
-	${MAKEFILE_PATH}/scripts/build-docker-images -p ${SUPPORTED_PLATFORMS_WINDOWS} -r ${IMG} -v ${VERSION}
+build-docker-images-windows-2019:
+	${MAKEFILE_PATH}/scripts/build-docker-images -p ${WINDOWS_2019} -r ${IMG} -v ${VERSION}
+
+build-docker-images-windows-2022:
+	${MAKEFILE_PATH}/scripts/build-docker-images -p ${WINDOWS_2022} -r ${IMG} -v ${VERSION}
+
+ecr-public-login:
+	@ECR_REGISTRY=${ECR_REGISTRY} ${MAKEFILE_PATH}/scripts/ecr-public-login
 
 push-docker-images:
 	${MAKEFILE_PATH}/scripts/retag-docker-images -p ${SUPPORTED_PLATFORMS_LINUX} -v ${VERSION} -o ${IMG} -n ${ECR_REPO}
 	@ECR_REGISTRY=${ECR_REGISTRY} ${MAKEFILE_PATH}/scripts/ecr-public-login
 	${MAKEFILE_PATH}/scripts/push-docker-images -p ${SUPPORTED_PLATFORMS_LINUX} -r ${ECR_REPO} -v ${VERSION} -m
 
-push-docker-images-windows:
-	${MAKEFILE_PATH}/scripts/retag-docker-images -p ${SUPPORTED_PLATFORMS_WINDOWS} -v ${VERSION} -o ${IMG} -n ${ECR_REPO}
+amazon-ecr-credential-helper:
 	bash ${MAKEFILE_PATH}/scripts/install-amazon-ecr-credential-helper $(AMAZON_ECR_CREDENTIAL_HELPER_VERSION)
-	${MAKEFILE_PATH}/scripts/push-docker-images -p ${SUPPORTED_PLATFORMS_WINDOWS} -r ${ECR_REPO} -v ${VERSION} -m
+
+push-docker-images-windows-2019:
+	${MAKEFILE_PATH}/scripts/retag-docker-images -p ${WINDOWS_2019} -v ${VERSION} -o ${IMG} -n ${ECR_REPO}
+	bash ${MAKEFILE_PATH}/scripts/install-amazon-ecr-credential-helper $(AMAZON_ECR_CREDENTIAL_HELPER_VERSION)
+	${MAKEFILE_PATH}/scripts/push-docker-images -p ${WINDOWS_2019} -r ${ECR_REPO} -v ${VERSION} -m
+
+push-docker-images-windows-2022:
+	${MAKEFILE_PATH}/scripts/retag-docker-images -p ${WINDOWS_2022} -v ${VERSION} -o ${IMG} -n ${ECR_REPO}
+	bash ${MAKEFILE_PATH}/scripts/install-amazon-ecr-credential-helper $(AMAZON_ECR_CREDENTIAL_HELPER_VERSION)
+	${MAKEFILE_PATH}/scripts/push-docker-images -p ${WINDOWS_2022} -r ${ECR_REPO} -v ${VERSION} -m
 
 push-helm-chart:
 	@ECR_REGISTRY=${ECR_REGISTRY} ${MAKEFILE_PATH}/scripts/helm-login
@@ -122,8 +145,11 @@ helm-validate-chart-versions:
 build-binaries:
 	${MAKEFILE_PATH}/scripts/build-binaries -p ${SUPPORTED_PLATFORMS_LINUX} -v ${VERSION}
 
-build-binaries-windows:
-	${MAKEFILE_PATH}/scripts/build-binaries -p ${SUPPORTED_PLATFORMS_WINDOWS} -v ${VERSION}
+build-binaries-windows-2019:
+	${MAKEFILE_PATH}/scripts/build-binaries -p ${WINDOWS_2019} -v ${VERSION}
+
+build-binaries-windows-2022:
+	${MAKEFILE_PATH}/scripts/build-binaries -p ${WINDOWS_2022} -v ${VERSION}
 
 upload-resources-to-github:
 	${MAKEFILE_PATH}/scripts/upload-resources-to-github
@@ -165,7 +191,9 @@ eks-cluster-test:
 
 release: build-binaries build-docker-images push-docker-images generate-k8s-yaml upload-resources-to-github
 
-release-windows: build-binaries-windows build-docker-images-windows push-docker-images-windows
+release-windows-2019: build-binaries-windows-2019 build-docker-images-windows-2019 push-docker-images-windows-2019
+
+release-windows-2022: build-binaries-windows-2022 build-docker-images-windows-2022 push-docker-images-windows-2022
 
 test: spellcheck shellcheck unit-test e2e-test compatibility-test license-test go-linter helm-version-sync-test helm-lint
 

--- a/scripts/build-binaries
+++ b/scripts/build-binaries
@@ -49,7 +49,7 @@ for os_arch in "${PLATFORMS[@]}"; do
     container_name="build-$BASE_BIN_NAME-$os-$arch"
     repo_name="bin-build"
 
-    if [[ $os == "windows" ]]; then
+    if [[ $os == "windows"* ]]; then
         bin_name="$BASE_BIN_NAME-$os-$arch.exe"
     else
         bin_name="$BASE_BIN_NAME-$os-$arch"
@@ -60,7 +60,7 @@ for os_arch in "${PLATFORMS[@]}"; do
     docker container create --rm --name $container_name "$repo_name:$VERSION-$os-$arch"
     docker container cp $container_name:/${BASE_BIN_NAME} $BIN_DIR/$bin_name
 
-    if [[ $os == "windows" ]]; then
+    if [[ $os == "windows"* ]]; then
       ## Create zip archive with binary taking into account windows .exe
       cp ${BIN_DIR}/${bin_name} ${BIN_DIR}/${BASE_BIN_NAME}.exe
       ## Can't reuse bin_name below because it includes .exe

--- a/scripts/build-docker-images
+++ b/scripts/build-docker-images
@@ -48,20 +48,23 @@ for os_arch in "${PLATFORMS[@]}"; do
     os=$(echo $os_arch | cut -d'/' -f1)
     arch=$(echo $os_arch | cut -d'/' -f2)
 
-    img_tag="$IMAGE_REPO:$VERSION-$os-$arch"
-
     dockerfile="$DOCKERFILE_PATH"
-    if [[ $os = "windows" ]]; then
+    if [[ $os == "windows"* ]]; then  
+        windows_version=$(echo $os | cut -d'-' -f2) 
+        os=$(echo $os | cut -d'-' -f1)
+        img_tag="$IMAGE_REPO:$VERSION-$os-$windows_version-$arch"
         dockerfile="${dockerfile}.windows"
         docker build \
             --file "${dockerfile}" \
             --build-arg GOOS=${os} \
             --build-arg GOARCH=${arch} \
+            --build-arg WINDOWS_VERSION=${windows_version} \
             --build-arg GOPROXY=${GOPROXY} \
             --tag ${img_tag} \
             ${REPO_ROOT_PATH}
     else
         # Launch a docker buildx instance and save its name so we can terminate it later
+        img_tag="$IMAGE_REPO:$VERSION-$os-$arch"
         buildx_instance_name=$(docker buildx create --use)
         docker buildx build \
             --load \

--- a/scripts/ecr-public-login
+++ b/scripts/ecr-public-login
@@ -16,4 +16,4 @@ function exit_and_fail() {
 
 trap exit_and_fail INT TERM ERR
 
-docker login --username AWS --password="$(aws ecr-public get-login-password --region us-east-1)" "${ECR_REGISTRY}"
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin "${ECR_REGISTRY}"

--- a/scripts/push-docker-images
+++ b/scripts/push-docker-images
@@ -68,9 +68,17 @@ if [[ $MANIFEST == "true" ]]; then
   if [[ manifest_exists -eq 0 ]]; then
     echo "manifest already exists"
     EXISTING_IMAGES=()
+
+    # Run while loop to collect images with no OS version (typically linux)
     while IFS='' read -r line; do 
       EXISTING_IMAGES+=("$line"); 
-    done < <(docker manifest inspect $IMAGE_REPO:$VERSION | jq -r '.manifests[] | "\(.platform.os)-\(.platform.architecture)"')
+    done < <(docker manifest inspect $IMAGE_REPO:$VERSION | jq -r '.manifests[] | select(.platform."os.version" == null) | "\(.platform.os)-\(.platform.architecture)"')
+
+    # Run while loop to collect images with OS version (typically windows)
+    while IFS='' read -r line; do 
+      EXISTING_IMAGES+=("$line"); 
+    done < <(docker manifest inspect $IMAGE_REPO:$VERSION | jq -r '.manifests[] | select(.platform."os.version" != null) | "\(.platform.os)-\(.platform."os.version")-\(.platform.architecture)"')
+
     # treat separate from PLATFORMS because existing images don't need to be tagged and pushed
     for os_arch in "${EXISTING_IMAGES[@]}"; do
       img_tag="$IMAGE_REPO:$VERSION-$os_arch"
@@ -117,7 +125,7 @@ if [[ $MANIFEST == "true" ]]; then
       # However, our builds in the past required this explicit annotation, and it doesn't hurt to keep it for now.
       os_arch=$(echo ${updated_img//$IMAGE_REPO:$VERSION-/})
       os=$(echo $os_arch | cut -d'-' -f1)
-      arch=$(echo $os_arch | cut -d'-' -f2)
+      arch=${os_arch##*-}
 
       echo "annotating manifest"
       docker manifest annotate $IMAGE_REPO:$VERSION $updated_img --arch $arch --os $os


### PR DESCRIPTION
Issue #826 

Updated scripts to build, test, and push docker images supporting both Windows 2019 and Windows 2022


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
