### PR TITLE
Add filtering before DeleteOrEvictPods

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -145,7 +145,7 @@ func (n Node) CordonAndDrain(nodeName string, reason string, recorder recorderIn
 	}
 	if n.nthConfig.UseAPIServerCacheToListPods {
 		if pods != nil {
-			pods = n.filterOutDaemonSetPods(pods)
+			pods = n.FilterOutDaemonSetPods(pods)
 			err = n.drainHelper.DeleteOrEvictPods(pods.Items)
 		}
 	} else {
@@ -649,8 +649,8 @@ func (n Node) fetchAllPods(nodeName string) (*corev1.PodList, error) {
 	return n.drainHelper.Client.CoreV1().Pods("").List(context.TODO(), listOptions)
 }
 
-// filterOutDaemonSetPods filters a list of pods to exclude DaemonSet pods when IgnoreDaemonSets is enabled
-func (n *Node) filterOutDaemonSetPods(pods *corev1.PodList) *corev1.PodList {
+// FilterOutDaemonSetPods filters a list of pods to exclude DaemonSet pods when IgnoreDaemonSets is enabled
+func (n *Node) FilterOutDaemonSetPods(pods *corev1.PodList) *corev1.PodList {
 	if !n.nthConfig.IgnoreDaemonSets {
 		return pods
 	}


### PR DESCRIPTION
**Issue #, if available:**
#1097

**Description of changes:**
- Add filtering before DeleteOrEvictPods

**How you tested your changes:**
Environment (Linux / Windows): Linux
Kubernetes Version: 1.31

Set `use-apiserver-cache: true` and `emit-kubernetes-events: true` then toggle the `ignore-daemon-sets` flag to test protect daemonset pods or not.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
