### PR TITLE
Add support to use KUBECONFIG env variable if incluster fails

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -48,7 +48,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 )
 
@@ -110,9 +110,9 @@ func main() {
 		log.Fatal().Err(err).Msg("Webhook validation failed,")
 	}
 
-	clusterConfig, err := rest.InClusterConfig()
+	clusterConfig, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
 	if err != nil {
-		log.Fatal().Err(err).Msgf("retreiving cluster config")
+		log.Fatal().Err(err).Msg("retrieving cluster config")
 	}
 	clientset, err := kubernetes.NewForConfig(clusterConfig)
 	if err != nil {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
As a Service Provider I would like to run the termination handler in a management cluster operating against a remote cluster.
The current [hard dep with incluster](https://github.com/aws/aws-node-termination-handler/blob/main/cmd/node-termination-handler.go#L113) makes this impossible 

**How you tested your changes:**
Environment (Linux / Windows): 
Kubernetes Version: 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
