### PR TITLE
Fix ASGLifecycle showing up as UnknownInterruption on K8 events (#1024)

### DIFF
--- a/pkg/observability/k8s-events.go
+++ b/pkg/observability/k8s-events.go
@@ -169,6 +169,8 @@ func getReasonForKindV1(eventKind, monitorKind string) string {
 		return spotITNReason
 	case monitor.RebalanceRecommendationKind:
 		return rebalanceRecommendationReason
+	case monitor.ASGLifecycleKind:
+		return asgLifecycleReason
 	default:
 		return unknownReason
 	}


### PR DESCRIPTION
**Issue #, if available:**
#1024 

**Description of changes:**
getReasonForKindV1 used for K8sEventsRecorder was not catching `ASGLifeCycle` event, making the event fall to the default case of `unknownReason`. Added a new case that catches this `ASGLifeCycle` event. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
