### PR TITLE
Upgrade Go version 1.23 to 1.25

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -13,7 +13,7 @@ on:
     - cron: '0 19 * * 1-5'
 
 env:
-  DEFAULT_GO_VERSION: ^1.22.0
+  DEFAULT_GO_VERSION: ^1.25.0
   GITHUB_USERNAME: ${{ secrets.EC2_BOT_GITHUB_USERNAME }}
   GITHUB_TOKEN: ${{ secrets.EC2_BOT_GITHUB_TOKEN }}
   WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
@@ -71,7 +71,7 @@ jobs:
           cache: false
 
       - name: Set up golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           args: --timeout=5m

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ permissions:
   id-token: write
 
 env:
-  DEFAULT_GO_VERSION: ^1.22.0
+  DEFAULT_GO_VERSION: ^1.25.0
   GITHUB_USERNAME: ${{ secrets.EC2_BOT_GITHUB_USERNAME }}
   GITHUB_TOKEN: ${{ secrets.EC2_BOT_GITHUB_TOKEN }}
   WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22 as builder
+FROM --platform=$BUILDPLATFORM golang:1.25 as builder
 
 ## GOLANG env
 ARG GOPROXY="https://proxy.golang.org|direct"

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,7 +1,7 @@
 ARG WINDOWS_VERSION=1809
 
 # Build the manager binary
-FROM --platform=windows/amd64 golang:1.22 as builder
+FROM --platform=windows/amd64 golang:1.25 as builder
 
 ## GOLANG env
 ENV GO111MODULE="on" CGO_ENABLED="0" GOOS="windows" GOARCH="amd64"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://github.com/kubernetes/kubernetes/releases">
     <img src="https://img.shields.io/badge/Kubernetes-%3E%3D%201.23-brightgreen" alt="kubernetes">
   </a>
-  <a href="https://golang.org/doc/go1.22">
+  <a href="https://golang.org/doc/go1.25">
     <img src="https://img.shields.io/github/go-mod/go-version/aws/aws-node-termination-handler?color=blueviolet" alt="go-version">
   </a>
   <a href="https://opensource.org/licenses/Apache-2.0">

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/aws/aws-node-termination-handler
 
-go 1.22.0
+go 1.25
 
-toolchain go1.22.2
+toolchain go1.25.5
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3

--- a/test/webhook-test-proxy/Dockerfile
+++ b/test/webhook-test-proxy/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22-alpine as builder
+FROM golang:1.25-alpine as builder
 
 ## GOLANG env
 ARG GOPROXY="https://proxy.golang.org|direct"

--- a/test/webhook-test-proxy/Dockerfile.windows
+++ b/test/webhook-test-proxy/Dockerfile.windows
@@ -1,7 +1,7 @@
 ARG WINDOWS_VERSION=1903
 
 # Build the manager binary
-FROM --platform=windows/amd64 golang:1.22 AS builder
+FROM --platform=windows/amd64 golang:1.25 AS builder
 
 ## GOLANG env
 ENV GO111MODULE="on" CGO_ENABLED="0" GOOS="windows" GOARCH="amd64"


### PR DESCRIPTION
**Issue #, if available:**
- 

**Description of changes:**
- Upgraded GO version to 1.25
- Updated golangci-lint-action version from v3 -> v6 for the validation step - Lint Eastwood. v3 used go version 1.24 and wasn't able to run the test.

**How you tested your changes:**
Environment (Linux / Windows): make unit-test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
