### PR TITLE
Deprecate old k8s version

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        k8sVersion: ["1.23", "1.24", "1.25", "1.26", "1.27", "1.28", "1.29", "1.30"]
+        k8sVersion: ["1.29", "1.30", "1.31"]
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ upload-resources-to-github-windows:
 
 generate-k8s-yaml:
 	${MAKEFILE_PATH}/scripts/generate-k8s-yaml
-	${MAKEFILE_PATH}/scripts/generate-k8s-yaml -k "1.25.0" -s ${K8S_1_25_ASSET_SUFFIX}
+	${MAKEFILE_PATH}/scripts/generate-k8s-yaml -k "1.31.2" -s ${K8S_1_25_ASSET_SUFFIX}
 
 sync-readme-to-ecr-public:
 	@ECR_REGISTRY=${ECR_REGISTRY} ${MAKEFILE_PATH}/scripts/ecr-public-login

--- a/scripts/generate-k8s-yaml
+++ b/scripts/generate-k8s-yaml
@@ -7,9 +7,9 @@ VERSION=$(make -s -f $MAKEFILEPATH version)
 BUILD_DIR=$SCRIPTPATH/../build/k8s-resources/$VERSION
 
 PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
-HELM_VERSION="3.7.1"
+HELM_VERSION="3.16.2"
 NAMESPACE="kube-system"
-K8S_VERSION="1.24.0"
+K8S_VERSION="1.31.2"
 SUFFIX=""
 
 USAGE=$(cat << EOM

--- a/test/k8s-compatibility-test/run-k8s-compatibility-test.sh
+++ b/test/k8s-compatibility-test/run-k8s-compatibility-test.sh
@@ -2,14 +2,14 @@
 set -euo pipefail 
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-versions=("1.26" "1.25" "1.24" "1.23" "1.22")
+versions=("1.29" "1.30" "1.31")
 E_CODE=0
 AFTER_FIRST_RUN_ARGS=""
 PASS_THRU_ARGS=""
 
 USAGE=$(cat << 'EOM'
   Usage: run-k8s-compatability-test [-h]
-  Executes the spot termination integration test for each version of kubernetes (k8s 1.22 - 1.26 supported)
+  Executes the spot termination integration test for each version of kubernetes (k8s 1.29 - 1.31 supported)
 
   Examples:
           # run test with direct download of go modules
@@ -36,7 +36,7 @@ done
 
 for i in "${!versions[@]}"; do
    version=${versions[$i]}
-   $SCRIPTPATH/../k8s-local-cluster-test/run-test -b "test-$version" -v $version $PASS_THRU_ARGS $AFTER_FIRST_RUN_ARGS
+   $SCRIPTPATH/../k8s-local-cluster-test/run-test -b "test-${version//./-}" -v $version $PASS_THRU_ARGS $AFTER_FIRST_RUN_ARGS
    if [ $? -eq 0 ]; then
       echo "✅ Passed test for K8s version $version"
    else

--- a/test/k8s-local-cluster-test/provision-cluster
+++ b/test/k8s-local-cluster-test/provision-cluster
@@ -9,26 +9,16 @@ OVERRIDE_PATH=0
 KIND_CONFIG_FILE=$SCRIPTPATH/kind-three-node-cluster.yaml
 use_psp=false
 # shellcheck disable=SC2034
+K8_1_31="kindest/node:v1.31.2@sha256:18fbefc20a7113353c7b75b5c869d7145a6abd6269154825872dc59c1329912e"
+# shellcheck disable=SC2034
 K8_1_30="kindest/node:v1.30@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e"
 # shellcheck disable=SC2034
 K8_1_29="kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245"
-# shellcheck disable=SC2034
-K8_1_28="kindest/node:v1.28.7@sha256:9bc6c451a289cf96ad0bbaf33d416901de6fd632415b076ab05f5fa7e4f65c58"
-# shellcheck disable=SC2034
-K8_1_27="kindest/node:v1.27.11@sha256:681253009e68069b8e01aad36a1e0fa8cf18bb0ab3e5c4069b2e65cafdd70843"
-# shellcheck disable=SC2034
-K8_1_26="kindest/node:v1.26.14@sha256:5d548739ddef37b9318c70cb977f57bf3e5015e4552be4e27e57280a8cbb8e4f"
-# shellcheck disable=SC2034
-K8_1_25="kindest/node:v1.25.16@sha256:e8b50f8e06b44bb65a93678a65a26248fae585b3d3c2a669e5ca6c90c69dc519"
-# shellcheck disable=SC2034
-K8_1_24="kindest/node:v1.24.17@sha256:bad10f9b98d54586cba05a7eaa1b61c6b90bfc4ee174fdc43a7b75ca75c95e51"
-# shellcheck disable=SC2034
-K8_1_23="kindest/node:v1.23.17@sha256:14d0a9a892b943866d7e6be119a06871291c517d279aedb816a4b4bc0ec0a5b3"
 
-K8_VERSION="$K8_1_30"
+K8_VERSION="$K8_1_31"
 KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
-KIND_VERSION="0.22.0"
-HELM_VERSION="3.14.3"
+KIND_VERSION="0.25.0"
+HELM_VERSION="3.16.2"
 
 echoerr() { echo "$@" 1>&2; }
 
@@ -37,7 +27,7 @@ USAGE=$(cat << 'EOM'
   Executes the spot termination integration test for the Node Termination Handler.
   Outputs the cluster context directory to stdout on successful completion
 
-  Example: provision-cluster -b my-test -i 123 -v 1.30
+  Example: provision-cluster -b my-test -i 123 -v 1.31
 
           Optional:
             -b          Base Name of cluster

--- a/test/k8s-local-cluster-test/run-test
+++ b/test/k8s-local-cluster-test/run-test
@@ -16,7 +16,7 @@ NODE_TERMINATION_HANDLER_DOCKER_IMG=""
 DEFAULT_WEBHOOK_DOCKER_IMG="webhook-test-proxy:customtest"
 WEBHOOK_DOCKER_IMG=""
 OVERRIDE_PATH=0
-K8S_VERSION="1.30"
+K8S_VERSION="1.31"
 AEMM_URL="amazon-ec2-metadata-mock-service.default.svc.cluster.local"
 AEMM_VERSION="1.12.0"
 AEMM_DL_URL="https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v$AEMM_VERSION/amazon-ec2-metadata-mock-$AEMM_VERSION.tgz"
@@ -139,7 +139,7 @@ USAGE=$(cat << 'EOM'
             -n          Node Termination Handler Docker Image
             -d          use GOPROXY=direct to bypass proxy.golang.org
             -o          Override path w/ your own kubectl and kind binaries
-            -v          Kubernetes Version (Default: 1.29) [1.23, 1.24, 1.25, 1.26, 1.27, 1.28, 1.29, and 1.30]
+            -v          Kubernetes Version (Default: 1.31) [1.29, 1.30, and 1.31]
             -w          Webhook Docker Image
 
 EOM


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Deprecate old k8s version

**How you tested your changes:**
Environment (Linux / Windows): Linux
Kubernetes Version: 1.31

Test in local by `make compatibility-test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
