### PR TITLE
Fix helm default val for heartbeat flags

### DIFF
--- a/config/helm/aws-node-termination-handler/README.md
+++ b/config/helm/aws-node-termination-handler/README.md
@@ -120,6 +120,9 @@ The configuration in this table applies to AWS Node Termination Handler in queue
 | `managedAsgTag`              | [DEPRECATED](Use `managedTag` instead) The node tag to check if `checkASGTagBeforeDraining` is `true`.     
 | `useProviderId`              | If `true`, fetch node name through Kubernetes node spec ProviderID instead of AWS event PrivateDnsHostname.                                                               | `false`                                |
 | `topologySpreadConstraints`  | [Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) for pod scheduling. Useful with a highly available deployment to reduce the risk of running multiple replicas on the same Node      | `[]`                                   |
+| `heartbeatInterval`  | The time period in seconds between consecutive heartbeat signals. Valid range: 30-3600 seconds (30 seconds to 1 hour). | `-1`                                   |
+| `heartbeatUntil`  | The duration in seconds over which heartbeat signals are sent. Valid range: 60-172800 seconds (1 minute to 48 hours). | `-1`                                   |
+
 ### IMDS Mode Configuration
 
 The configuration in this table applies to AWS Node Termination Handler in IMDS mode.

--- a/config/helm/aws-node-termination-handler/values.yaml
+++ b/config/helm/aws-node-termination-handler/values.yaml
@@ -285,6 +285,12 @@ enableRebalanceDraining: false
 # deleteSqsMsgIfNodeNotFound If true, delete the SQS Message from the SQS Queue if the targeted node(s) are not found. Only used in Queue Processor mode.
 deleteSqsMsgIfNodeNotFound: false
 
+# The time period in seconds between consecutive heartbeat signals. Valid range: 30-3600 seconds (30 seconds to 1 hour).
+heartbeatInterval: -1
+
+# The duration in seconds over which heartbeat signals are sent. Valid range: 60-172800 seconds (1 minute to 48 hours).
+heartbeatUntil: -1
+
 # ---------------------------------------------------------------------------------------------------------------------
 # Testing
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
**Issue #, if available:**
#1135

**Description of changes:**
Add helm default value (-1) for heartbeatInterval and heartbeatUntil

**How you tested your changes:**
Environment (Linux / Windows): Linux
Kubernetes Version: 1.31

Helm upgrade dryrun commend

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
