### PR TITLE
Resolve concurrency problem causing skipping taint by surfacing error and retrying with SQS

### DIFF
--- a/pkg/interruptionevent/draincordon/handler.go
+++ b/pkg/interruptionevent/draincordon/handler.go
@@ -81,7 +81,18 @@ func (h *Handler) HandleEvent(drainEvent *monitor.InterruptionEvent) error {
 	}
 
 	if drainEvent.PreDrainTask != nil {
-		h.commonHandler.RunPreDrainTask(nodeName, drainEvent)
+		if err := h.commonHandler.RunPreDrainTask(nodeName, drainEvent); err != nil {
+			log.Err(err).Str("nodeName", nodeName).Msg("Pre-drain task failed; aborting to allow SQS retry")
+			h.commonHandler.InterruptionEventStore.CancelInterruptionEvent(drainEvent.EventID)
+
+			// If the node is missing and the user opted for DeleteSqsMsgIfNodeNotFound then delete the SQS message
+			if !nodeFound && h.commonHandler.NthConfig.DeleteSqsMsgIfNodeNotFound && drainEvent.PostDrainTask != nil {
+				h.commonHandler.RunPostDrainTask(nodeName, drainEvent)
+				return nil
+			}
+			
+			return err
+		}
 	}
 
 	podNameList, err := h.commonHandler.Node.FetchPodNameList(nodeName)

--- a/pkg/interruptionevent/internal/common/handler.go
+++ b/pkg/interruptionevent/internal/common/handler.go
@@ -44,7 +44,7 @@ func (h *Handler) GetNodeName(drainEvent *monitor.InterruptionEvent) (string, er
 	return nodeName, nil
 }
 
-func (h *Handler) RunPreDrainTask(nodeName string, drainEvent *monitor.InterruptionEvent) {
+func (h *Handler) RunPreDrainTask(nodeName string, drainEvent *monitor.InterruptionEvent) error {
 	err := drainEvent.PreDrainTask(*drainEvent, h.Node)
 	if err != nil {
 		log.Err(err).Msg("There was a problem executing the pre-drain task")
@@ -53,6 +53,7 @@ func (h *Handler) RunPreDrainTask(nodeName string, drainEvent *monitor.Interrupt
 		h.Recorder.Emit(nodeName, observability.Normal, observability.PreDrainReason, observability.PreDrainMsg)
 	}
 	h.Metrics.NodeActionsInc("pre-drain", nodeName, drainEvent.EventID, err)
+	return err
 }
 
 func (h *Handler) RunCancelDrainTask(nodeName string, drainEvent *monitor.InterruptionEvent) {

--- a/pkg/monitor/sqsevent/spot-itn-event.go
+++ b/pkg/monitor/sqsevent/spot-itn-event.go
@@ -96,7 +96,7 @@ func (m SQSMonitor) spotITNTerminationToInterruptionEvent(event *EventBridgeEven
 		if err != nil {
 			log.Err(err).Msgf("Unable to taint node with taint %s:%s", node.SpotInterruptionTaint, interruptionEvent.EventID)
 		}
-		return nil
+		return err
 	}
 	return &interruptionEvent, nil
 }


### PR DESCRIPTION
**Issue #, if available:**
#1277

**Description of changes:**
As mentioned in the issue above, concurrency problems leads to taint errors. In specific, for situations over 100+ nodes getting de-provisioned simultaneously, 3-6% of nodes fails to be tainted and proceeds to be cordoned. This was due to the taint error not surfacing, and the message disappearing from the queue even without a successful taint. The new change explicitly returns the taint error and fails the pre-drain task so that the failed message can be handled by SQS retry logic.

Also added `DeleteSqsMsgIfNodeNotFound` condition (passed in as config param) in case the user wants to delete the message if the node is gone, to maintain consistent behavior with postDrain path.

**How you tested your changes:**
Environment (Linux / Windows): 
Locally with unit-tests, e2e run by github workflow.

Verified the fix of #1277 by actually launching +100 instances and interrupting them simultaneously (tested both reproduction of the bug and the fix of the bug).

Kubernetes Version: 
1.32

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
