### PR TITLE
Add SQS InterruptionEvent.InstanceType

### DIFF
--- a/pkg/monitor/sqsevent/asg-lifecycle-event.go
+++ b/pkg/monitor/sqsevent/asg-lifecycle-event.go
@@ -91,6 +91,7 @@ func (m SQSMonitor) asgTerminationToInterruptionEvent(event *EventBridgeEvent, m
 		IsManaged:            nodeInfo.IsManaged,
 		InstanceID:           lifecycleDetail.EC2InstanceID,
 		ProviderID:           nodeInfo.ProviderID,
+		InstanceType:         nodeInfo.InstanceType,
 		Description:          fmt.Sprintf("ASG Lifecycle Termination event received. Instance will be interrupted at %s \n", event.getTime()),
 	}
 

--- a/pkg/monitor/sqsevent/ec2-state-change-event.go
+++ b/pkg/monitor/sqsevent/ec2-state-change-event.go
@@ -75,6 +75,7 @@ func (m SQSMonitor) ec2StateChangeToInterruptionEvent(event *EventBridgeEvent, m
 		AutoScalingGroupName: nodeInfo.AsgName,
 		InstanceID:           ec2StateChangeDetail.InstanceID,
 		ProviderID:           nodeInfo.ProviderID,
+		InstanceType:         nodeInfo.InstanceType,
 		Description:          fmt.Sprintf("EC2 State Change event received. Instance %s went into %s at %s \n", ec2StateChangeDetail.InstanceID, ec2StateChangeDetail.State, event.getTime()),
 	}
 

--- a/pkg/monitor/sqsevent/rebalance-recommendation-event.go
+++ b/pkg/monitor/sqsevent/rebalance-recommendation-event.go
@@ -67,6 +67,7 @@ func (m SQSMonitor) rebalanceRecommendationToInterruptionEvent(event *EventBridg
 		IsManaged:            nodeInfo.IsManaged,
 		InstanceID:           nodeInfo.InstanceID,
 		ProviderID:           nodeInfo.ProviderID,
+		InstanceType:         nodeInfo.InstanceType,
 		Description:          fmt.Sprintf("Rebalance recommendation event received. Instance %s will be cordoned at %s \n", rebalanceRecDetail.InstanceID, event.getTime()),
 	}
 	interruptionEvent.PostDrainTask = func(interruptionEvent monitor.InterruptionEvent, n node.Node) error {

--- a/pkg/monitor/sqsevent/scheduled-change-event.go
+++ b/pkg/monitor/sqsevent/scheduled-change-event.go
@@ -102,6 +102,7 @@ func (m SQSMonitor) scheduledEventToInterruptionEvents(event *EventBridgeEvent, 
 			NodeName:             nodeInfo.Name,
 			InstanceID:           nodeInfo.InstanceID,
 			ProviderID:           nodeInfo.ProviderID,
+			InstanceType:         nodeInfo.InstanceType,
 			IsManaged:            nodeInfo.IsManaged,
 			Description:          fmt.Sprintf("AWS Health scheduled change event received. Instance %s will be interrupted at %s \n", nodeInfo.InstanceID, event.getTime()),
 		}

--- a/pkg/monitor/sqsevent/spot-itn-event.go
+++ b/pkg/monitor/sqsevent/spot-itn-event.go
@@ -69,6 +69,7 @@ func (m SQSMonitor) spotITNTerminationToInterruptionEvent(event *EventBridgeEven
 		IsManaged:            nodeInfo.IsManaged,
 		InstanceID:           spotInterruptionDetail.InstanceID,
 		ProviderID:           nodeInfo.ProviderID,
+		InstanceType:         nodeInfo.InstanceType,
 		Description:          fmt.Sprintf("Spot Interruption notice for instance %s was sent at %s \n", spotInterruptionDetail.InstanceID, event.getTime()),
 	}
 	interruptionEvent.PostDrainTask = func(interruptionEvent monitor.InterruptionEvent, n node.Node) error {

--- a/pkg/monitor/sqsevent/sqs-monitor.go
+++ b/pkg/monitor/sqsevent/sqs-monitor.go
@@ -343,7 +343,7 @@ type NodeInfo struct {
 	AsgName      string
 	InstanceID   string
 	ProviderID   string
-  InstanceType string
+	InstanceType string
 	IsManaged    bool
 	Name         string
 	Tags         map[string]string

--- a/pkg/monitor/sqsevent/sqs-monitor.go
+++ b/pkg/monitor/sqsevent/sqs-monitor.go
@@ -340,12 +340,13 @@ func (m SQSMonitor) completeLifecycleAction(input *autoscaling.CompleteLifecycle
 
 // NodeInfo is relevant information about a single node
 type NodeInfo struct {
-	AsgName    string
-	InstanceID string
-	ProviderID string
-	IsManaged  bool
-	Name       string
-	Tags       map[string]string
+	AsgName      string
+	InstanceID   string
+	ProviderID   string
+  InstanceType string
+	IsManaged    bool
+	Name         string
+	Tags         map[string]string
 }
 
 // getNodeInfo returns the NodeInfo record for the given instanceID.
@@ -411,11 +412,12 @@ func (m SQSMonitor) getNodeInfo(instanceID string) (*NodeInfo, error) {
 	}
 
 	nodeInfo := &NodeInfo{
-		Name:       *instance.PrivateDnsName,
-		InstanceID: instanceID,
-		ProviderID: providerID,
-		Tags:       make(map[string]string),
-		IsManaged:  true,
+		Name:         *instance.PrivateDnsName,
+		InstanceID:   instanceID,
+		ProviderID:   providerID,
+		InstanceType: *instance.InstanceType,
+		Tags:         make(map[string]string),
+		IsManaged:    true,
 	}
 	for _, t := range (*instance).Tags {
 		nodeInfo.Tags[*t.Key] = *t.Value

--- a/pkg/monitor/sqsevent/sqs-monitor_internal_test.go
+++ b/pkg/monitor/sqsevent/sqs-monitor_internal_test.go
@@ -199,6 +199,7 @@ func getDescribeInstancesResp(instanceID string, privateDNSName string, tags map
 							GroupName:        aws.String(""),
 							Tenancy:          aws.String("default"),
 						},
+						InstanceType: aws.String("t3.medium"),
 						PrivateDnsName: aws.String(privateDNSName),
 						Tags:           awsTags,
 					},

--- a/pkg/monitor/sqsevent/sqs-monitor_internal_test.go
+++ b/pkg/monitor/sqsevent/sqs-monitor_internal_test.go
@@ -199,7 +199,7 @@ func getDescribeInstancesResp(instanceID string, privateDNSName string, tags map
 							GroupName:        aws.String(""),
 							Tenancy:          aws.String("default"),
 						},
-						InstanceType: aws.String("t3.medium"),
+						InstanceType:   aws.String("t3.medium"),
 						PrivateDnsName: aws.String(privateDNSName),
 						Tags:           awsTags,
 					},

--- a/pkg/monitor/sqsevent/sqs-monitor_test.go
+++ b/pkg/monitor/sqsevent/sqs-monitor_test.go
@@ -929,7 +929,7 @@ func getDescribeInstancesResp(privateDNSName string, withASGTag bool, withManage
 							GroupName:        aws.String(""),
 							Tenancy:          aws.String("default"),
 						},
-						InstanceType: aws.String("t3.medium"),
+						InstanceType:   aws.String("t3.medium"),
 						PrivateDnsName: &privateDNSName,
 						Tags:           tags,
 					},

--- a/pkg/monitor/sqsevent/sqs-monitor_test.go
+++ b/pkg/monitor/sqsevent/sqs-monitor_test.go
@@ -929,6 +929,7 @@ func getDescribeInstancesResp(privateDNSName string, withASGTag bool, withManage
 							GroupName:        aws.String(""),
 							Tenancy:          aws.String("default"),
 						},
+						InstanceType: aws.String("t3.medium"),
 						PrivateDnsName: &privateDNSName,
 						Tags:           tags,
 					},

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -53,6 +53,7 @@ type InterruptionEvent struct {
 	Pods                 []string
 	InstanceID           string
 	ProviderID           string
+	InstanceType         string
 	IsManaged            bool
 	StartTime            time.Time
 	EndTime              time.Time

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -33,7 +33,8 @@ import (
 type combinedDrainData struct {
 	ec2metadata.NodeMetadata
 	monitor.InterruptionEvent
-	InstanceID string
+	InstanceID   string
+	InstanceType string
 }
 
 // Post makes a http post to send drain event data to webhook url
@@ -60,12 +61,17 @@ func Post(additionalInfo ec2metadata.NodeMetadata, event *monitor.InterruptionEv
 		return
 	}
 
-	// Need to merge the two data sources manually since both have an InstanceID field
+	// Need to merge the two data sources manually since both have
+	// InstanceID and InstanceType fields
 	instanceID := additionalInfo.InstanceID
 	if event.InstanceID != "" {
 		instanceID = event.InstanceID
 	}
-	var combined = combinedDrainData{NodeMetadata: additionalInfo, InterruptionEvent: *event, InstanceID: instanceID}
+	instanceType := additionalInfo.InstanceType
+	if event.InstanceType != "" {
+		instanceType = event.InstanceType
+	}
+	var combined = combinedDrainData{NodeMetadata: additionalInfo, InterruptionEvent: *event, InstanceID: instanceID, InstanceType: instanceType}
 
 	var byteBuffer bytes.Buffer
 	err = webhookTemplate.Execute(&byteBuffer, combined)


### PR DESCRIPTION
Feature - would like to expose the InstanceType also in the webhook notifications

Changes - Updated getNodeInfo to return the InstanceType 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
