### PR TITLE
Fix log level in drain helper

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -89,6 +89,18 @@ type Node struct {
 	uptime      uptime.UptimeFuncType
 }
 
+type ZerologWriter struct {
+	logger zerolog.Logger
+}
+
+type StdWriter struct {
+	*ZerologWriter
+}
+
+type ErrWriter struct {
+	*ZerologWriter
+}
+
 // New will construct a node struct to perform various node function through the kubernetes api server
 func New(nthConfig config.Config, clientset *kubernetes.Clientset) (*Node, error) {
 	drainHelper, err := getDrainHelper(nthConfig, clientset)
@@ -737,8 +749,8 @@ func getDrainHelper(nthConfig config.Config, clientset *kubernetes.Clientset) (*
 		AdditionalFilters:   []drain.PodFilter{filterPodForDeletion(nthConfig.PodName, nthConfig.PodNamespace)},
 		DeleteEmptyDirData:  nthConfig.DeleteLocalData,
 		Timeout:             time.Duration(nthConfig.NodeTerminationGracePeriod) * time.Second,
-		Out:                 log.Logger,
-		ErrOut:              log.Logger,
+		Out:                 &StdWriter{&ZerologWriter{logger: log.Logger}},
+		ErrOut:              &ErrWriter{&ZerologWriter{logger: log.Logger}},
 	}
 
 	if nthConfig.DryRun {
@@ -925,6 +937,18 @@ func isDaemonSetPod(pod corev1.Pod) bool {
 		}
 	}
 	return false
+}
+
+func (w *StdWriter) Write(p []byte) (n int, err error) {
+	msg := strings.TrimRight(string(p), "\n")
+	w.logger.Info().Msg(msg)
+	return len(p), nil
+}
+
+func (w *ErrWriter) Write(p []byte) (n int, err error) {
+	msg := strings.TrimRight(string(p), "\n")
+	w.logger.Error().Msg(msg)
+	return len(p), nil
 }
 
 type recorderInterface interface {


### PR DESCRIPTION
**Issue #, if available:**
#1148

**Description of changes:**

Fix log level in drain helper by passing custom loggers.

Ref:
- `evictPods` and `fmt.Fprintf` in [pkg/drain/drain.go](https://github.com/kubernetes/kubectl/blob/fec9d5b3d5b1c3addf8cebd3c2437257ea5e4332/pkg/drain/drain.go#L268)
- `Fprintf` in [src/fmt/print.go](https://github.com/golang/go/blob/master/src/fmt/print.go#L222-L225)

**How you tested your changes:**
Environment (Linux / Windows): Linux
Kubernetes Version: 1.32

Test by:
- e2e test
- deploy NTH by private ECR image; trigger spot interruption; validate the log messages

Prev:
```
INF Draining the node
??? evicting pod kube-system/ebs-csi-controller-xxx
??? error when evicting pods/"ebs-csi-controller-xxx" -n "kube-system" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
```
Cur:
```
INF Draining the node
INF evicting pod kube-system/ebs-csi-controller-xxx
ERR error when evicting pods/"ebs-csi-controller-xxx" -n "kube-system" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
