### PR TITLE
Fix silent taint loss under concurrent spot interruptions

### DIFF
--- a/pkg/monitor/sqsevent/spot-itn-event.go
+++ b/pkg/monitor/sqsevent/spot-itn-event.go
@@ -96,7 +96,7 @@ func (m SQSMonitor) spotITNTerminationToInterruptionEvent(event *EventBridgeEven
 		if err != nil {
 			log.Err(err).Msgf("Unable to taint node with taint %s:%s", node.SpotInterruptionTaint, interruptionEvent.EventID)
 		}
-		return nil
+		return err
 	}
 	return &interruptionEvent, nil
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -77,8 +77,8 @@ const (
 )
 
 var (
-	maxRetryDeadline      time.Duration = 5 * time.Second
-	conflictRetryInterval time.Duration = 750 * time.Millisecond
+	maxRetryDeadline      time.Duration = 15 * time.Second
+	conflictRetryInterval time.Duration = 500 * time.Millisecond
 	instanceIDRegex                     = regexp.MustCompile(`^i-.*`)
 )
 
@@ -789,35 +789,31 @@ func addTaint(node *corev1.Node, nth Node, taintKey string, taintValue string, e
 	}
 
 	retryDeadline := time.Now().Add(maxRetryDeadline)
-	freshNode := node.DeepCopy()
 	client := nth.drainHelper.Client
-	var err error
-	refresh := false
+
 	for {
-		if refresh {
-			// Get the newest version of the node.
-			freshNode, err = client.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
-			if err != nil || freshNode == nil {
-				nodeErr := fmt.Errorf("failed to get node %v: %w", node.Name, err)
-				log.Err(nodeErr).
-					Str("taint_key", taintKey).
-					Str("node_name", node.Name).
-					Msg("Error while adding taint on node")
-				return nodeErr
-			}
+		freshNode, err := client.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+		if err != nil || freshNode == nil {
+			nodeErr := fmt.Errorf("failed to get node %v: %w", node.Name, err)
+			log.Err(nodeErr).
+				Str("taint_key", taintKey).
+				Str("node_name", node.Name).
+				Msg("Error while adding taint on node")
+			return nodeErr
 		}
 
 		if !addTaintToSpec(freshNode, taintKey, taintValue, effect) {
-			if !refresh {
-				// Make sure we have the latest version before skipping update.
-				refresh = true
-				continue
-			}
 			return nil
 		}
-		_, err = client.CoreV1().Nodes().Update(context.TODO(), freshNode, metav1.UpdateOptions{})
+
+		taintsJSON, err := json.Marshal(freshNode.Spec.Taints)
+		if err != nil {
+			return fmt.Errorf("failed to marshal taints for node %s: %w", node.Name, err)
+		}
+		patchData := []byte(fmt.Sprintf(`{"spec":{"taints":%s}}`, taintsJSON))
+
+		_, err = client.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.StrategicMergePatchType, patchData, metav1.PatchOptions{})
 		if err != nil && errors.IsConflict(err) && time.Now().Before(retryDeadline) {
-			refresh = true
 			time.Sleep(conflictRetryInterval)
 			continue
 		}


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws/aws-node-termination-handler/issues/1277

**Description of changes:**
addTaint uses a full-object Nodes().Update() that conflicts with concurrent cordon operations due to resourceVersion mismatch (HTTP 409 Conflict). Under high WORKERS values (>=30), the 5-second retry budget with 750ms fixed intervals is exhausted for ~6-13% of taint attempts. Additionally, the PreDrainTask closure in spot-itn-event.go swallows the taint error (returns nil), so the caller sees success, processing continues to cordon and drain, and the SQS message is deleted. No retry ever occurs for the failed taint.

This fix:
- Replaces Nodes().Update() with Nodes().Patch() using StrategicMergePatchType so taint patches don't conflict with concurrent cordon patches (they target different fields: spec.taints vs spec.unschedulable)
- Always fetches fresh node state before building the patch (removes the wasted first retry on a stale DeepCopy)
- Increases retry budget from 5s/750ms to 15s/500ms
- Propagates the taint error from PreDrainTask so the SQS message is not deleted and the event is retried on the next poll cycle


**How you tested your changes:**
Environment (Linux / Windows): Linux (RHEL CoreOS 9.8)
Kubernetes Version: v1.35.4 (OpenShift 4.22)

Tested on a ROSA HCP cluster with 100 spot instances (c5a.xlarge). Injected 100 simultaneous synthetic SQS spot interruption messages and verified that all 100 nodes were tainted at WORKERS=50. Before the fix, only 87-91 out of 100 taints succeeded at that concurrency level.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
