### PR TITLE
Modified cache and ubuntu versions to resolve the build failures

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -21,7 +21,7 @@ env:
 jobs:
   fastTests:
     name: Fast Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
@@ -32,7 +32,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Restore go mod cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/go-build
@@ -57,7 +57,7 @@ jobs:
   golangci:
     # this action needs to run in its own job per setup
     name: Lint Eastwood
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
 
@@ -76,7 +76,7 @@ jobs:
     
   buildLinux:
     name: Build Linux Binaries
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
@@ -87,7 +87,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Restore go mod cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/go-build
@@ -100,7 +100,7 @@ jobs:
 
   buildLinuxDocker:
     name: Build Linux Docker Images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
@@ -108,7 +108,7 @@ jobs:
         go-version: ${{ env.DEFAULT_GO_VERSION }}
 
     - name: Restore go mod cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/go-build
@@ -138,7 +138,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Restore go mod cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/go-build
@@ -170,7 +170,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Restore go mod cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/go-build
@@ -188,7 +188,7 @@ jobs:
 
   e2e:
     name: E2E Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         k8sVersion: ["1.29", "1.30", "1.31", "1.32"]
@@ -202,7 +202,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Restore go mod cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/go-build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   releaseLinux:
     name: Release Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
@@ -64,7 +64,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [releaseLinux, releaseWindows]
     steps:
     - name: Set up Go 1.x

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # 15+5 day stale policy for PRs
       # * Except PRs marked as "stalebot-ignore"


### PR DESCRIPTION
**Issue #, if available:**
We are using deprecated versions in our workflows causing Github Actions workflow failures.

**Description of changes:**
- Modified the `actions/cache` versions from v2 to v4 as per recommendation in official notice.
- Modified `ubuntu` versions as well in workflows as the current versions will be deprecated by March end.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
