### PR TITLE
Add configurable Kubernetes API client QPS and burst rate limits

### DIFF
--- a/cmd/node-termination-handler.go
+++ b/cmd/node-termination-handler.go
@@ -114,6 +114,8 @@ func main() {
 	if err != nil {
 		log.Fatal().Err(err).Msgf("retreiving cluster config")
 	}
+	clusterConfig.QPS = float32(nthConfig.KubeApiQps)
+	clusterConfig.Burst = nthConfig.KubeApiBurst
 	clientset, err := kubernetes.NewForConfig(clusterConfig)
 	if err != nil {
 		log.Fatal().Err(err).Msgf("creating new clientset with config: %v", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,10 @@ const (
 	podTerminationGracePeriodDefault        = -1
 	nodeTerminationGracePeriodConfigKey     = "NODE_TERMINATION_GRACE_PERIOD"
 	nodeTerminationGracePeriodDefault       = 120
+	kubeApiQpsConfigKey                     = "KUBE_API_QPS"
+	kubeApiQpsDefault                       = 5
+	kubeApiBurstConfigKey                   = "KUBE_API_BURST"
+	kubeApiBurstDefault                     = 10
 	webhookURLConfigKey                     = "WEBHOOK_URL"
 	webhookURLDefault                       = ""
 	webhookProxyConfigKey                   = "WEBHOOK_PROXY"
@@ -135,6 +139,8 @@ type Config struct {
 	KubernetesServicePort               string
 	PodTerminationGracePeriod           int
 	NodeTerminationGracePeriod          int
+	KubeApiQps                          int
+	KubeApiBurst                        int
 	WebhookURL                          string
 	WebhookHeaders                      string
 	WebhookTemplate                     string
@@ -203,6 +209,8 @@ func ParseCliArgs() (config Config, err error) {
 	flag.IntVar(&gracePeriod, "grace-period", getIntEnv(gracePeriodConfigKey, podTerminationGracePeriodDefault), "[DEPRECATED] * Use pod-termination-grace-period instead * Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used.")
 	flag.IntVar(&config.PodTerminationGracePeriod, "pod-termination-grace-period", getIntEnv(podTerminationGracePeriodConfigKey, podTerminationGracePeriodDefault), "Period of time in seconds given to each POD to terminate gracefully. If negative, the default value specified in the pod will be used.")
 	flag.IntVar(&config.NodeTerminationGracePeriod, "node-termination-grace-period", getIntEnv(nodeTerminationGracePeriodConfigKey, nodeTerminationGracePeriodDefault), "Period of time in seconds given to each NODE to terminate gracefully. Node draining will be scheduled based on this value to optimize the amount of compute time, but still safely drain the node before an event.")
+	flag.IntVar(&config.KubeApiQps, "kube-api-qps", getIntEnv(kubeApiQpsConfigKey, kubeApiQpsDefault), "QPS rate limit for the Kubernetes API client shared by all workers. Increase when running with high WORKERS count to avoid client-side throttling during correlated spot interruptions.")
+	flag.IntVar(&config.KubeApiBurst, "kube-api-burst", getIntEnv(kubeApiBurstConfigKey, kubeApiBurstDefault), "Burst rate limit for the Kubernetes API client. Should be >= kube-api-qps.")
 	flag.StringVar(&config.WebhookURL, "webhook-url", getEnv(webhookURLConfigKey, webhookURLDefault), "If specified, posts event data to URL upon instance interruption action.")
 	flag.StringVar(&config.WebhookProxy, "webhook-proxy", getEnv(webhookProxyConfigKey, webhookProxyDefault), "If specified, uses the HTTP(S) proxy to send webhooks. Example: --webhook-url='tcp://<ip-or-dns-to-proxy>:<port>'")
 	flag.StringVar(&config.WebhookHeaders, "webhook-headers", getEnv(webhookHeadersConfigKey, webhookHeadersDefault), "If specified, replaces the default webhook headers.")
@@ -351,6 +359,8 @@ func (c Config) PrintJsonConfigArgs() {
 		Bool("ignore_daemon_sets", c.IgnoreDaemonSets).
 		Int("pod_termination_grace_period", c.PodTerminationGracePeriod).
 		Int("node_termination_grace_period", c.NodeTerminationGracePeriod).
+		Int("kube_api_qps", c.KubeApiQps).
+		Int("kube_api_burst", c.KubeApiBurst).
 		Bool("enable_scheduled_event_draining", c.EnableScheduledEventDraining).
 		Bool("enable_spot_interruption_draining", c.EnableSpotInterruptionDraining).
 		Bool("enable_sqs_termination_draining", c.EnableSQSTerminationDraining).


### PR DESCRIPTION
## Description of changes

Add `KUBE_API_QPS` and `KUBE_API_BURST` environment variables (and corresponding `--kube-api-qps` / `--kube-api-burst` CLI flags) to configure the Kubernetes API client rate limits.

The client created via `rest.InClusterConfig()` uses client-go defaults of QPS=5 and Burst=10. When `WORKERS` is set to 50 or higher for correlated spot interruption scenarios, all workers share this single rate limiter, causing severe client-side throttling (8-10 second waits per API call). This prevents NTH from processing all interruption events within the 2-minute AWS spot interruption notice window.

Changes:
- `pkg/config/config.go`: Add `KUBE_API_QPS` (default 5) and `KUBE_API_BURST` (default 10) configuration parameters
- `cmd/node-termination-handler.go`: Apply QPS/Burst to `rest.Config` before creating the clientset

Defaults preserve backward compatibility.

Fixes: #1280

## How you tested your changes

Environment (Linux): ROSA HCP on AWS (us-east-2), 50 spot nodes (c5a.xlarge, 3 AZs)
Kubernetes Version: v1.35.5 (OpenShift 4.22)

Triggered 50 concurrent spot interruptions via AWS FIS (`aws:ec2:send-spot-instance-interruptions` with `durationBeforeInterruption=PT2M`):

| Configuration | Nodes tainted | Cordon P99 | Throttle events |
|---|---|---|---|
| `WORKERS=50`, QPS=5 (default) | 39/50 (78%) | 154s | 10 events, 8-10s each |
| `WORKERS=50`, **QPS=100, Burst=200** | **50/50 (100%)** | **52s** | **0** |

NTH logs with default QPS show continuous client-side throttling:
```
INF Waited for 9.994s due to client-side throttling, not priority and fairness, request: GET:...
WRN all workers busy, waiting
```

With QPS=100, zero throttling events and all 50 nodes processed within the 2-minute window.