### PR TITLE
Add windows 2019 deprecation link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The aws-node-termination-handler **Queue Processor** will monitor an SQS queue o
 
 You can run the termination handler on any Kubernetes cluster running on AWS, including self-managed clusters and those created with Amazon [Elastic Kubernetes Service](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html). If you're using [EKS managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html), you don't need the aws-node-termination-handler.
 
-> Notice: Windows Server 2019 support has been removed to align with GitHub's deprecation schedule (end date: June 30, 2025). You can continue using other supported Windows versions.
+> ⚠️ Note: Windows Server 2019 support has been removed as GitHub Actions no longer supports this version. Please migrate to Windows Server 2022. For more details, see [GitHub's deprecation announcement](https://github.com/actions/runner-images/issues/12045).
 
 ## Major Features
 


### PR DESCRIPTION
**Issue #, if available:** [1182](https://github.com/aws/aws-node-termination-handler/issues/1182)

**Description of changes:**
- Updated readme note and added deprecation notice link. 

**How you tested your changes:**
Environment (Linux / Windows): 
Kubernetes Version: 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
