### PR TITLE
Upgrade Go version 1.23 to 1.25

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -13,7 +13,7 @@ on:
     - cron: '0 19 * * 1-5'
 
 env:
-  DEFAULT_GO_VERSION: ^1.22.0
+  DEFAULT_GO_VERSION: ^1.25.0
   GITHUB_USERNAME: ${{ secrets.EC2_BOT_GITHUB_USERNAME }}
   GITHUB_TOKEN: ${{ secrets.EC2_BOT_GITHUB_TOKEN }}
   WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
@@ -71,7 +71,7 @@ jobs:
           cache: false
 
       - name: Set up golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v7
         with:
           version: latest
           args: --timeout=5m

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ permissions:
   id-token: write
 
 env:
-  DEFAULT_GO_VERSION: ^1.22.0
+  DEFAULT_GO_VERSION: ^1.25.0
   GITHUB_USERNAME: ${{ secrets.EC2_BOT_GITHUB_USERNAME }}
   GITHUB_TOKEN: ${{ secrets.EC2_BOT_GITHUB_TOKEN }}
   WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22 as builder
+FROM --platform=$BUILDPLATFORM golang:1.25 as builder
 
 ## GOLANG env
 ARG GOPROXY="https://proxy.golang.org|direct"

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,7 +1,7 @@
 ARG WINDOWS_VERSION=1809
 
 # Build the manager binary
-FROM --platform=windows/amd64 golang:1.22 as builder
+FROM --platform=windows/amd64 golang:1.25 as builder
 
 ## GOLANG env
 ENV GO111MODULE="on" CGO_ENABLED="0" GOOS="windows" GOARCH="amd64"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://github.com/kubernetes/kubernetes/releases">
     <img src="https://img.shields.io/badge/Kubernetes-%3E%3D%201.23-brightgreen" alt="kubernetes">
   </a>
-  <a href="https://golang.org/doc/go1.22">
+  <a href="https://golang.org/doc/go1.25">
     <img src="https://img.shields.io/github/go-mod/go-version/aws/aws-node-termination-handler?color=blueviolet" alt="go-version">
   </a>
   <a href="https://opensource.org/licenses/Apache-2.0">

--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -279,11 +279,12 @@ func main() {
 	asgLaunchHandler := launch.New(interruptionEventStore, *node, nthConfig, metrics, recorder, clientset)
 	drainCordonHander := draincordon.New(interruptionEventStore, *node, nthConfig, nodeMetadata, metrics, recorder)
 
+InterruptionLoop:
 	for range time.NewTicker(1 * time.Second).C {
 		select {
 		case <-signalChan:
 			// Exit interruption loop if a SIGTERM is received or the channel is closed
-			break
+			break InterruptionLoop
 		default:
 		EventLoop:
 			for event, ok := interruptionEventStore.GetActiveEvent(); ok; event, ok = interruptionEventStore.GetActiveEvent() {

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/aws/aws-node-termination-handler
 
-go 1.22.0
+go 1.25
 
-toolchain go1.22.2
+toolchain go1.25.5
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -316,8 +316,12 @@ func ParseCliArgs() (config Config, err error) {
 	}
 
 	// client-go expects these to be set in env vars
-	os.Setenv(kubernetesServiceHostConfigKey, config.KubernetesServiceHost)
-	os.Setenv(kubernetesServicePortConfigKey, config.KubernetesServicePort)
+	if err := os.Setenv(kubernetesServiceHostConfigKey, config.KubernetesServiceHost); err != nil {
+		return config, fmt.Errorf("failed to set %s environment variable: %w", kubernetesServiceHostConfigKey, err)
+	}
+	if err := os.Setenv(kubernetesServicePortConfigKey, config.KubernetesServicePort); err != nil {
+		return config, fmt.Errorf("failed to set %s environment variable: %w", kubernetesServicePortConfigKey, err)
+	}
 
 	return config, err
 }

--- a/pkg/ec2metadata/ec2metadata.go
+++ b/pkg/ec2metadata/ec2metadata.go
@@ -144,7 +144,7 @@ func (e *Service) GetScheduledMaintenanceEvents() ([]ScheduledEventDetail, error
 	if err != nil {
 		return nil, fmt.Errorf("Unable to parse metadata response: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	var scheduledEvents []ScheduledEventDetail
 	err = json.NewDecoder(resp.Body).Decode(&scheduledEvents)
 	if err != nil {
@@ -165,7 +165,7 @@ func (e *Service) GetSpotITNEvent() (instanceAction *InstanceAction, err error) 
 	if err != nil {
 		return nil, fmt.Errorf("Unable to parse metadata response: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	err = json.NewDecoder(resp.Body).Decode(&instanceAction)
 	if err != nil {
@@ -186,7 +186,7 @@ func (e *Service) GetRebalanceRecommendationEvent() (rebalanceRec *RebalanceReco
 	if err != nil {
 		return nil, fmt.Errorf("Unable to parse metadata response: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	err = json.NewDecoder(resp.Body).Decode(&rebalanceRec)
 	if err != nil {

--- a/pkg/ec2metadata/ec2metadata_internal_test.go
+++ b/pkg/ec2metadata/ec2metadata_internal_test.go
@@ -27,8 +27,8 @@ import (
 )
 
 func TestRetry(t *testing.T) {
-	var numRetries int = 3
-	var errorMsg string = "Request failed"
+	var numRetries = 3
+	var errorMsg = "Request failed"
 	var requestCount int
 
 	request := func() (*http.Response, error) {

--- a/pkg/ec2metadata/ec2metadata_test.go
+++ b/pkg/ec2metadata/ec2metadata_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestRequestV1(t *testing.T) {
-	var requestPath string = "/some/path"
+	var requestPath = "/some/path"
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.String() == "/latest/api/token" {
@@ -55,7 +55,7 @@ func TestRequestV1(t *testing.T) {
 }
 
 func TestRequestV2(t *testing.T) {
-	var requestPath string = "/some/path"
+	var requestPath = "/some/path"
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		rw.Header().Add("X-aws-ec2-metadata-token-ttl-seconds", "100")
@@ -173,10 +173,10 @@ func TestGetSpotITNEventSuccess(t *testing.T) {
 		}
 		h.Equals(t, req.Header.Get("X-aws-ec2-metadata-token"), "token")
 		h.Equals(t, req.URL.String(), requestPath)
-		_, err := rw.Write([]byte(fmt.Sprintf(`{
+		_, err := fmt.Fprintf(rw, `{
 			"action": "%s",
 			"time": "%s"
-		}`, instanceAction, time)))
+		}`, instanceAction, time)
 		h.Ok(t, err)
 	}))
 	defer server.Close()
@@ -297,7 +297,7 @@ func TestGetScheduledMaintenanceEventsSuccess(t *testing.T) {
 		}
 		h.Equals(t, req.Header.Get("X-aws-ec2-metadata-token"), "token")
 		h.Equals(t, req.URL.String(), requestPath)
-		_, err := rw.Write([]byte(fmt.Sprintf(`[
+		_, err := fmt.Fprintf(rw, `[
 			{
 			  "NotBefore" : "%s",
 			  "Code" : "%s",
@@ -306,7 +306,7 @@ func TestGetScheduledMaintenanceEventsSuccess(t *testing.T) {
 			  "NotAfter" : "%s",
 			  "State" : "%s"
 			}
-		  ]`, notBefore, code, description, eventId, notAfter, state)))
+		  ]`, notBefore, code, description, eventId, notAfter, state)
 		h.Ok(t, err)
 	}))
 	defer server.Close()
@@ -403,9 +403,9 @@ func TestGetRebalanceRecommendationEventSuccess(t *testing.T) {
 		}
 		h.Equals(t, req.Header.Get("X-aws-ec2-metadata-token"), "token")
 		h.Equals(t, req.URL.String(), requestPath)
-		_, err := rw.Write([]byte(fmt.Sprintf(`{
+		_, err := fmt.Fprintf(rw, `{
 			"noticeTime": "%s"
-		}`, noticeTime)))
+		}`, noticeTime)
 		h.Ok(t, err)
 	}))
 	defer server.Close()

--- a/pkg/monitor/scheduledevent/scheduled-event-monitor_test.go
+++ b/pkg/monitor/scheduledevent/scheduled-event-monitor_test.go
@@ -54,7 +54,7 @@ func oneSecondAgo() time.Time {
 }
 
 func TestMonitor_Success(t *testing.T) {
-	var requestPath string = ec2metadata.ScheduledEventPath
+	var requestPath = ec2metadata.ScheduledEventPath
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if imdsV2TokenPath == req.URL.String() {
@@ -103,7 +103,7 @@ func TestMonitor_Success(t *testing.T) {
 }
 
 func TestMonitor_CanceledEvent(t *testing.T) {
-	var requestPath string = ec2metadata.ScheduledEventPath
+	var requestPath = ec2metadata.ScheduledEventPath
 	var state = "canceled"
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if imdsV2TokenPath == req.URL.String() {
@@ -158,7 +158,7 @@ func TestMonitor_CanceledEvent(t *testing.T) {
 }
 
 func TestMonitor_MetadataParseFailure(t *testing.T) {
-	var requestPath string = ec2metadata.ScheduledEventPath
+	var requestPath = ec2metadata.ScheduledEventPath
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if imdsV2TokenPath == req.URL.String() {

--- a/pkg/monitor/sqsevent/sqs-monitor.go
+++ b/pkg/monitor/sqsevent/sqs-monitor.go
@@ -211,21 +211,23 @@ func (m SQSMonitor) processEventBridgeEvent(eventBridgeEvent *EventBridgeEvent, 
 			interruptionEvent, err = nil, fmt.Errorf("unmarshaling message, %s, from ASG lifecycle event: %w", *message.MessageId, err)
 			interruptionEventWrappers = append(interruptionEventWrappers, InterruptionEventWrapper{interruptionEvent, err})
 		}
-		if lifecycleEvent.LifecycleTransition == ASGLaunchingLifecycleTransition {
+		switch lifecycleEvent.LifecycleTransition {
+		case ASGLaunchingLifecycleTransition:
 			interruptionEvent, err = m.createAsgInstanceLaunchEvent(eventBridgeEvent, message)
 			interruptionEventWrappers = append(interruptionEventWrappers, InterruptionEventWrapper{interruptionEvent, err})
-		} else if lifecycleEvent.LifecycleTransition == ASGTerminatingLifecycleTransition {
+		case ASGTerminatingLifecycleTransition:
 			interruptionEvent, err = m.asgTerminationToInterruptionEvent(eventBridgeEvent, message)
 			interruptionEventWrappers = append(interruptionEventWrappers, InterruptionEventWrapper{interruptionEvent, err})
 		}
 		return interruptionEventWrappers
 
 	case "aws.ec2":
-		if eventBridgeEvent.DetailType == "EC2 Instance State-change Notification" {
+		switch eventBridgeEvent.DetailType {
+		case "EC2 Instance State-change Notification":
 			interruptionEvent, err = m.ec2StateChangeToInterruptionEvent(eventBridgeEvent, message)
-		} else if eventBridgeEvent.DetailType == "EC2 Spot Instance Interruption Warning" {
+		case "EC2 Spot Instance Interruption Warning":
 			interruptionEvent, err = m.spotITNTerminationToInterruptionEvent(eventBridgeEvent, message)
-		} else if eventBridgeEvent.DetailType == "EC2 Instance Rebalance Recommendation" {
+		case "EC2 Instance Rebalance Recommendation":
 			interruptionEvent, err = m.rebalanceRecommendationToInterruptionEvent(eventBridgeEvent, message)
 		}
 		return append(interruptionEventWrappers, InterruptionEventWrapper{interruptionEvent, err})

--- a/pkg/monitor/sqsevent/sqs-monitor_internal_test.go
+++ b/pkg/monitor/sqsevent/sqs-monitor_internal_test.go
@@ -29,7 +29,7 @@ func TestGetTime_Success(t *testing.T) {
 	testTime, err := time.Parse(time.RFC3339, testTimeStr)
 	h.Ok(t, err)
 	asgLifecycleTime := EventBridgeEvent{Time: testTimeStr}.getTime()
-	h.Assert(t, testTime == asgLifecycleTime, "RFC3339 should be parsed correctly from event")
+	h.Assert(t, testTime.Equal(asgLifecycleTime), "RFC3339 should be parsed correctly from event")
 }
 
 func TestGetTime_Empty(t *testing.T) {

--- a/pkg/monitor/sqsevent/sqs-retryer_test.go
+++ b/pkg/monitor/sqsevent/sqs-retryer_test.go
@@ -103,10 +103,10 @@ func getSqsRetryer(t *testing.T) sqsevent.SqsRetryer {
 	h.Ok(t, err)
 
 	sqsClient := sqsevent.GetSqsClient(sess)
-	h.Assert(t, sqsClient.Client.Config.Region != nil, "Region should not be nil")
-	h.Equals(t, "us-east-1", *sqsClient.Client.Config.Region)
+	h.Assert(t, sqsClient.Config.Region != nil, "Region should not be nil")
+	h.Equals(t, "us-east-1", *sqsClient.Config.Region)
 
-	retryer, ok := sqsClient.Client.Config.Retryer.(sqsevent.SqsRetryer)
+	retryer, ok := sqsClient.Config.Retryer.(sqsevent.SqsRetryer)
 	h.Assert(t, ok, "Retryer should be of type SqsRetryer")
 	return retryer
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -327,7 +327,7 @@ func (n Node) addLabel(nodeName string, key string, value string, skipExisting b
 		return err
 	}
 	if skipExisting {
-		_, ok := node.ObjectMeta.Labels[key]
+		_, ok := node.Labels[key]
 		if ok {
 			return nil
 		}
@@ -394,7 +394,7 @@ func (n Node) removeLabelIfValueMatches(nodeName string, key string, matchValue 
 	if err != nil {
 		return err
 	}
-	val, ok := node.ObjectMeta.Labels[key]
+	val, ok := node.Labels[key]
 	if !ok || val == matchValue {
 		return nil
 	}
@@ -763,8 +763,8 @@ func getDrainHelper(nthConfig config.Config, clientset *kubernetes.Clientset) (*
 }
 
 func jsonPatchEscape(value string) string {
-	value = strings.Replace(value, "~", "~0", -1)
-	return strings.Replace(value, "/", "~1", -1)
+	value = strings.ReplaceAll(value, "~", "~0")
+	return strings.ReplaceAll(value, "/", "~1")
 }
 
 func getTaintEffect(effect string) corev1.TaintEffect {

--- a/pkg/node/node_internal_test.go
+++ b/pkg/node/node_internal_test.go
@@ -104,7 +104,7 @@ func TestUncordonIfRebootedSystemNotRestarted(t *testing.T) {
 	h.Ok(t, err)
 	tNode := getNode(t, getTestDrainHelper(client), getUptimeFromFile(testFile))
 	err = tNode.UncordonIfRebooted(nodeName)
-	os.Remove(testFile)
+	_ = os.Remove(testFile)
 	h.Ok(t, err)
 }
 

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/aws/aws-node-termination-handler/pkg/node"
 	h "github.com/aws/aws-node-termination-handler/pkg/test"
 	"github.com/aws/aws-node-termination-handler/pkg/uptime"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -470,8 +469,8 @@ func TestFilterOutDaemonSetPods(t *testing.T) {
 	tNode, err := newNode(config.Config{IgnoreDaemonSets: true}, fake.NewSimpleClientset())
 	h.Ok(t, err)
 
-	mockPodList := &corev1.PodList{
-		Items: []corev1.Pod{
+	mockPodList := &v1.PodList{
+		Items: []v1.Pod{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mock-daemon-pod",
@@ -530,7 +529,7 @@ func TestTaintOutOfService(t *testing.T) {
 	expectedTaint := v1.Taint{
 		Key:    outOfServiceTaintKey,
 		Value:  outOfServiceTaintValue,
-		Effect: corev1.TaintEffectNoExecute,
+		Effect: v1.TaintEffectNoExecute,
 	}
 	for _, taint := range updatedNode.Spec.Taints {
 		if taint.Key == expectedTaint.Key &&

--- a/pkg/observability/opentelemetry_test.go
+++ b/pkg/observability/opentelemetry_test.go
@@ -225,11 +225,11 @@ func TestServeMetrics(t *testing.T) {
 	if err != nil {
 		t.Errorf("server is not listening on port %d: %v", mockDefaultPort, err)
 	}
-	conn.Close()
+	_ = conn.Close()
 
 	conn, err = net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", mockClosedPort), time.Second)
 	if err == nil {
-		conn.Close()
+		_ = conn.Close()
 		t.Errorf("server should not be listening on port %d: %v", mockClosedPort, err)
 	}
 }

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -61,7 +61,7 @@ func Equals(tb testing.TB, exp, act interface{}) {
 
 // TimeWithinRange fails the test if act is not after lowerBound or not before upperBound
 func TimeWithinRange(tb testing.TB, act time.Time, lowerBound time.Time, upperBound time.Time) {
-	if !(act.After(lowerBound) && act.Before(upperBound)) {
+	if !act.After(lowerBound) || !act.Before(upperBound) {
 		_, file, line, _ := runtime.Caller(1)
 		fmt.Printf("\033[31m%s:%d:\n\n\tlower bound: %#v\n\n\tgot: %#v\n\n\tupper bound: %#v\033[39m\n\n", filepath.Base(file), line, lowerBound, act, upperBound)
 		tb.FailNow()

--- a/pkg/uptime/common_test.go
+++ b/pkg/uptime/common_test.go
@@ -28,7 +28,7 @@ func TestUptimeFromFileSuccess(t *testing.T) {
 	h.Ok(t, err)
 
 	value, err := UptimeFromFile(testFile)
-	os.Remove(testFile)
+	_ = os.Remove(testFile)
 	h.Ok(t, err)
 	h.Equals(t, int64(350735), value)
 }
@@ -44,6 +44,6 @@ func TestUptimeFromFileBadData(t *testing.T) {
 	h.Ok(t, err)
 
 	_, err = UptimeFromFile(testFile)
-	os.Remove(testFile)
+	_ = os.Remove(testFile)
 	h.Assert(t, err != nil, "Failed to return error for int64 parse")
 }

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -181,7 +181,7 @@ func TestPostHeaderParseFail(t *testing.T) {
 }
 
 func TestPostTimeout(t *testing.T) {
-	var requestCount int = 0
+	var requestCount = 0
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		requestCount++
 		time.Sleep(6 * time.Second)
@@ -201,7 +201,7 @@ func TestPostTimeout(t *testing.T) {
 }
 
 func TestPostBadResponseCode(t *testing.T) {
-	var requestCount int = 0
+	var requestCount = 0
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		requestCount++
 		http.Error(rw, "404 page not found", http.StatusNotFound)

--- a/test/webhook-test-proxy/Dockerfile
+++ b/test/webhook-test-proxy/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22-alpine as builder
+FROM golang:1.25-alpine as builder
 
 ## GOLANG env
 ARG GOPROXY="https://proxy.golang.org|direct"

--- a/test/webhook-test-proxy/Dockerfile.windows
+++ b/test/webhook-test-proxy/Dockerfile.windows
@@ -1,7 +1,7 @@
 ARG WINDOWS_VERSION=1903
 
 # Build the manager binary
-FROM --platform=windows/amd64 golang:1.22 AS builder
+FROM --platform=windows/amd64 golang:1.25 AS builder
 
 ## GOLANG env
 ENV GO111MODULE="on" CGO_ENABLED="0" GOOS="windows" GOARCH="amd64"


### PR DESCRIPTION
Description of changes:

Upgraded GO version to 1.25
Updated golangci-lint-action version from v3 -> v7 for the validation step - Lint Eastwood. v3 uses go version 1.24, so cannot run the test.

How you tested your changes:
Environment (Linux / Windows): make unit-test

Notes:
All code changes don't modify the logic, except `node-termination-handler.go`. In the file, the existing break statement doesn't do anything. It only exits the select statement, which is the same with not having the break statement. Referring to the comment, it seems like the author wanted to exit the outer loop. Please take a careful look into this part when reviewing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.