### PR TITLE
Misleading 404 logs in IMDS mode when querying EC2 Metadata without a public IP

### DIFF
--- a/pkg/ec2metadata/ec2metadata.go
+++ b/pkg/ec2metadata/ec2metadata.go
@@ -194,7 +194,7 @@ func (e *Service) GetRebalanceRecommendationEvent() (rebalanceRec *RebalanceReco
 }
 
 // GetMetadataInfo generic function for retrieving ec2 metadata
-func (e *Service) GetMetadataInfo(path string) (info string, err error) {
+func (e *Service) GetMetadataInfo(path string, allowMissing bool) (info string, err error) {
 	metadataInfo := ""
 	resp, err := e.Request(path)
 	if err != nil {
@@ -208,8 +208,12 @@ func (e *Service) GetMetadataInfo(path string) (info string, err error) {
 		}
 		metadataInfo = string(body)
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			log.Info().Msgf("Metadata response status code: %d. Body: %s", resp.StatusCode, metadataInfo)
-			return "", fmt.Errorf("Metadata request received http status code: %d", resp.StatusCode)
+			if resp.StatusCode != 404 || !allowMissing {
+				log.Info().Msgf("Metadata response status code: %d. Body: %s", resp.StatusCode, metadataInfo)
+				return "", fmt.Errorf("Metadata request received http status code: %d", resp.StatusCode)
+			} else {
+				return "", nil
+			}
 		}
 	}
 	return metadataInfo, nil
@@ -327,7 +331,7 @@ func retry(attempts int, sleep time.Duration, httpReq func() (*http.Response, er
 // GetNodeMetadata attempts to gather additional ec2 instance information from the metadata service
 func (e *Service) GetNodeMetadata() NodeMetadata {
 	metadata := NodeMetadata{}
-	identityDoc, err := e.GetMetadataInfo(IdentityDocPath)
+	identityDoc, err := e.GetMetadataInfo(IdentityDocPath, false)
 	if err != nil {
 		log.Err(err).Msg("Unable to fetch metadata from IMDS")
 		return metadata
@@ -335,18 +339,18 @@ func (e *Service) GetNodeMetadata() NodeMetadata {
 	err = json.NewDecoder(strings.NewReader(identityDoc)).Decode(&metadata)
 	if err != nil {
 		log.Warn().Msg("Unable to fetch instance identity document from ec2 metadata")
-		metadata.InstanceID, _ = e.GetMetadataInfo(InstanceIDPath)
-		metadata.InstanceType, _ = e.GetMetadataInfo(InstanceTypePath)
-		metadata.LocalIP, _ = e.GetMetadataInfo(LocalIPPath)
-		metadata.AvailabilityZone, _ = e.GetMetadataInfo(AZPlacementPath)
+		metadata.InstanceID, _ = e.GetMetadataInfo(InstanceIDPath, false)
+		metadata.InstanceType, _ = e.GetMetadataInfo(InstanceTypePath, false)
+		metadata.LocalIP, _ = e.GetMetadataInfo(LocalIPPath, false)
+		metadata.AvailabilityZone, _ = e.GetMetadataInfo(AZPlacementPath, false)
 		if len(metadata.AvailabilityZone) > 1 {
 			metadata.Region = metadata.AvailabilityZone[0 : len(metadata.AvailabilityZone)-1]
 		}
 	}
-	metadata.InstanceLifeCycle, _ = e.GetMetadataInfo(InstanceLifeCycle)
-	metadata.LocalHostname, _ = e.GetMetadataInfo(LocalHostnamePath)
-	metadata.PublicHostname, _ = e.GetMetadataInfo(PublicHostnamePath)
-	metadata.PublicIP, _ = e.GetMetadataInfo(PublicIPPath)
+	metadata.InstanceLifeCycle, _ = e.GetMetadataInfo(InstanceLifeCycle, false)
+	metadata.LocalHostname, _ = e.GetMetadataInfo(LocalHostnamePath, false)
+	metadata.PublicHostname, _ = e.GetMetadataInfo(PublicHostnamePath, true)
+	metadata.PublicIP, _ = e.GetMetadataInfo(PublicIPPath, true)
 
 	log.Info().Interface("metadata", metadata).Msg("Startup Metadata Retrieved")
 

--- a/pkg/ec2metadata/ec2metadata_test.go
+++ b/pkg/ec2metadata/ec2metadata_test.go
@@ -524,7 +524,7 @@ func TestGetMetadataServiceRequest404(t *testing.T) {
 	// Use URL from our local test server
 	imds := ec2metadata.New(server.URL, 1)
 
-	_, err := imds.GetMetadataInfo(requestPath)
+	_, err := imds.GetMetadataInfo(requestPath, false)
 
 	h.Assert(t, err != nil, "Expected error to be nil but it was not")
 }
@@ -533,7 +533,7 @@ func TestGetMetadataServiceRequestFailure(t *testing.T) {
 	// Use URL from our local test server
 	imds := ec2metadata.New("/some-path-that-will-error", 1)
 
-	_, err := imds.GetMetadataInfo("/latest/meta-data/instance-type")
+	_, err := imds.GetMetadataInfo("/latest/meta-data/instance-type", false)
 	h.Assert(t, err != nil, "Error expected because no server should be running")
 }
 
@@ -558,7 +558,7 @@ func TestGetMetadataServiceSuccess(t *testing.T) {
 	// Use URL from our local test server
 	imds := ec2metadata.New(server.URL, 1)
 
-	resp, err := imds.GetMetadataInfo(requestPath)
+	resp, err := imds.GetMetadataInfo(requestPath, false)
 
 	h.Ok(t, err)
 	h.Equals(t, `x1.32xlarge`, resp)

--- a/pkg/ec2metadata/ec2metadata_test.go
+++ b/pkg/ec2metadata/ec2metadata_test.go
@@ -526,7 +526,57 @@ func TestGetMetadataServiceRequest404(t *testing.T) {
 
 	_, err := imds.GetMetadataInfo(requestPath, false)
 
-	h.Assert(t, err != nil, "Expected error to be nil but it was not")
+	h.Assert(t, err != nil, "Error expected because request errored with 404")
+}
+
+func TestGetMetadataServiceRequest404AllowMissing(t *testing.T) {
+	var requestPath string = "/latest/meta-data/instance-type"
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Add("X-aws-ec2-metadata-token-ttl-seconds", "100")
+		if req.URL.String() == "/latest/api/token" {
+			rw.WriteHeader(200)
+			_, err := rw.Write([]byte(`token`))
+			h.Ok(t, err)
+			return
+		}
+		h.Equals(t, req.Header.Get("X-aws-ec2-metadata-token"), "token")
+		h.Equals(t, req.URL.String(), requestPath)
+		rw.WriteHeader(404)
+	}))
+	defer server.Close()
+
+	// Use URL from our local test server
+	imds := ec2metadata.New(server.URL, 1)
+
+	_, err := imds.GetMetadataInfo(requestPath, true)
+
+	h.Assert(t, err == nil, "Expected error to be nil but it was not")
+}
+
+func TestGetMetadataServiceRequest500AllowMissing(t *testing.T) {
+	var requestPath string = "/latest/meta-data/instance-type"
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Add("X-aws-ec2-metadata-token-ttl-seconds", "100")
+		if req.URL.String() == "/latest/api/token" {
+			rw.WriteHeader(200)
+			_, err := rw.Write([]byte(`token`))
+			h.Ok(t, err)
+			return
+		}
+		h.Equals(t, req.Header.Get("X-aws-ec2-metadata-token"), "token")
+		h.Equals(t, req.URL.String(), requestPath)
+		rw.WriteHeader(500)
+	}))
+	defer server.Close()
+
+	// Use URL from our local test server
+	imds := ec2metadata.New(server.URL, 1)
+
+	_, err := imds.GetMetadataInfo(requestPath, true)
+
+	h.Assert(t, err != nil, "Error expected because request errored with 500")
 }
 
 func TestGetMetadataServiceRequestFailure(t *testing.T) {


### PR DESCRIPTION
**Description of changes:**

While running NTH in IMDS mode on instances without an assigned public IP, I noticed that requests to certain EC2 Metadata endpoints, specifically `public-hostname` and `public-ipv4`, return a 404 status code.  This is the expected behavior, as documented [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-data-categories). Although NTH does not fail and works as expected in this scenario, some log messages about these 404 status codes are displayed:

```
2024/08/29 13:42:34 INF Metadata response status code: 404. Body: <?xml version="1.0" encoding="iso-8859-1"?>
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
		 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
  <title>404 - Not Found</title>
 </head>
 <body>
  <h1>404 - Not Found</h1>
 </body>
</html>
```

These messages don't clarify the reason for the 404 codes, which can mislead users (like myself!) into thinking something is wrong. To address this, I've added an `allowMissing` parameter to the `GetMetadataInfo` function. When this flag is enabled, no message will be logged for 404 responses, and no error will be returned.

While this might not be the most elegant solution, I felt like any other alternative, such as implementing the options pattern, would be overkill and too complex for the limited scope of the function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
