### PR TITLE
IMDS Lifecycle Hook Event on drain

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -16,13 +16,14 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-node-termination-handler/pkg/monitor/asglifecycle"
 	"os"
 	"os/signal"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/aws/aws-node-termination-handler/pkg/monitor/asglifecycle"
 
 	"github.com/aws/aws-node-termination-handler/pkg/config"
 	"github.com/aws/aws-node-termination-handler/pkg/ec2metadata"
@@ -192,7 +193,7 @@ func main() {
 			monitoringFns[spotITN] = imdsSpotMonitor
 		}
 		if nthConfig.EnableASGLifecycleDraining {
-			asgLifecycleMonitor := asglifecycle.NewASGLifecycleMonitor(imds, interruptionChan, cancelChan, nthConfig.NodeName)
+			asgLifecycleMonitor := asglifecycle.NewASGLifecycleMonitor(imds, interruptionChan, cancelChan, nthConfig.NodeName, nthConfig.LifecycleHookName)
 			monitoringFns[asgLifecycle] = asgLifecycleMonitor
 		}
 		if nthConfig.EnableScheduledEventDraining {

--- a/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
+++ b/config/helm/aws-node-termination-handler/templates/daemonset.linux.yaml
@@ -155,6 +155,8 @@ spec:
               value: "false"
             - name: UPTIME_FROM_FILE
               value: {{ .Values.procUptimeFile | quote }}
+            - name: LIFECYCLE_HOOK_NAME
+              value: {{ .Values.lifecycleHookName | quote }}
             {{- with .Values.extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -301,3 +301,5 @@ instanceMetadataURL: ""
 
 # (TESTING USE): Mount path for uptime file
 procUptimeFile: /proc/uptime
+
+lifecycleHookName: "NTH_TERMINATION"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -112,6 +112,7 @@ const (
 	queueURLConfigKey                         = "QUEUE_URL"
 	completeLifecycleActionDelaySecondsKey    = "COMPLETE_LIFECYCLE_ACTION_DELAY_SECONDS"
 	deleteSqsMsgIfNodeNotFoundKey             = "DELETE_SQS_MSG_IF_NODE_NOT_FOUND"
+	lifecycleHookNameKey                      = "LIFECYCLE_HOOK_NAME"
 )
 
 // Config arguments set via CLI, environment variables, or defaults
@@ -166,6 +167,7 @@ type Config struct {
 	CompleteLifecycleActionDelaySeconds int
 	DeleteSqsMsgIfNodeNotFound          bool
 	UseAPIServerCacheToListPods         bool
+	LifecycleHookName                   string
 }
 
 // ParseCliArgs parses cli arguments and uses environment variables as fallback values
@@ -230,6 +232,8 @@ func ParseCliArgs() (config Config, err error) {
 	flag.IntVar(&config.CompleteLifecycleActionDelaySeconds, "complete-lifecycle-action-delay-seconds", getIntEnv(completeLifecycleActionDelaySecondsKey, -1), "Delay completing the Autoscaling lifecycle action after a node has been drained.")
 	flag.BoolVar(&config.DeleteSqsMsgIfNodeNotFound, "delete-sqs-msg-if-node-not-found", getBoolEnv(deleteSqsMsgIfNodeNotFoundKey, false), "If true, delete SQS Messages from the SQS Queue if the targeted node(s) are not found.")
 	flag.BoolVar(&config.UseAPIServerCacheToListPods, "use-apiserver-cache", getBoolEnv(useAPIServerCache, false), "If true, leverage the k8s apiserver's index on pod's spec.nodeName to list pods on a node, instead of doing an etcd quorum read.")
+	flag.StringVar(&config.LifecycleHookName, "lifecycle-hook-name", getEnv(lifecycleHookNameKey, ""), "Name of the ASG lifecycle hook to monitor for termination events.")
+
 	flag.Parse()
 
 	if isConfigProvided("pod-termination-grace-period", podTerminationGracePeriodConfigKey) && isConfigProvided("grace-period", gracePeriodConfigKey) {

--- a/pkg/monitor/asglifecycle/asg-lifecycle-monitor.go
+++ b/pkg/monitor/asglifecycle/asg-lifecycle-monitor.go
@@ -34,19 +34,21 @@ const ASGLifecycleMonitorKind = "ASG_LIFECYCLE_MONITOR"
 
 // ASGLifecycleMonitor is a struct definition which facilitates monitoring of ASG target lifecycle state from IMDS
 type ASGLifecycleMonitor struct {
-	IMDS             *ec2metadata.Service
-	InterruptionChan chan<- monitor.InterruptionEvent
-	CancelChan       chan<- monitor.InterruptionEvent
-	NodeName         string
+	IMDS              *ec2metadata.Service
+	InterruptionChan  chan<- monitor.InterruptionEvent
+	CancelChan        chan<- monitor.InterruptionEvent
+	NodeName          string
+	LifecycleHookName string
 }
 
 // NewASGLifecycleMonitor creates an instance of a ASG lifecycle IMDS monitor
-func NewASGLifecycleMonitor(imds *ec2metadata.Service, interruptionChan chan<- monitor.InterruptionEvent, cancelChan chan<- monitor.InterruptionEvent, nodeName string) ASGLifecycleMonitor {
+func NewASGLifecycleMonitor(imds *ec2metadata.Service, interruptionChan chan<- monitor.InterruptionEvent, cancelChan chan<- monitor.InterruptionEvent, nodeName string, lifecycleHookName string) ASGLifecycleMonitor {
 	return ASGLifecycleMonitor{
-		IMDS:             imds,
-		InterruptionChan: interruptionChan,
-		CancelChan:       cancelChan,
-		NodeName:         nodeName,
+		IMDS:              imds,
+		InterruptionChan:  interruptionChan,
+		CancelChan:        cancelChan,
+		NodeName:          nodeName,
+		LifecycleHookName: lifecycleHookName,
 	}
 }
 
@@ -131,7 +133,7 @@ func (m ASGLifecycleMonitor) completeLifecycleAction() error {
 	ec2Svc := ec2.New(sess)
 
 	instanceID := m.IMDS.GetNodeMetadata().InstanceID
-	lifecycleHookName := "PAU_TERMINATION"
+	lifecycleHookName := m.LifecycleHookName
 
 	// Get the ASG name from similar to aws autoscaling describe-auto-scaling-instances --instance-ids="i-zzxxccvv"
 	autoScalingGroupName, err := m.getAutoScalingGroupName(ec2Svc, instanceID)

--- a/pkg/monitor/asglifecycle/asg-lifecycle-monitor_test.go
+++ b/pkg/monitor/asglifecycle/asg-lifecycle-monitor_test.go
@@ -14,10 +14,11 @@
 package asglifecycle_test
 
 import (
-	"github.com/aws/aws-node-termination-handler/pkg/monitor/asglifecycle"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/aws/aws-node-termination-handler/pkg/monitor/asglifecycle"
 
 	"github.com/aws/aws-node-termination-handler/pkg/ec2metadata"
 	"github.com/aws/aws-node-termination-handler/pkg/monitor"
@@ -57,7 +58,7 @@ func TestMonitor_Success(t *testing.T) {
 		h.Equals(t, expFormattedTime, result.StartTime.String())
 	}()
 
-	asgLifecycleMonitor := asglifecycle.NewASGLifecycleMonitor(imds, drainChan, cancelChan, nodeName)
+	asgLifecycleMonitor := asglifecycle.NewASGLifecycleMonitor(imds, drainChan, cancelChan, nodeName, "test-lifecycle-hook")
 	err := asgLifecycleMonitor.Monitor()
 	h.Ok(t, err)
 }
@@ -75,7 +76,7 @@ func TestMonitor_MetadataParseFailure(t *testing.T) {
 	cancelChan := make(chan monitor.InterruptionEvent)
 	imds := ec2metadata.New(server.URL, 1)
 
-	asgLifecycleMonitor := asglifecycle.NewASGLifecycleMonitor(imds, drainChan, cancelChan, nodeName)
+	asgLifecycleMonitor := asglifecycle.NewASGLifecycleMonitor(imds, drainChan, cancelChan, nodeName, "test-lifecycle-hook")
 	err := asgLifecycleMonitor.Monitor()
 	h.Ok(t, err)
 }
@@ -97,7 +98,7 @@ func TestMonitor_404Response(t *testing.T) {
 	cancelChan := make(chan monitor.InterruptionEvent)
 	imds := ec2metadata.New(server.URL, 1)
 
-	asgLifecycleMonitor := asglifecycle.NewASGLifecycleMonitor(imds, drainChan, cancelChan, nodeName)
+	asgLifecycleMonitor := asglifecycle.NewASGLifecycleMonitor(imds, drainChan, cancelChan, nodeName, "test-lifecycle-hook")
 	err := asgLifecycleMonitor.Monitor()
 	h.Ok(t, err)
 }
@@ -119,7 +120,7 @@ func TestMonitor_500Response(t *testing.T) {
 	cancelChan := make(chan monitor.InterruptionEvent)
 	imds := ec2metadata.New(server.URL, 1)
 
-	asgLifecycleMonitor := asglifecycle.NewASGLifecycleMonitor(imds, drainChan, cancelChan, nodeName)
+	asgLifecycleMonitor := asglifecycle.NewASGLifecycleMonitor(imds, drainChan, cancelChan, nodeName, "test-lifecycle-hook")
 	err := asgLifecycleMonitor.Monitor()
 	h.Assert(t, err != nil, "Failed to return error when 500 response")
 }


### PR DESCRIPTION
**Description of changes:**

Emit a CONTINUE event once the node has been drained when running in IMDS mode, currently the machine hangs until lifecylce hook timeout or terminates immediately making the draining impossible sometimes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
