### PR TITLE
Add node_name to `Draining the node` message

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -129,7 +129,7 @@ func (n Node) CordonAndDrain(nodeName string, reason string, recorder recorderIn
 	}
 	var pods *corev1.PodList
 	// Delete all pods on the node
-	log.Info().Msg("Draining the node")
+	log.Info().Str("node_name", nodeName).Msg("Draining the node")
 	// Emit events for all pods that will be evicted
 	if recorder != nil {
 		pods, err = n.fetchAllPods(node.Name)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Add `node_name` property to `Draining the node` message
The log message without the context doesn't really help, for example when using a logging system like Graylog/ELK and you want to filter for everything related to that node.

**How you tested your changes:**
Environment (Linux / Windows): Linux
Kubernetes Version: 1.32


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
