### PR TITLE
Fix misleading message for launch lifecycle events logged as drain operations

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -288,7 +288,7 @@ func main() {
 			for event, ok := interruptionEventStore.GetActiveEvent(); ok; event, ok = interruptionEventStore.GetActiveEvent() {
 				select {
 				case interruptionEventStore.Workers <- 1:
-					logging.VersionedMsgs.RequestingInstanceDrain(event)
+					logging.VersionedMsgs.ProcessingInterruptionEvent(event)
 					event.InProgress = true
 					wg.Add(1)
 					recorder.Emit(event.NodeName, observability.Normal, observability.GetReasonForKind(event.Kind, event.Monitor), event.Description)

--- a/pkg/logging/versioned.go
+++ b/pkg/logging/versioned.go
@@ -30,14 +30,22 @@ func (versionedMsgsV1) ProblemMonitoringForEvents(monitorKind string, err error)
 	log.Warn().Str("event_type", monitorKind).Err(err).Msg("There was a problem monitoring for events")
 }
 
-func (versionedMsgsV1) RequestingInstanceDrain(event *monitor.InterruptionEvent) {
+func (versionedMsgsV1) ProcessingInterruptionEvent(event *monitor.InterruptionEvent) {
+	var message string
+	switch event.Kind {
+	case monitor.ASGLaunchLifecycleKind:
+		message = "Waiting for node to be ready before completing ASG launch lifecycle"
+	default:
+		message = "Requesting instance drain"
+	}
+
 	log.Info().
 		Str("event-id", event.EventID).
 		Str("kind", event.Kind).
 		Str("node-name", event.NodeName).
 		Str("instance-id", event.InstanceID).
 		Str("provider-id", event.ProviderID).
-		Msg("Requesting instance drain")
+		Msg(message)
 }
 
 func (versionedMsgsV1) SendingInterruptionEventToChannel(_ string) {
@@ -54,7 +62,15 @@ func (versionedMsgsV2) ProblemMonitoringForEvents(monitorKind string, err error)
 	log.Warn().Str("monitor_type", monitorKind).Err(err).Msg("There was a problem monitoring for events")
 }
 
-func (versionedMsgsV2) RequestingInstanceDrain(event *monitor.InterruptionEvent) {
+func (versionedMsgsV2) ProcessingInterruptionEvent(event *monitor.InterruptionEvent) {
+	var message string
+	switch event.Kind {
+	case monitor.ASGLaunchLifecycleKind:
+		message = "Waiting for node to be ready before completing ASG launch lifecycle"
+	default:
+		message = "Requesting instance drain"
+	}
+
 	log.Info().
 		Str("event-id", event.EventID).
 		Str("kind", event.Kind).
@@ -62,7 +78,7 @@ func (versionedMsgsV2) RequestingInstanceDrain(event *monitor.InterruptionEvent)
 		Str("node-name", event.NodeName).
 		Str("instance-id", event.InstanceID).
 		Str("provider-id", event.ProviderID).
-		Msg("Requesting instance drain")
+		Msg(message)
 }
 
 func (versionedMsgsV2) SendingInterruptionEventToChannel(eventKind string) {
@@ -72,7 +88,7 @@ func (versionedMsgsV2) SendingInterruptionEventToChannel(eventKind string) {
 var VersionedMsgs interface {
 	MonitoringStarted(monitorKind string)
 	ProblemMonitoringForEvents(monitorKind string, err error)
-	RequestingInstanceDrain(event *monitor.InterruptionEvent)
+	ProcessingInterruptionEvent(event *monitor.InterruptionEvent)
 	SendingInterruptionEventToChannel(eventKind string)
 } = versionedMsgsV1{}
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

This fix resolves a message confusion where launch lifecycle events were misleadingly logged as "drain" operations when they're actually doing the opposite.
- Updated logging interface: renamed `RequestingInstanceDrain()` to `ProcessingInterruptionEvent()`
- Added event-type awareness: the logging function now uses a switch statement based on `event.Kind`

Before the fix: Everything logged "_Requesting instance drain_"
```json
{
    "level": "info",
    "event": {
        "EventID": "asg-lifecycle-term-65343736363839362d346666352d303536352d656661622d303432326331343631666665",
        "Kind": "ASG_LAUNCH_LIFECYCLE",
        "Monitor": "SQS_MONITOR",
        "Description": "ASG Lifecycle Launch event received. Instance was started at 2025-10-27 12:10:53.217 +0000 UTC \n",
        "State": "",
        "AutoScalingGroupName": "on-demand-huge-workers-01-2024112121084029580000002c",
        "NodeName": "ip-10-31-16-222.eu-west-1.compute.internal",
        "NodeLabels": null,
        "Pods": null,
        "InstanceID": "i-070c03698c54561a9",
        "ProviderID": "aws:///eu-west-1a/i-070c03698c54561a9",
        "InstanceType": "",
        "IsManaged": true,
        "StartTime": "2025-10-27T12:10:53.217Z",
        "EndTime": "0001-01-01T00:00:00Z",
        "NodeProcessed": false,
        "InProgress": false
    },
    "time": "2025-10-27T12:11:16Z",
    "message": "Adding new event to the event store"
}
{
    "level": "info",
    "event-id": "asg-lifecycle-term-65343736363839362d346666352d303536352d656661622d303432326331343631666665",
    "kind": "ASG_LAUNCH_LIFECYCLE",
    "node-name": "ip-10-31-16-222.eu-west-1.compute.internal",
    "instance-id": "i-070c03698c54561a9",
    "provider-id": "aws:///eu-west-1a/i-070c03698c54561a9",
    "time": "2025-10-27T12:11:17Z",
    "message": "Requesting instance drain"  #<==
}
```
After the fix:
- Only launch lifecycle events get the specific message "_Waiting for node to be ready before completing ASG launch lifecycle_"
- Everything else (including actual drain operations) still gets "_Requesting instance drain_"
```json
{
    "level": "info",
    "event": {
        "EventID": "asg-lifecycle-term-32346536363839392d326162342d376165612d323936332d376438383166333631323932",
        "Kind": "ASG_LAUNCH_LIFECYCLE",
        "Monitor": "SQS_MONITOR",
        "Description": "ASG Lifecycle Launch event received. Instance was started at 2025-10-27 15:30:25.519 +0000 UTC \n",
        "State": "",
        "AutoScalingGroupName": "on-demand-huge-workers-01-2024112121084029580000002c",
        "NodeName": "ip-10-31-26-73.eu-west-1.compute.internal",
        "NodeLabels": null,
        "Pods": null,
        "InstanceID": "i-069246571a8ee057a",
        "ProviderID": "aws:///eu-west-1c/i-069246571a8ee057a",
        "InstanceType": "",
        "IsManaged": true,
        "StartTime": "2025-10-27T15:30:25.519Z",
        "EndTime": "0001-01-01T00:00:00Z",
        "NodeProcessed": false,
        "InProgress": false
    },
    "time": "2025-10-27T15:30:25Z",
    "message": "Adding new event to the event store"
}
{
    "level": "info",
    "event-id": "asg-lifecycle-term-32346536363839392d326162342d376165612d323936332d376438383166333631323932",
    "kind": "ASG_LAUNCH_LIFECYCLE",
    "node-name": "ip-10-31-26-73.eu-west-1.compute.internal",
    "instance-id": "i-069246571a8ee057a",
    "provider-id": "aws:///eu-west-1c/i-069246571a8ee057a",
    "time": "2025-10-27T15:30:26Z",
    "message": "Waiting for node to be ready before completing ASG launch lifecycle"  #<==
}
```

**How you tested your changes:**
Environment (Linux / Windows): Linux
Kubernetes Version: v1.31.13


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
